### PR TITLE
Optimize VDOM renderer

### DIFF
--- a/packages/pulse-ui-client/src/index.ts
+++ b/packages/pulse-ui-client/src/index.ts
@@ -13,7 +13,6 @@ export { PulseSocketIOClient } from "./client";
 export type {
   PulseClient,
   MountedView,
-  VDOMListener,
   ConnectionStatusListener,
   ServerErrorListener,
 } from "./client";
@@ -30,7 +29,7 @@ export type {
 // Renderer helpers
 export {
   VDOMRenderer,
-  applyVDOMUpdates,
+  applyReactTreeUpdates,
   RenderLazy,
 } from "./renderer";
 

--- a/packages/pulse-ui-client/src/index.ts
+++ b/packages/pulse-ui-client/src/index.ts
@@ -1,11 +1,7 @@
 // Public API surface for pulse-client
 
 // Core React bindings
-export {
-  PulseProvider,
-  usePulseClient,
-  PulseView,
-} from "./pulse";
+export { PulseProvider, usePulseClient, PulseView } from "./pulse";
 export type { PulseConfig, PulseProviderProps } from "./pulse";
 
 // Client implementation
@@ -29,7 +25,7 @@ export type {
 // Renderer helpers
 export {
   VDOMRenderer,
-  applyReactTreeUpdates,
+  applyUpdates as applyReactTreeUpdates,
   RenderLazy,
 } from "./renderer";
 

--- a/packages/pulse-ui-client/src/pulse.tsx
+++ b/packages/pulse-ui-client/src/pulse.tsx
@@ -6,7 +6,7 @@ import React, {
   useContext,
   type ComponentType,
 } from "react";
-import { VDOMRenderer, applyReactTreeUpdates } from "./renderer";
+import { VDOMRenderer, applyUpdates } from "./renderer";
 import { PulseSocketIOClient } from "./client";
 import type { VDOM, ComponentRegistry, RegistryEntry } from "./vdom";
 import { useLocation, useParams, useNavigate } from "react-router";
@@ -108,7 +108,9 @@ export function PulseView({
     () => new VDOMRenderer(client, path, externalComponents),
     [client, path, externalComponents]
   );
-  const [tree, setTree] = useState<React.ReactNode>(() => renderer.renderNode(initialVDOM));
+  const [tree, setTree] = useState<React.ReactNode>(() =>
+    renderer.renderNode(initialVDOM)
+  );
   const [serverError, setServerError] = useState<ServerErrorInfo | null>(null);
 
   const location = useLocation();
@@ -141,7 +143,7 @@ export function PulseView({
         },
         onUpdate: (ops) => {
           setTree((prev) =>
-            prev == null ? prev : applyReactTreeUpdates(prev, ops, renderer)
+            prev == null ? prev : applyUpdates(prev, ops, renderer)
           );
         },
       });

--- a/packages/pulse-ui-client/src/pulse.tsx
+++ b/packages/pulse-ui-client/src/pulse.tsx
@@ -6,7 +6,7 @@ import React, {
   useContext,
   type ComponentType,
 } from "react";
-import { VDOMRenderer } from "./renderer";
+import { VDOMRenderer, applyReactTreeUpdates } from "./renderer";
 import { PulseSocketIOClient } from "./client";
 import type { VDOM, ComponentRegistry, RegistryEntry } from "./vdom";
 import { useLocation, useParams, useNavigate } from "react-router";
@@ -104,7 +104,11 @@ export function PulseView({
   path,
 }: PulseViewProps) {
   const client = usePulseClient();
-  const [vdom, setVdom] = useState(initialVDOM);
+  const renderer = useMemo(
+    () => new VDOMRenderer(client, path, externalComponents),
+    [client, path, externalComponents]
+  );
+  const [tree, setTree] = useState<React.ReactNode>(() => renderer.renderNode(initialVDOM));
   const [serverError, setServerError] = useState<ServerErrorInfo | null>(null);
 
   const location = useLocation();
@@ -131,15 +135,20 @@ export function PulseView({
   useEffect(() => {
     if (inBrowser) {
       client.mountView(path, {
-        vdom: initialVDOM,
-        listener: setVdom,
         routeInfo,
+        onInit: (vdom) => {
+          setTree(renderer.renderNode(vdom));
+        },
+        onUpdate: (ops) => {
+          setTree((prev) =>
+            prev == null ? prev : applyReactTreeUpdates(prev, ops, renderer)
+          );
+        },
       });
       const offErr = client.onServerError((p, err) => {
         if (p === path) setServerError(err);
       });
       return () => {
-        // console.log("Unmounting", path)
         offErr();
         client.unmount(path);
       };
@@ -153,16 +162,11 @@ export function PulseView({
     }
   }, [client, path, routeInfo]);
 
-  const renderer = useMemo(
-    () => new VDOMRenderer(client, path, externalComponents),
-    [client, path, externalComponents]
-  );
-
   if (serverError) {
     return <ServerError error={serverError} />;
   }
 
-  return renderer.renderNode(vdom);
+  return tree;
 }
 
 function ServerError({ error }: { error: ServerErrorInfo }) {

--- a/packages/pulse-ui-client/src/renderer.test.tsx
+++ b/packages/pulse-ui-client/src/renderer.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { describe, it, expect, vi } from "vitest";
-import { VDOMRenderer, applyReactTreeUpdates } from "./renderer";
+import { VDOMRenderer, applyUpdates } from "./renderer";
 
 import type { VDOMNode, VDOMUpdate } from "./vdom";
 
@@ -32,7 +32,7 @@ describe("applyReactTreeUpdates", () => {
       },
     ];
 
-    tree = applyReactTreeUpdates(tree, ops, renderer);
+    tree = applyUpdates(tree, ops, renderer);
     const root = tree as React.ReactElement;
     expect(root.type).toBe("div");
     expect((root.props as any).id).toBe("root");
@@ -52,7 +52,7 @@ describe("applyReactTreeUpdates", () => {
         data: { id: "root", onClick: "$$fn:cb" },
       },
     ];
-    tree = applyReactTreeUpdates(tree, ops, renderer);
+    tree = applyUpdates(tree, ops, renderer);
     const root = tree as React.ReactElement;
     expect((root.props as any).id).toBe("root");
     expect(typeof (root.props as any).onClick).toBe("function");
@@ -74,7 +74,7 @@ describe("applyReactTreeUpdates", () => {
         data: { tag: "span", children: ["B"] },
       },
     ];
-    tree = applyReactTreeUpdates(tree, ops, renderer);
+    tree = applyUpdates(tree, ops, renderer);
     const root = tree as React.ReactElement;
     const rootChildren = childrenArray(root);
     const child0 = rootChildren[0] as React.ReactElement;
@@ -94,7 +94,7 @@ describe("applyReactTreeUpdates", () => {
     let tree = renderer.renderNode(initialVDOM);
 
     // Insert at index 1 under parent path 0
-    tree = applyReactTreeUpdates(
+    tree = applyUpdates(
       tree,
       [
         {
@@ -114,7 +114,7 @@ describe("applyReactTreeUpdates", () => {
     expect((kids[1] as React.ReactElement).type).toBe("span");
 
     // Remove the first child under parent path 0 (index 0)
-    tree = applyReactTreeUpdates(
+    tree = applyUpdates(
       tree,
       [
         {
@@ -157,7 +157,7 @@ describe("applyReactTreeUpdates", () => {
         data: { from_index: 0, to_index: 1 },
       },
     ];
-    tree = applyReactTreeUpdates(tree, ops, renderer);
+    tree = applyUpdates(tree, ops, renderer);
     const root = tree as React.ReactElement;
     const p0 = childrenArray(root)[0] as React.ReactElement;
     const kids = childrenArray(p0) as React.ReactElement[];

--- a/packages/pulse-ui-client/src/renderer.test.tsx
+++ b/packages/pulse-ui-client/src/renderer.test.tsx
@@ -99,7 +99,8 @@ describe("applyReactTreeUpdates", () => {
       [
         {
           type: "insert",
-          path: "0.1",
+          path: "0",
+          idx: 1,
           data: { tag: "span", children: ["B"] },
         },
       ],
@@ -118,8 +119,9 @@ describe("applyReactTreeUpdates", () => {
       [
         {
           type: "remove",
-          path: "0.0",
-        } as VDOMUpdate,
+          path: "0",
+          idx: 0,
+        },
       ],
       renderer
     );
@@ -160,6 +162,6 @@ describe("applyReactTreeUpdates", () => {
     const p0 = childrenArray(root)[0] as React.ReactElement;
     const kids = childrenArray(p0) as React.ReactElement[];
     const texts = kids.map((k) => childrenArray(k)[0]);
-    expect(texts).toEqual(["B","A", "C"]);
+    expect(texts).toEqual(["B", "A", "C"]);
   });
 });

--- a/packages/pulse-ui-client/src/renderer.test.tsx
+++ b/packages/pulse-ui-client/src/renderer.test.tsx
@@ -1,0 +1,165 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { VDOMRenderer, applyReactTreeUpdates } from "./renderer";
+
+import type { VDOMNode, VDOMUpdate } from "./vdom";
+
+function childrenArray(el: React.ReactElement): React.ReactNode[] {
+  return React.Children.toArray((el.props as any)?.children);
+}
+
+describe("applyReactTreeUpdates", () => {
+  function makeRenderer() {
+    const invokeCallback = vi.fn();
+    const client: any = { invokeCallback };
+    const renderer = new VDOMRenderer(client, "/test", {});
+    return { renderer, invokeCallback };
+  }
+
+  it("replaces the root element", () => {
+    const { renderer } = makeRenderer();
+    const initialVDOM: VDOMNode = {
+      tag: "div",
+      children: [{ tag: "span", children: ["A"] }],
+    };
+    let tree = renderer.renderNode(initialVDOM);
+
+    const ops: VDOMUpdate[] = [
+      {
+        type: "replace",
+        path: "",
+        data: { tag: "div", props: { id: "root" }, children: ["B"] },
+      },
+    ];
+
+    tree = applyReactTreeUpdates(tree, ops, renderer);
+    const root = tree as React.ReactElement;
+    expect(root.type).toBe("div");
+    expect((root.props as any).id).toBe("root");
+    const kids = childrenArray(root);
+    expect(kids).toHaveLength(1);
+    expect(kids[0]).toBe("B");
+  });
+
+  it("updates root props and maps callbacks", () => {
+    const { renderer, invokeCallback } = makeRenderer();
+    const initialVDOM: VDOMNode = { tag: "div", children: [] };
+    let tree = renderer.renderNode(initialVDOM);
+    const ops: VDOMUpdate[] = [
+      {
+        type: "update_props",
+        path: "",
+        data: { id: "root", onClick: "$$fn:cb" },
+      },
+    ];
+    tree = applyReactTreeUpdates(tree, ops, renderer);
+    const root = tree as React.ReactElement;
+    expect((root.props as any).id).toBe("root");
+    expect(typeof (root.props as any).onClick).toBe("function");
+    (root.props as any).onClick(123);
+    expect(invokeCallback).toHaveBeenCalledWith("/test", "cb", [123]);
+  });
+
+  it("replaces a nested child via path", () => {
+    const { renderer } = makeRenderer();
+    const initialVDOM: VDOMNode = {
+      tag: "div",
+      children: [{ tag: "div", children: [{ tag: "span", children: ["A"] }] }],
+    };
+    let tree = renderer.renderNode(initialVDOM);
+    const ops: VDOMUpdate[] = [
+      {
+        type: "replace",
+        path: "0.0",
+        data: { tag: "span", children: ["B"] },
+      },
+    ];
+    tree = applyReactTreeUpdates(tree, ops, renderer);
+    const root = tree as React.ReactElement;
+    const rootChildren = childrenArray(root);
+    const child0 = rootChildren[0] as React.ReactElement;
+    const innerChildren = childrenArray(child0);
+    const replaced = innerChildren[0] as React.ReactElement;
+    const leafChildren = childrenArray(replaced);
+    expect(replaced.type).toBe("span");
+    expect(leafChildren[0]).toBe("B");
+  });
+
+  it("inserts and removes children at nested parent path", () => {
+    const { renderer } = makeRenderer();
+    const initialVDOM: VDOMNode = {
+      tag: "div",
+      children: [{ tag: "div", children: [{ tag: "span", children: ["A"] }] }],
+    };
+    let tree = renderer.renderNode(initialVDOM);
+
+    // Insert at index 1 under parent path 0
+    tree = applyReactTreeUpdates(
+      tree,
+      [
+        {
+          type: "insert",
+          path: "0.1",
+          data: { tag: "span", children: ["B"] },
+        },
+      ],
+      renderer
+    );
+    let root = tree as React.ReactElement;
+    let p0 = childrenArray(root)[0] as React.ReactElement;
+    let kids = childrenArray(p0);
+    expect(kids).toHaveLength(2);
+    expect((kids[0] as React.ReactElement).type).toBe("span");
+    expect((kids[1] as React.ReactElement).type).toBe("span");
+
+    // Remove the first child under parent path 0 (index 0)
+    tree = applyReactTreeUpdates(
+      tree,
+      [
+        {
+          type: "remove",
+          path: "0.0",
+        } as VDOMUpdate,
+      ],
+      renderer
+    );
+    root = tree as React.ReactElement;
+    p0 = childrenArray(root)[0] as React.ReactElement;
+    kids = childrenArray(p0);
+    expect(kids).toHaveLength(1);
+    const only = kids[0] as React.ReactElement;
+    const onlyText = childrenArray(only)[0];
+    expect(onlyText).toBe("B");
+  });
+
+  it("moves children within a nested parent (path points to parent)", () => {
+    const { renderer } = makeRenderer();
+    const initialVDOM: VDOMNode = {
+      tag: "div",
+      children: [
+        {
+          tag: "div",
+          children: [
+            { tag: "span", children: ["A"] },
+            { tag: "span", children: ["B"] },
+            { tag: "span", children: ["C"] },
+          ],
+        },
+      ],
+    };
+    let tree = renderer.renderNode(initialVDOM);
+    const ops: VDOMUpdate[] = [
+      {
+        type: "move",
+        path: "0", // parent path
+        data: { from_index: 0, to_index: 1 },
+      },
+    ];
+    tree = applyReactTreeUpdates(tree, ops, renderer);
+    const root = tree as React.ReactElement;
+    const p0 = childrenArray(root)[0] as React.ReactElement;
+    const kids = childrenArray(p0) as React.ReactElement[];
+    const texts = kids.map((k) => childrenArray(k)[0]);
+    expect(texts).toEqual(["B","A", "C"]);
+  });
+});

--- a/packages/pulse-ui-client/src/renderer.tsx
+++ b/packages/pulse-ui-client/src/renderer.tsx
@@ -1,11 +1,5 @@
 import React, { Suspense, type ComponentType } from "react";
-import type {
-  ComponentRegistry,
-  RegistryEntry,
-  VDOMElement,
-  VDOMNode,
-  VDOMUpdate,
-} from "./vdom";
+import type { ComponentRegistry, VDOMNode, VDOMUpdate } from "./vdom";
 import {
   FRAGMENT_TAG,
   isElementNode,
@@ -126,7 +120,7 @@ function cloneElementWithChildren(
   return React.cloneElement(el, undefined, ...children);
 }
 
-export function applyReactTreeUpdates(
+export function applyUpdates(
   initialTree: React.ReactNode,
   updates: VDOMUpdate[],
   renderer: VDOMRenderer
@@ -140,11 +134,13 @@ export function applyReactTreeUpdates(
       .map(Number);
 
     const descend = (node: React.ReactNode, depth: number): React.ReactNode => {
-      if (!React.isValidElement(node)) return node;
+      if (!React.isValidElement(node)) {
+        throw new Error(
+          "Invalid node at path " + parts.slice(0, depth).join(".")
+        );
+      }
       if (depth === parts.length) {
-        const childrenArr = React.isValidElement(node)
-          ? toChildrenArrayFromElement(node)
-          : [];
+        const childrenArr = toChildrenArrayFromElement(node);
         switch (update.type) {
           case "replace": {
             return renderer.renderNode(update.data);
@@ -175,9 +171,8 @@ export function applyReactTreeUpdates(
             }
           }
         }
-        return React.isValidElement(node)
-          ? cloneElementWithChildren(node, childrenArr)
-          : node;
+        return cloneElementWithChildren(node, childrenArr);
+      } else {
       }
       const idx = parts[depth]!;
       const childrenArr = toChildrenArrayFromElement(node);

--- a/packages/pulse-ui-client/src/serialize/clean.test.ts
+++ b/packages/pulse-ui-client/src/serialize/clean.test.ts
@@ -56,7 +56,6 @@ describe("encodeForWire / decodeFromWire", () => {
     a.arr = arr;
 
     const encoded = await encodeForWire({ a, b, arr });
-    console.log(encoded);
     const asAny = encoded as any;
     // Expect top-level to be encoded as object with props
     expect(asAny.__t).toBe("object");

--- a/packages/pulse-ui-client/src/vdom.ts
+++ b/packages/pulse-ui-client/src/vdom.ts
@@ -42,10 +42,12 @@ export interface VDOMUpdateBase {
 export interface InsertUpdate extends VDOMUpdateBase {
   type: "insert";
   data: VDOMNode; // The node to insert
+  idx: number;
 }
 
 export interface RemoveUpdate extends VDOMUpdateBase {
   type: "remove";
+  idx: number;
 }
 
 export interface ReplaceUpdate extends VDOMUpdateBase {

--- a/packages/pulse-ui-client/src/vdom.ts
+++ b/packages/pulse-ui-client/src/vdom.ts
@@ -63,7 +63,6 @@ export interface MoveUpdate extends VDOMUpdateBase {
   data: {
     from_index: number;
     to_index: number;
-    key: string;
   };
 }
 

--- a/packages/pulse/src/pulse/reconciler.py
+++ b/packages/pulse/src/pulse/reconciler.py
@@ -42,7 +42,6 @@ class UpdatePropsOperation(TypedDict):
 class MoveOperationData(TypedDict):
     from_index: int
     to_index: int
-    key: str
 
 
 class MoveOperation(TypedDict):


### PR DESCRIPTION
Update the VDOM renderer to:
1. Apply operations on React nodes directly
2. Only shallow clone the React tree along the update path
3. Use a more efficient operation format for insert and remove operations

Remaining optimizations:
- Update the server-side reconciler to perform optimal keyed reconciliation (most likely using a LIS algorithm similar to Vue or morphdom)
- Group operations by prefix to minimize node cloning and tree traversal