### PR TITLE
Add route origin source identity

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -161,7 +161,7 @@
     },
     "packages/pulse/js": {
       "name": "pulse-ui-client",
-      "version": "0.1.95",
+      "version": "0.1.100",
       "dependencies": {
         "socket.io-client": "^4.8.1",
         "ws": "^8.18.3",

--- a/docs/content/docs/reference/pulse-client/hooks.mdx
+++ b/docs/content/docs/reference/pulse-client/hooks.mdx
@@ -80,6 +80,8 @@ The returned client has these methods:
 interface PulseClient {
   // Connection
   connect(): Promise<void>;
+  suspend(): void;
+  resume(): Promise<void>;
   disconnect(): void;
   isConnected(): boolean;
   onConnectionChange(listener: ConnectionStatusListener): () => void;

--- a/docs/content/docs/reference/pulse-client/types.mdx
+++ b/docs/content/docs/reference/pulse-client/types.mdx
@@ -581,6 +581,8 @@ Interface for the Pulse client.
 ```ts
 interface PulseClient {
   connect(): Promise<void>;
+  suspend(): void;
+  resume(): Promise<void>;
   disconnect(): void;
   isConnected(): boolean;
   onConnectionChange(listener: ConnectionStatusListener): () => void;

--- a/packages/pulse/js/package.json
+++ b/packages/pulse/js/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pulse-ui-client",
-	"version": "0.1.95",
+	"version": "0.1.100",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/erwinkn/pulse-ui",

--- a/packages/pulse/js/src/client.test.ts
+++ b/packages/pulse/js/src/client.test.ts
@@ -1,4 +1,7 @@
 import { beforeEach, describe, expect, it, mock, vi } from "bun:test";
+import React from "react";
+import { act, render } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
 import { deserialize, serialize } from "./serialize/serializer";
 
 class FakeSocket {
@@ -52,26 +55,45 @@ const view = {
 	onServerError: vi.fn(),
 };
 
-async function makeClient() {
-	const { PulseSocketIOClient } = await import("./client");
-	return new PulseSocketIOClient("http://pulse.test", {}, vi.fn() as any, {
+async function makeClient(
+	connectionStatus = {
 		initialConnectingDelay: 0,
 		initialErrorDelay: 0,
 		reconnectErrorDelay: 0,
-	});
+	},
+) {
+	const { PulseSocketIOClient } = await import("./client");
+	return new PulseSocketIOClient(
+		"http://pulse.test",
+		{},
+		vi.fn() as any,
+		connectionStatus,
+	);
 }
 
-function sentMessages() {
-	return socket.emitted
+function sentMessages(target: FakeSocket = socket) {
+	return target.emitted
 		.filter(([event]) => event === "message")
 		.map(([, payload]) =>
 			deserialize(payload as any, { coerceNullsToUndefined: true }),
 		);
 }
 
+function waitForEffects() {
+	return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe("PulseSocketIOClient attach ack", () => {
 	beforeEach(() => {
 		io.mockClear();
+		Object.defineProperty(document, "visibilityState", {
+			configurable: true,
+			value: "visible",
+		});
+		Object.defineProperty(navigator, "onLine", {
+			configurable: true,
+			value: true,
+		});
 	});
 
 	it("queues callbacks until the active attach is acknowledged", async () => {
@@ -126,5 +148,191 @@ describe("PulseSocketIOClient attach ack", () => {
 			"attach",
 			"detach",
 		]);
+	});
+
+	it("suspends hidden tabs without clearing active views and reattaches on resume", async () => {
+		const client = await makeClient();
+		const connected = client.connect();
+		client.attach("/", view);
+		const firstSocket = socket;
+		firstSocket.trigger("connect");
+		await connected;
+
+		client.suspend();
+
+		expect(client.isConnected()).toBe(false);
+		expect(firstSocket.connected).toBe(false);
+		expect(sentMessages(firstSocket).map((message) => message.type)).toEqual([
+			"attach",
+		]);
+
+		const resumed = client.resume();
+		const secondSocket = socket;
+		expect(secondSocket).not.toBe(firstSocket);
+		secondSocket.trigger("connect");
+		await resumed;
+
+		expect(sentMessages(secondSocket)[0]).toMatchObject({
+			type: "attach",
+			path: "/",
+		});
+	});
+
+	it("does not reload visible active tabs when reconnect times out", async () => {
+		const reload = vi.fn();
+		Object.defineProperty(window.location, "reload", {
+			configurable: true,
+			value: reload,
+		});
+		const client = await makeClient();
+		const connected = client.connect();
+		socket.trigger("connect");
+		await connected;
+
+		socket.trigger("disconnect");
+		await waitForEffects();
+
+		expect(reload).not.toHaveBeenCalled();
+	});
+
+	it("reloads when resume from suspension cannot reconnect", async () => {
+		const reload = vi.fn();
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		Object.defineProperty(window.location, "reload", {
+			configurable: true,
+			value: reload,
+		});
+		const client = await makeClient({
+			initialConnectingDelay: 0,
+			initialErrorDelay: 0,
+			reconnectErrorDelay: 20,
+		});
+		const connected = client.connect();
+		socket.trigger("connect");
+		await connected;
+
+		client.suspend();
+		void client.resume().catch(() => {});
+		socket.trigger("connect_error", new Error("websocket error"));
+		await new Promise((resolve) => setTimeout(resolve, 25));
+
+		expect(reload).toHaveBeenCalled();
+		consoleError.mockRestore();
+	});
+
+	it("does not postpone resume reload on repeated reconnect errors", async () => {
+		const reload = vi.fn();
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		Object.defineProperty(window.location, "reload", {
+			configurable: true,
+			value: reload,
+		});
+		const client = await makeClient({
+			initialConnectingDelay: 0,
+			initialErrorDelay: 0,
+			reconnectErrorDelay: 20,
+		});
+		const connected = client.connect();
+		socket.trigger("connect");
+		await connected;
+
+		client.suspend();
+		void client.resume().catch(() => {});
+		await new Promise((resolve) => setTimeout(resolve, 15));
+		socket.trigger("connect_error", new Error("websocket error"));
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		expect(reload).toHaveBeenCalled();
+		consoleError.mockRestore();
+	});
+
+	it("does not reconnect or reload while suspended", async () => {
+		const reload = vi.fn();
+		Object.defineProperty(window.location, "reload", {
+			configurable: true,
+			value: reload,
+		});
+		const client = await makeClient({
+			initialConnectingDelay: 0,
+			initialErrorDelay: 0,
+			reconnectErrorDelay: 0,
+		});
+		const connected = client.connect();
+		socket.trigger("connect");
+		await connected;
+
+		client.suspend();
+		await waitForEffects();
+
+		expect(io).toHaveBeenCalledTimes(1);
+		expect(reload).not.toHaveBeenCalled();
+	});
+
+	it("does not reload hidden tabs when reconnect times out", async () => {
+		const reload = vi.fn();
+		Object.defineProperty(window.location, "reload", {
+			configurable: true,
+			value: reload,
+		});
+		Object.defineProperty(document, "visibilityState", {
+			configurable: true,
+			value: "hidden",
+		});
+		const client = await makeClient();
+		const connected = client.connect();
+		socket.trigger("connect");
+		await connected;
+
+		socket.trigger("disconnect");
+		await waitForEffects();
+
+		expect(reload).not.toHaveBeenCalled();
+	});
+});
+
+describe("PulseProvider connection handling", () => {
+	beforeEach(() => {
+		io.mockClear();
+		Object.defineProperty(document, "visibilityState", {
+			configurable: true,
+			value: "visible",
+		});
+	});
+
+	it("handles initial connection errors without an unhandled rejection", async () => {
+		const { PulseProvider } = await import("./pulse");
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		render(
+			React.createElement(
+				MemoryRouter,
+				null,
+				React.createElement(
+					PulseProvider,
+					{
+						config: {
+							serverAddress: "http://pulse.test",
+							apiPrefix: "/_pulse",
+							connectionStatus: {
+								initialConnectingDelay: 0,
+								initialErrorDelay: 0,
+								reconnectErrorDelay: 0,
+							},
+						},
+						prerender: { views: {}, directives: {} },
+						children: React.createElement("div", null, "child"),
+					},
+				),
+			),
+		);
+		await waitForEffects();
+
+		await act(async () => {
+			socket.trigger("connect_error", new Error("websocket error"));
+			await waitForEffects();
+		});
+
+		expect(io).toHaveBeenCalledTimes(1);
+		consoleError.mockRestore();
 	});
 });

--- a/packages/pulse/js/src/client.tsx
+++ b/packages/pulse/js/src/client.tsx
@@ -18,6 +18,13 @@ import { extractEvent } from "./serialize/events";
 import { deserialize, serialize } from "./serialize/serializer";
 import type { VDOMUpdate } from "./vdom";
 
+function documentIsHidden(): boolean {
+	return typeof document !== "undefined" && document.visibilityState === "hidden";
+}
+
+function browserIsOnline(): boolean {
+	return typeof navigator === "undefined" || navigator.onLine !== false;
+}
 
 export interface SocketIODirectives {
 	headers?: Record<string, string>;
@@ -42,6 +49,8 @@ export type ConnectionStatusListener = (status: ConnectionStatus) => void;
 export interface PulseClient {
 	// Connection management
 	connect(): Promise<void>;
+	suspend(): void;
+	resume(): Promise<void>;
 	disconnect(): void;
 	isConnected(): boolean;
 	onConnectionChange(listener: ConnectionStatusListener): () => void;
@@ -75,6 +84,8 @@ export class PulseSocketIOClient {
 	#errorTimeout: ReturnType<typeof setTimeout> | null = null;
 	#currentStatus: ConnectionStatus = "ok";
 	#nextAttachId = 0;
+	#suspended = false;
+	#reloadOnReconnectTimeout = false;
 
 	constructor(
 		url: string,
@@ -123,6 +134,7 @@ export class PulseSocketIOClient {
 
 	#handleConnected(): void {
 		this.#hasConnectedOnce = true;
+		this.#reloadOnReconnectTimeout = false;
 		this.#setStatus("ok");
 	}
 
@@ -138,20 +150,45 @@ export class PulseSocketIOClient {
 	}
 
 	#handleDisconnected(): void {
+		if (this.#currentStatus === "reconnecting" && this.#errorTimeout) return;
+		if (this.#currentStatus === "error") return;
 		// Reconnection after losing connection - show reconnecting immediately
 		this.#setStatus("reconnecting");
 		this.#errorTimeout = setTimeout(() => {
-			this.#setStatus("error");
+			this.#handleReconnectTimedOut();
 		}, this.#connectionStatusConfig.reconnectErrorDelay);
+	}
+
+	#handleConnectionError(): void {
+		if (this.#hasConnectedOnce) {
+			this.#handleDisconnected();
+		}
+	}
+
+	#handleReconnectTimedOut(): void {
+		this.#setStatus("error");
+		if (
+			this.#hasConnectedOnce &&
+			!this.#suspended &&
+			this.#reloadOnReconnectTimeout &&
+			!documentIsHidden() &&
+			browserIsOnline() &&
+			typeof window !== "undefined"
+		) {
+			window.location.reload();
+		}
 	}
 
 	public async connect(): Promise<void> {
 		if (this.#socket) {
 			return;
 		}
+		this.#suspended = false;
 		// Start timing logic for connection attempt
 		if (!this.#hasConnectedOnce) {
 			this.#setInitialConnectionStatus();
+		} else {
+			this.#handleDisconnected();
 		}
 		return new Promise((resolve, reject) => {
 			const socket = io(this.#url, {
@@ -162,6 +199,7 @@ export class PulseSocketIOClient {
 			this.#socket = socket;
 
 			socket.on("connect", () => {
+				if (this.#socket !== socket) return;
 				console.log("[SocketIOTransport] Connected:", this.#socket?.id);
 				// Send attach for all active views on connect/reconnect
 				for (const [path, route] of this.#activeViews) {
@@ -186,21 +224,24 @@ export class PulseSocketIOClient {
 			});
 
 			socket.on("connect_error", (err) => {
+				if (this.#socket !== socket) return;
 				console.error("[SocketIOTransport] Connection failed:", err);
-				this.#handleDisconnected();
+				this.#handleConnectionError();
 				reject(err);
 			});
 
 			socket.on("disconnect", () => {
+				if (this.#socket !== socket) return;
 				console.log("[SocketIOTransport] Disconnected");
 				this.#handleTransportDisconnect();
 				this.#handleDisconnected();
 			});
 
 			// Wrap in an arrow function to avoid losing the `this` reference
-			socket.on("message", (data) =>
-				this.#handleServerMessage(deserialize(data, { coerceNullsToUndefined: true })),
-			);
+			socket.on("message", (data) => {
+				if (this.#socket !== socket) return;
+				this.#handleServerMessage(deserialize(data, { coerceNullsToUndefined: true }));
+			});
 		});
 	}
 
@@ -257,10 +298,30 @@ export class PulseSocketIOClient {
 		void this.sendMessage({ type: "detach", path });
 	}
 
-	public disconnect() {
+	public suspend() {
+		if (this.#suspended) return;
+		this.#suspended = true;
+		this.#reloadOnReconnectTimeout = false;
 		this.#clearTimeouts();
-		this.#socket?.disconnect();
-		this.#socket = null;
+		this.#closeSocket();
+		this.#setStatus("ok");
+	}
+
+	public resume(): Promise<void> {
+		if (!this.#suspended && this.#socket) {
+			return Promise.resolve();
+		}
+		const wasSuspended = this.#suspended;
+		this.#suspended = false;
+		this.#reloadOnReconnectTimeout = wasSuspended;
+		return this.connect();
+	}
+
+	public disconnect() {
+		this.#suspended = false;
+		this.#reloadOnReconnectTimeout = false;
+		this.#clearTimeouts();
+		this.#closeSocket();
 		this.#messageQueue = [];
 		this.#connectionListeners.clear();
 		this.#activeViews.clear();
@@ -273,6 +334,14 @@ export class PulseSocketIOClient {
 		this.#channels.clear();
 		this.#currentStatus = "ok";
 		this.#hasConnectedOnce = false;
+	}
+
+	#closeSocket(): void {
+		const socket = this.#socket;
+		if (!socket) return;
+		this.#socket = null;
+		this.#handleTransportDisconnect();
+		socket.disconnect();
 	}
 
 	#handleServerMessage(message: ServerMessage) {

--- a/packages/pulse/js/src/pulse.tsx
+++ b/packages/pulse/js/src/pulse.tsx
@@ -80,6 +80,10 @@ export interface PulseProviderProps {
 const inBrowser = typeof window !== "undefined";
 const useIsomorphicLayoutEffect = inBrowser ? useLayoutEffect : useEffect;
 
+function reportConnectionError(err: unknown) {
+	console.error("[PulseProvider] Connection failed:", err);
+}
+
 export function PulseProvider({ children, config, prerender }: PulseProviderProps) {
 	const [status, setStatus] = useState<ConnectionStatus>("ok");
 	const rrNavigate = useNavigate();
@@ -106,11 +110,29 @@ export function PulseProvider({ children, config, prerender }: PulseProviderProp
 		const unsubscribe = client.onConnectionChange(handleConnectionChange);
 
 		// Start connection attempt
-		client.connect();
+		void client.connect().catch(reportConnectionError);
 
 		return () => {
 			unsubscribe();
 			client.disconnect();
+		};
+	}, [client]);
+
+	useEffect(() => {
+		if (!inBrowser) return;
+
+		const handleVisibilityChange = () => {
+			if (document.visibilityState === "hidden") {
+				client.suspend();
+				return;
+			}
+			void client.resume().catch(reportConnectionError);
+		};
+
+		document.addEventListener("visibilitychange", handleVisibilityChange);
+		handleVisibilityChange();
+		return () => {
+			document.removeEventListener("visibilitychange", handleVisibilityChange);
 		};
 	}, [client]);
 

--- a/packages/pulse/python/pyproject.toml
+++ b/packages/pulse/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pulse-framework"
-version = "0.1.95"
+version = "0.1.100"
 description = "Pulse - Full-stack framework for building real-time React applications in Python"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/pulse/python/src/pulse/channel.py
+++ b/packages/pulse/python/src/pulse/channel.py
@@ -14,7 +14,6 @@ from pulse.messages import (
 	ServerChannelRequestMessage,
 	ServerChannelResponseMessage,
 )
-from pulse.routing import RouteOrigin
 from pulse.scheduling import create_future
 
 if TYPE_CHECKING:
@@ -173,14 +172,10 @@ class ChannelsManager:
 			return
 
 		route_ctx = None
-		origin = None
-		mount_id = None
 		if channel.route_path is not None:
 			try:
 				mount = render.get_route_mount(channel.route_path)
-				route_ctx = mount.route
-				origin = RouteOrigin.from_route(route_ctx)
-				mount_id = mount.mount_id
+				route_ctx = mount.route_snapshot()
 			except Exception:
 				route_ctx = None
 
@@ -190,8 +185,6 @@ class ChannelsManager:
 					session=session,
 					render=render,
 					route=route_ctx,
-					origin=origin,
-					mount_id=mount_id,
 				):
 					result = await channel.dispatch(event, payload, request_id)
 			except Exception as exc:

--- a/packages/pulse/python/src/pulse/channel.py
+++ b/packages/pulse/python/src/pulse/channel.py
@@ -14,6 +14,7 @@ from pulse.messages import (
 	ServerChannelRequestMessage,
 	ServerChannelResponseMessage,
 )
+from pulse.routing import RouteOrigin
 from pulse.scheduling import create_future
 
 if TYPE_CHECKING:
@@ -172,12 +173,14 @@ class ChannelsManager:
 			return
 
 		route_ctx = None
-		source_mount_id = None
+		origin = None
+		mount_id = None
 		if channel.route_path is not None:
 			try:
 				mount = render.get_route_mount(channel.route_path)
 				route_ctx = mount.route
-				source_mount_id = mount.mount_id
+				origin = RouteOrigin.from_route(route_ctx)
+				mount_id = mount.mount_id
 			except Exception:
 				route_ctx = None
 
@@ -187,11 +190,8 @@ class ChannelsManager:
 					session=session,
 					render=render,
 					route=route_ctx,
-					source_route_path=(
-						route_ctx.route_path if route_ctx is not None else None
-					),
-					source_path=route_ctx.pathname if route_ctx is not None else None,
-					source_mount_id=source_mount_id,
+					origin=origin,
+					mount_id=mount_id,
 				):
 					result = await channel.dispatch(event, payload, request_id)
 			except Exception as exc:

--- a/packages/pulse/python/src/pulse/context.py
+++ b/packages/pulse/python/src/pulse/context.py
@@ -129,6 +129,8 @@ def wrap_with_forked_context(fn: Callable[P, T]) -> Callable[P, T]:
 
 		@wraps(fn)
 		async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> Any:
+			if PULSE_CONTEXT.get() is None:
+				return await fn(*args, **kwargs)
 			with PulseContext.fork():
 				return await fn(*args, **kwargs)
 
@@ -137,6 +139,8 @@ def wrap_with_forked_context(fn: Callable[P, T]) -> Callable[P, T]:
 
 	@wraps(fn)
 	def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+		if PULSE_CONTEXT.get() is None:
+			return fn(*args, **kwargs)
 		ctx = PulseContext.fork()
 		with ctx:
 			result = fn(*args, **kwargs)

--- a/packages/pulse/python/src/pulse/context.py
+++ b/packages/pulse/python/src/pulse/context.py
@@ -91,28 +91,15 @@ class PulseContext:
 			route=ctx.route if route is _UNSET else route,
 		)
 
-	def copy(self) -> "PulseContext":
-		return PulseContext(
-			app=self.app,
-			session=self.session,
-			render=self.render,
-			route=self.route,
-		)
-
 	@classmethod
 	def fork(cls) -> "PulseContext":
-		return cls.get().forked()
-
-	def forked(self) -> "PulseContext":
+		ctx = cls.get()
 		return PulseContext(
-			app=self.app,
-			session=self.session,
-			render=self.render,
-			route=self.route.snapshot() if self.route is not None else None,
+			app=ctx.app,
+			session=ctx.session,
+			render=ctx.render,
+			route=ctx.route.snapshot() if ctx.route is not None else None,
 		)
-
-	def snapshot(self) -> "PulseContext":
-		return self.forked()
 
 	def __enter__(self):
 		self._token = PULSE_CONTEXT.set(self)

--- a/packages/pulse/python/src/pulse/context.py
+++ b/packages/pulse/python/src/pulse/context.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Literal
 
-from pulse.routing import RouteContext
+from pulse.routing import RouteContext, RouteOrigin
 
 if TYPE_CHECKING:
 	from pulse.app import App
@@ -25,10 +25,9 @@ class PulseContext:
 		app: Application instance.
 		session: Per-user session (UserSession or None).
 		render: Per-connection render session (RenderSession or None).
-		route: Active route context (RouteContext or None).
-		source_route_path: Route mount path that originated the active callback/effect.
-		source_path: URL pathname that originated the active callback/effect.
-		source_mount_id: Route mount lifecycle id that originated the active callback/effect.
+		route: Active live route context (RouteContext or None).
+		origin: Immutable route context that originated the active callback/effect.
+		mount_id: Route mount lifecycle id that originated the active callback/effect.
 
 	Example:
 		```python
@@ -44,9 +43,8 @@ class PulseContext:
 	session: "UserSession | None" = None
 	render: "RenderSession | None" = None
 	route: "RouteContext | None" = None
-	source_route_path: str | None = None
-	source_path: str | None = None
-	source_mount_id: str | None = None
+	origin: "RouteOrigin | None" = None
+	mount_id: str | None = None
 	_token: "Token[PulseContext | None] | None" = None
 
 	@classmethod
@@ -70,9 +68,8 @@ class PulseContext:
 		session: Any = _UNSET,
 		render: Any = _UNSET,
 		route: Any = _UNSET,
-		source_route_path: Any = _UNSET,
-		source_path: Any = _UNSET,
-		source_mount_id: Any = _UNSET,
+		origin: Any = _UNSET,
+		mount_id: Any = _UNSET,
 	) -> "PulseContext":
 		"""Create a new context with updated values.
 
@@ -82,9 +79,8 @@ class PulseContext:
 			session: New session (optional, inherits if not provided).
 			render: New render session (optional, inherits if not provided).
 			route: New route context (optional, inherits if not provided).
-			source_route_path: New source route path (optional, inherits if not provided).
-			source_path: New source URL path (optional, inherits if not provided).
-			source_mount_id: New source mount id (optional, inherits if not provided).
+			origin: New origin route context (optional, inherits if not provided).
+			mount_id: New origin mount id (optional, inherits if not provided).
 
 		Returns:
 			New PulseContext instance with updated values.
@@ -95,15 +91,8 @@ class PulseContext:
 			session=ctx.session if session is _UNSET else session,
 			render=ctx.render if render is _UNSET else render,
 			route=ctx.route if route is _UNSET else route,
-			source_route_path=(
-				ctx.source_route_path
-				if source_route_path is _UNSET
-				else source_route_path
-			),
-			source_path=ctx.source_path if source_path is _UNSET else source_path,
-			source_mount_id=(
-				ctx.source_mount_id if source_mount_id is _UNSET else source_mount_id
-			),
+			origin=ctx.origin if origin is _UNSET else origin,
+			mount_id=ctx.mount_id if mount_id is _UNSET else mount_id,
 		)
 
 	def __enter__(self):

--- a/packages/pulse/python/src/pulse/context.py
+++ b/packages/pulse/python/src/pulse/context.py
@@ -1,17 +1,23 @@
 # pyright: reportImportCycles=false
+import inspect
+from collections.abc import Callable
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
+from functools import wraps
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, ParamSpec, TypeVar, cast
 
-from pulse.routing import RouteContext, RouteOrigin
+from pulse.routing import RouteContext
 
 if TYPE_CHECKING:
 	from pulse.app import App
 	from pulse.render_session import RenderSession
 	from pulse.user_session import UserSession
 
+P = ParamSpec("P")
+T = TypeVar("T")
 _UNSET = object()
+_WRAPPED_ATTR = "__pulse_forked_context__"
 
 
 @dataclass
@@ -25,9 +31,7 @@ class PulseContext:
 		app: Application instance.
 		session: Per-user session (UserSession or None).
 		render: Per-connection render session (RenderSession or None).
-		route: Active live route context (RouteContext or None).
-		origin: Immutable route context that originated the active callback/effect.
-		mount_id: Route mount lifecycle id that originated the active callback/effect.
+		route: Active route context (RouteContext or None).
 
 	Example:
 		```python
@@ -43,8 +47,6 @@ class PulseContext:
 	session: "UserSession | None" = None
 	render: "RenderSession | None" = None
 	route: "RouteContext | None" = None
-	origin: "RouteOrigin | None" = None
-	mount_id: str | None = None
 	_token: "Token[PulseContext | None] | None" = None
 
 	@classmethod
@@ -68,8 +70,6 @@ class PulseContext:
 		session: Any = _UNSET,
 		render: Any = _UNSET,
 		route: Any = _UNSET,
-		origin: Any = _UNSET,
-		mount_id: Any = _UNSET,
 	) -> "PulseContext":
 		"""Create a new context with updated values.
 
@@ -79,8 +79,6 @@ class PulseContext:
 			session: New session (optional, inherits if not provided).
 			render: New render session (optional, inherits if not provided).
 			route: New route context (optional, inherits if not provided).
-			origin: New origin route context (optional, inherits if not provided).
-			mount_id: New origin mount id (optional, inherits if not provided).
 
 		Returns:
 			New PulseContext instance with updated values.
@@ -91,9 +89,30 @@ class PulseContext:
 			session=ctx.session if session is _UNSET else session,
 			render=ctx.render if render is _UNSET else render,
 			route=ctx.route if route is _UNSET else route,
-			origin=ctx.origin if origin is _UNSET else origin,
-			mount_id=ctx.mount_id if mount_id is _UNSET else mount_id,
 		)
+
+	def copy(self) -> "PulseContext":
+		return PulseContext(
+			app=self.app,
+			session=self.session,
+			render=self.render,
+			route=self.route,
+		)
+
+	@classmethod
+	def fork(cls) -> "PulseContext":
+		return cls.get().forked()
+
+	def forked(self) -> "PulseContext":
+		return PulseContext(
+			app=self.app,
+			session=self.session,
+			render=self.render,
+			route=self.route.snapshot() if self.route is not None else None,
+		)
+
+	def snapshot(self) -> "PulseContext":
+		return self.forked()
 
 	def __enter__(self):
 		self._token = PULSE_CONTEXT.set(self)
@@ -115,6 +134,39 @@ PULSE_CONTEXT: ContextVar["PulseContext | None"] = ContextVar(
 	"pulse_context", default=None
 )
 
+
+def wrap_with_forked_context(fn: Callable[P, T]) -> Callable[P, T]:
+	if getattr(fn, _WRAPPED_ATTR, False):
+		return fn
+	if inspect.iscoroutinefunction(fn):
+
+		@wraps(fn)
+		async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> Any:
+			with PulseContext.fork():
+				return await fn(*args, **kwargs)
+
+		setattr(async_wrapper, _WRAPPED_ATTR, True)
+		return cast(Callable[P, T], async_wrapper)
+
+	@wraps(fn)
+	def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+		ctx = PulseContext.fork()
+		with ctx:
+			result = fn(*args, **kwargs)
+		if inspect.isawaitable(result):
+
+			async def await_result() -> Any:
+				with ctx:
+					return await result
+
+			return cast(T, await_result())
+		return result
+
+	setattr(wrapper, _WRAPPED_ATTR, True)
+	return wrapper
+
+
 __all__ = [
 	"PULSE_CONTEXT",
+	"wrap_with_forked_context",
 ]

--- a/packages/pulse/python/src/pulse/decorators.py
+++ b/packages/pulse/python/src/pulse/decorators.py
@@ -4,6 +4,7 @@ import inspect
 from collections.abc import Awaitable, Callable
 from typing import Any, ParamSpec, Protocol, TypeVar, cast, overload
 
+from pulse.context import wrap_with_forked_context
 from pulse.hooks.core import HOOK_CONTEXT
 from pulse.hooks.effects import effect_state
 from pulse.hooks.state import collect_component_identity
@@ -288,9 +289,10 @@ def effect(
 		ctx = HOOK_CONTEXT.get()
 
 		def create_effect() -> Effect | AsyncEffect:
+			wrapped_func = wrap_with_forked_context(func)
 			if inspect.iscoroutinefunction(func):
 				return AsyncEffect(
-					func,  # type: ignore[arg-type]
+					wrapped_func,  # type: ignore[arg-type]
 					name=name or func.__name__,
 					lazy=lazy,
 					on_error=on_error,
@@ -299,7 +301,7 @@ def effect(
 					interval=interval,
 				)
 			return Effect(
-				func,  # type: ignore[arg-type]
+				wrapped_func,  # type: ignore[arg-type]
 				name=name or func.__name__,
 				immediate=immediate,
 				lazy=lazy,

--- a/packages/pulse/python/src/pulse/forms.py
+++ b/packages/pulse/python/src/pulse/forms.py
@@ -22,7 +22,6 @@ from pulse.hooks.runtime import server_address
 from pulse.hooks.stable import stable
 from pulse.react_component import react_component
 from pulse.reactive import Signal
-from pulse.routing import RouteOrigin
 from pulse.serializer import deserialize
 from pulse.transpiler.imports import Import
 from pulse.transpiler.nodes import Node
@@ -190,9 +189,7 @@ class FormRegistry(Disposable):
 
 		with PulseContext.update(
 			render=self._render,
-			route=mount.route,
-			origin=RouteOrigin.from_route(mount.route),
-			mount_id=mount.mount_id,
+			route=mount.route_snapshot(),
 		):
 			await call_flexible(registration.on_submit, data)
 

--- a/packages/pulse/python/src/pulse/forms.py
+++ b/packages/pulse/python/src/pulse/forms.py
@@ -22,6 +22,7 @@ from pulse.hooks.runtime import server_address
 from pulse.hooks.stable import stable
 from pulse.react_component import react_component
 from pulse.reactive import Signal
+from pulse.routing import RouteOrigin
 from pulse.serializer import deserialize
 from pulse.transpiler.imports import Import
 from pulse.transpiler.nodes import Node
@@ -190,9 +191,8 @@ class FormRegistry(Disposable):
 		with PulseContext.update(
 			render=self._render,
 			route=mount.route,
-			source_route_path=registration.route_path,
-			source_path=mount.route.pathname,
-			source_mount_id=mount.mount_id,
+			origin=RouteOrigin.from_route(mount.route),
+			mount_id=mount.mount_id,
 		):
 			await call_flexible(registration.on_submit, data)
 

--- a/packages/pulse/python/src/pulse/hooks/init.py
+++ b/packages/pulse/python/src/pulse/hooks/init.py
@@ -76,6 +76,7 @@ class InitContext:
 	pre_keys: set[str]
 	saved: dict[str, Any]
 	key: str | None
+	_scope: Any | None
 
 	def __init__(self, *, key: str | None = None):
 		self.callsite = None
@@ -84,6 +85,7 @@ class InitContext:
 		self.pre_keys = set()
 		self.saved = {}
 		self.key = key
+		self._scope = None
 
 	def __enter__(self):
 		self.frame = previous_frame()
@@ -99,6 +101,11 @@ class InitContext:
 		else:
 			self.first_render = False
 			self.saved = entry["vars"]
+		if self.first_render:
+			from pulse.reactive import Scope
+
+			self._scope = Scope()
+			self._scope.__enter__()
 		return self
 
 	def restore_variables(self):
@@ -132,12 +139,21 @@ class InitContext:
 		exc_value: BaseException | None,
 		exc_tb: Any,
 	) -> Literal[False]:
-		if exc_type is None:
-			captured = self._capture_new_locals()
-			assert self.callsite is not None, "callsite  None"
-			storage = _init_hook().storage
-			storage[self.callsite] = {"vars": captured, "key": self.key}
-		self.frame = None
+		try:
+			if exc_type is None:
+				captured = self._capture_new_locals()
+				assert self.callsite is not None, "callsite  None"
+				storage = _init_hook().storage
+				storage[self.callsite] = {"vars": captured, "key": self.key}
+		finally:
+			if self._scope is not None:
+				from pulse.context import wrap_with_forked_context
+
+				for effect in self._scope.effects:
+					effect.fn = wrap_with_forked_context(effect.fn)
+				self._scope.__exit__(exc_type, exc_value, exc_tb)
+				self._scope = None
+			self.frame = None
 		return False
 
 

--- a/packages/pulse/python/src/pulse/hooks/runtime.py
+++ b/packages/pulse/python/src/pulse/hooks/runtime.py
@@ -14,7 +14,7 @@ from pulse.context import PulseContext
 from pulse.hooks.core import HOOK_CONTEXT
 from pulse.messages import ServerNavigateToMessage
 from pulse.reactive_extensions import ReactiveDict
-from pulse.routing import Layout, Route, RouteInfo, RouteOrigin
+from pulse.routing import Layout, Route, RouteInfo
 from pulse.state.state import State
 
 
@@ -260,11 +260,10 @@ def navigate(
 		"hard": hard,
 	}
 	if not force and ctx.route is not None:
-		origin = ctx.origin or RouteOrigin.from_route(ctx.route)
-		message["sourceRoutePath"] = origin.route_path
-		message["sourcePath"] = origin.pathname
-		if ctx.mount_id is not None:
-			message["sourceMountId"] = ctx.mount_id
+		message["sourceRoutePath"] = ctx.route.route_path
+		message["sourcePath"] = ctx.route.pathname
+		if ctx.route.mount_id is not None:
+			message["sourceMountId"] = ctx.route.mount_id
 	ctx.render.send(message)
 
 

--- a/packages/pulse/python/src/pulse/hooks/runtime.py
+++ b/packages/pulse/python/src/pulse/hooks/runtime.py
@@ -14,7 +14,7 @@ from pulse.context import PulseContext
 from pulse.hooks.core import HOOK_CONTEXT
 from pulse.messages import ServerNavigateToMessage
 from pulse.reactive_extensions import ReactiveDict
-from pulse.routing import Layout, Route, RouteInfo
+from pulse.routing import Layout, Route, RouteInfo, RouteOrigin
 from pulse.state.state import State
 
 
@@ -260,10 +260,11 @@ def navigate(
 		"hard": hard,
 	}
 	if not force and ctx.route is not None:
-		message["sourceRoutePath"] = ctx.source_route_path or ctx.route.route_path
-		message["sourcePath"] = ctx.source_path or ctx.route.pathname
-		if ctx.source_mount_id is not None:
-			message["sourceMountId"] = ctx.source_mount_id
+		origin = ctx.origin or RouteOrigin.from_route(ctx.route)
+		message["sourceRoutePath"] = origin.route_path
+		message["sourcePath"] = origin.pathname
+		if ctx.mount_id is not None:
+			message["sourceMountId"] = ctx.mount_id
 	ctx.render.send(message)
 
 

--- a/packages/pulse/python/src/pulse/hooks/setup.py
+++ b/packages/pulse/python/src/pulse/hooks/setup.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, ParamSpec, TypeVar, cast, override
 
+from pulse.context import PulseContext, wrap_with_forked_context
 from pulse.hooks.core import HookMetadata, HookState, hooks
 from pulse.reactive import Effect, Scope, Signal
 
@@ -64,8 +65,11 @@ class SetupState(HookState):
 	) -> Any:
 		self.dispose_effects()
 		with Scope() as scope:
-			self.value = init_func(*args, **kwargs)
+			with PulseContext.fork():
+				self.value = init_func(*args, **kwargs)
 			self.effects = list(scope.effects)
+			for effect in self.effects:
+				effect.fn = wrap_with_forked_context(effect.fn)
 		self.args = [Signal(arg) for arg in args]
 		self.kwargs = {name: Signal(value) for name, value in kwargs.items()}
 		self.initialized = True

--- a/packages/pulse/python/src/pulse/hooks/state.py
+++ b/packages/pulse/python/src/pulse/hooks/state.py
@@ -4,6 +4,7 @@ from types import CodeType, FrameType
 from typing import Any, TypeVar, override
 
 from pulse.component import is_component_code
+from pulse.context import PulseContext
 from pulse.hooks.core import HookMetadata, HookState, hooks
 from pulse.state.state import State
 
@@ -91,7 +92,11 @@ class StateHookState(HookState):
 
 
 def _instantiate_state(arg: State | Callable[[], State]) -> State:
-	instance = arg() if callable(arg) else arg
+	if callable(arg):
+		with PulseContext.fork():
+			instance = arg()
+	else:
+		instance = arg
 	if not isinstance(instance, State):
 		raise TypeError(
 			"`pulse.state` expects a State instance or a callable returning a State instance"

--- a/packages/pulse/python/src/pulse/queries/mutation.py
+++ b/packages/pulse/python/src/pulse/queries/mutation.py
@@ -10,6 +10,7 @@ from typing import (
 	override,
 )
 
+from pulse.context import PulseContext
 from pulse.helpers import call_flexible, maybe_await
 from pulse.queries.common import OnErrorFn, OnSuccessFn, bind_state
 from pulse.reactive import Signal
@@ -90,21 +91,22 @@ class MutationResult(Generic[T, P]):
 		return self._error()
 
 	async def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T:
-		self._is_running.write(True)
-		self._error.write(None)
-		try:
-			mutation_result = await self._fn(*args, **kwargs)
-			self._data.write(mutation_result)
-			if self._on_success:
-				await maybe_await(call_flexible(self._on_success, mutation_result))
-			return mutation_result
-		except Exception as e:
-			self._error.write(e)
-			if self._on_error:
-				await maybe_await(call_flexible(self._on_error, e))
-			raise e
-		finally:
-			self._is_running.write(False)
+		with PulseContext.fork():
+			self._is_running.write(True)
+			self._error.write(None)
+			try:
+				mutation_result = await self._fn(*args, **kwargs)
+				self._data.write(mutation_result)
+				if self._on_success:
+					await maybe_await(call_flexible(self._on_success, mutation_result))
+				return mutation_result
+			except Exception as e:
+				self._error.write(e)
+				if self._on_error:
+					await maybe_await(call_flexible(self._on_error, e))
+				raise
+			finally:
+				self._is_running.write(False)
 
 
 class MutationProperty(Generic[T, TState, P], InitializableProperty):

--- a/packages/pulse/python/src/pulse/queries/query.py
+++ b/packages/pulse/python/src/pulse/queries/query.py
@@ -231,34 +231,35 @@ async def run_fetch_with_retries(
 		untrack: If True, wrap fetch_fn in Untrack() to prevent dependency tracking.
 		         Use for keyed queries where fetch is triggered via create_task().
 	"""
-	state.reset_retries()
+	with PulseContext.fork():
+		state.reset_retries()
 
-	while True:
-		try:
-			if untrack:
-				with Untrack():
-					result = await fetch_fn()
-			else:
-				result = await fetch_fn()
-			state.set_success(result)
-			if on_success:
-				with Untrack():
-					await maybe_await(call_flexible(on_success, result))
-			return
-		except asyncio.CancelledError:
-			raise
-		except Exception as e:
-			current_retries = state.retries.read()
-			if current_retries < state.cfg.retries:
-				state.failed_retry(e)
-				await asyncio.sleep(state.cfg.retry_delay)
-			else:
-				state.retry_reason.write(e)
-				state.apply_error(e)
-				if on_error:
+		while True:
+			try:
+				if untrack:
 					with Untrack():
-						await maybe_await(call_flexible(on_error, e))
+						result = await fetch_fn()
+				else:
+					result = await fetch_fn()
+				state.set_success(result)
+				if on_success:
+					with Untrack():
+						await maybe_await(call_flexible(on_success, result))
 				return
+			except asyncio.CancelledError:
+				raise
+			except Exception as e:
+				current_retries = state.retries.read()
+				if current_retries < state.cfg.retries:
+					state.failed_retry(e)
+					await asyncio.sleep(state.cfg.retry_delay)
+				else:
+					state.retry_reason.write(e)
+					state.apply_error(e)
+					if on_error:
+						with Untrack():
+							await maybe_await(call_flexible(on_error, e))
+					return
 
 
 class KeyedQuery(Generic[T], Disposable):

--- a/packages/pulse/python/src/pulse/reactive.py
+++ b/packages/pulse/python/src/pulse/reactive.py
@@ -793,39 +793,40 @@ class AsyncEffect(Effect):
 		self.cancel(cancel_interval=False)
 		this_task: asyncio.Task[None] | None = None
 
+		async def _run_body():
+			self._task_started = True
+			# Perform cleanups in the new task
+			with Untrack():
+				try:
+					self._cleanup_before_run()
+				except Exception as e:
+					self.handle_error(e)
+
+			# Capture last_change for explicit deps before running
+			captured_last_changes: dict[Signal[Any] | Computed[Any], int] | None = None
+			if not self.update_deps:
+				captured_last_changes = {dep: dep.last_change for dep in self.deps}
+
+			with Scope() as scope:
+				try:
+					result = self.fn()
+					self.cleanup_fn = await maybe_await(result)
+				except asyncio.CancelledError:
+					# Re-raise so finally block executes to clear task reference
+					raise
+				except Exception as e:
+					self.handle_error(e)
+				self.runs += 1
+				self.last_run = execution_epoch
+			self._apply_scope_results(scope, captured_last_changes)
+			# Start/restart interval if set and not currently scheduled
+			if self._interval is not None and self._interval_handle is None:
+				self._schedule_interval()
+
 		async def _runner():
 			nonlocal execution_epoch, this_task
 			try:
-				self._task_started = True
-				# Perform cleanups in the new task
-				with Untrack():
-					try:
-						self._cleanup_before_run()
-					except Exception as e:
-						self.handle_error(e)
-
-				# Capture last_change for explicit deps before running
-				captured_last_changes: dict[Signal[Any] | Computed[Any], int] | None = (
-					None
-				)
-				if not self.update_deps:
-					captured_last_changes = {dep: dep.last_change for dep in self.deps}
-
-				with Scope() as scope:
-					try:
-						result = self.fn()
-						self.cleanup_fn = await maybe_await(result)
-					except asyncio.CancelledError:
-						# Re-raise so finally block executes to clear task reference
-						raise
-					except Exception as e:
-						self.handle_error(e)
-					self.runs += 1
-					self.last_run = execution_epoch
-				self._apply_scope_results(scope, captured_last_changes)
-				# Start/restart interval if set and not currently scheduled
-				if self._interval is not None and self._interval_handle is None:
-					self._schedule_interval()
+				await _run_body()
 			finally:
 				# Clear the task reference when it finishes
 				if self._task is this_task:

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -26,6 +26,7 @@ from pulse.routing import (
 	Route,
 	RouteContext,
 	RouteInfo,
+	RouteOrigin,
 	RouteTree,
 	ensure_absolute_path,
 )
@@ -575,16 +576,14 @@ class RenderSession:
 		ctx = PulseContext.get()
 		render_session = ctx.session if session is None else session
 		with Untrack():
-			source_path = mount.route.pathname
-			source_route_path = mount.route.route_path
-			source_mount_id = mount.mount_id
+			origin = RouteOrigin.from_route(mount.route)
+			mount_id = mount.mount_id
 		with PulseContext.update(
 			session=render_session,
 			render=self,
 			route=mount.route,
-			source_route_path=source_route_path,
-			source_path=source_path,
-			source_mount_id=source_mount_id,
+			origin=origin,
+			mount_id=mount_id,
 		):
 			try:
 				self._check_render_loop(mount, path)
@@ -743,15 +742,13 @@ class RenderSession:
 
 		try:
 			with Untrack():
-				source_path = mount.route.pathname
-				source_route_path = mount.route.route_path
-				source_mount_id = mount.mount_id
+				origin = RouteOrigin.from_route(mount.route)
+				mount_id = mount.mount_id
 			with PulseContext.update(
 				render=self,
 				route=mount.route,
-				source_route_path=source_route_path,
-				source_path=source_path,
-				source_mount_id=source_mount_id,
+				origin=origin,
+				mount_id=mount_id,
 			):
 				res = cb.fn(*args[: cb.n_args])
 				if iscoroutine(res):

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -102,7 +102,6 @@ class RouteMount:
 	pending_action: PendingAction | None
 	queue: list[ServerMessage] | None
 	queue_timeout: TimerHandleLike | None
-	mount_id: str
 	render_batch_id: int
 	render_batch_renders: int
 
@@ -115,8 +114,9 @@ class RouteMount:
 	) -> None:
 		self.render = render
 		self.path = ensure_absolute_path(path)
-		self.mount_id = uuid.uuid4().hex
-		self.route = RouteContext(route_info, route, self.path, mount_id=self.mount_id)
+		self.route = RouteContext(
+			route_info, route, self.path, mount_id=uuid.uuid4().hex
+		)
 		self.query_params = QueryParamSync(render, self.route)
 		self.effect = None
 		self.tree = RenderTree(route.render())
@@ -131,9 +131,14 @@ class RouteMount:
 	def update_route(self, route_info: RouteInfo) -> None:
 		self.route.update(route_info)
 
+	@property
+	def mount_id(self) -> str:
+		if self.route.mount_id is None:
+			raise RuntimeError("Route mount id is missing")
+		return self.route.mount_id
+
 	def renew_mount_id(self) -> None:
-		self.mount_id = uuid.uuid4().hex
-		self.route.mount_id = self.mount_id
+		self.route.mount_id = uuid.uuid4().hex
 
 	def route_snapshot(self) -> RouteContext:
 		return self.route.snapshot(mount_id=self.mount_id)
@@ -728,8 +733,9 @@ class RenderSession:
 	) -> asyncio.Task[Any]:
 		"""Create a tracked task tied to this render session."""
 		if callable(coroutine):
+			awaitable = context.run(coroutine) if context is not None else coroutine()
 			return self._tasks.create_task(
-				coroutine(),
+				awaitable,
 				name=name,
 				on_done=on_done,
 				context=context,

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -4,6 +4,7 @@ import traceback
 import uuid
 from asyncio import iscoroutine
 from collections.abc import Awaitable, Callable
+from contextvars import Context
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 
 from pulse.channel import Channel
@@ -26,7 +27,6 @@ from pulse.routing import (
 	Route,
 	RouteContext,
 	RouteInfo,
-	RouteOrigin,
 	RouteTree,
 	ensure_absolute_path,
 )
@@ -36,6 +36,7 @@ from pulse.scheduling import (
 	TimerRegistry,
 	create_future,
 )
+from pulse.state.query_param import QueryParamSync
 from pulse.state.state import State
 from pulse.transpiler.id import next_id
 from pulse.transpiler.nodes import Expr
@@ -94,8 +95,8 @@ class RouteMount:
 	path: str
 	route: RouteContext
 	tree: RenderTree
+	query_params: QueryParamSync
 	effect: Effect | None
-	_pulse_ctx: PulseContext | None
 	initialized: bool
 	state: MountState
 	pending_action: PendingAction | None
@@ -114,16 +115,16 @@ class RouteMount:
 	) -> None:
 		self.render = render
 		self.path = ensure_absolute_path(path)
-		self.route = RouteContext(route_info, route, render, self.path)
+		self.mount_id = uuid.uuid4().hex
+		self.route = RouteContext(route_info, route, self.path, mount_id=self.mount_id)
+		self.query_params = QueryParamSync(render, self.route)
 		self.effect = None
-		self._pulse_ctx = None
 		self.tree = RenderTree(route.render())
 		self.initialized = False
 		self.state = "pending"
 		self.pending_action = None
 		self.queue = []
 		self.queue_timeout = None
-		self.mount_id = uuid.uuid4().hex
 		self.render_batch_id = -1
 		self.render_batch_renders = 0
 
@@ -132,6 +133,10 @@ class RouteMount:
 
 	def renew_mount_id(self) -> None:
 		self.mount_id = uuid.uuid4().hex
+		self.route.mount_id = self.mount_id
+
+	def route_snapshot(self) -> RouteContext:
+		return self.route.snapshot(mount_id=self.mount_id)
 
 	def _cancel_pending_timeout(self) -> None:
 		if self.queue_timeout is not None:
@@ -245,6 +250,7 @@ class RouteMount:
 		self.tree.unmount()
 		if self.effect:
 			self.effect.dispose()
+		self.query_params.dispose()
 
 
 class RenderSession:
@@ -575,15 +581,10 @@ class RenderSession:
 	) -> T_Render | ServerNavigateToMessage:
 		ctx = PulseContext.get()
 		render_session = ctx.session if session is None else session
-		with Untrack():
-			origin = RouteOrigin.from_route(mount.route)
-			mount_id = mount.mount_id
 		with PulseContext.update(
 			session=render_session,
 			render=self,
 			route=mount.route,
-			origin=origin,
-			mount_id=mount_id,
 		):
 			try:
 				self._check_render_loop(mount, path)
@@ -674,6 +675,19 @@ class RenderSession:
 			raise ValueError(f"No active route for '{path}'")
 		return mount
 
+	def current_query_param_sync(self) -> QueryParamSync:
+		ctx = PulseContext.get()
+		if ctx.route is None:
+			raise RuntimeError(
+				"QueryParam properties require a route render context. Create the state inside a component render."
+			)
+		mount = self.route_mounts.get(ctx.route.route_path)
+		if mount is None:
+			raise RuntimeError("QueryParam route is no longer mounted")
+		if ctx.route.mount_id is not None and mount.mount_id != ctx.route.mount_id:
+			raise RuntimeError("QueryParam route mount is stale")
+		return mount.query_params
+
 	def get_global_state(self, key: str, factory: Callable[[], Any]) -> Any:
 		"""Return a per-session singleton for the provided key."""
 		inst = self._global_states.get(key)
@@ -710,11 +724,22 @@ class RenderSession:
 		*,
 		name: str | None = None,
 		on_done: Callable[[asyncio.Task[Any]], None] | None = None,
+		context: Context | None = None,
 	) -> asyncio.Task[Any]:
 		"""Create a tracked task tied to this render session."""
 		if callable(coroutine):
-			return self._tasks.create_task(coroutine(), name=name, on_done=on_done)
-		return self._tasks.create_task(coroutine, name=name, on_done=on_done)
+			return self._tasks.create_task(
+				coroutine(),
+				name=name,
+				on_done=on_done,
+				context=context,
+			)
+		return self._tasks.create_task(
+			coroutine,
+			name=name,
+			on_done=on_done,
+			context=context,
+		)
 
 	def schedule_later(
 		self, delay: float, fn: Callable[..., Any], *args: Any, **kwargs: Any
@@ -741,15 +766,7 @@ class RenderSession:
 			self.report_error(path, "callback", e, {"callback": key, "async": is_async})
 
 		try:
-			with Untrack():
-				origin = RouteOrigin.from_route(mount.route)
-				mount_id = mount.mount_id
-			with PulseContext.update(
-				render=self,
-				route=mount.route,
-				origin=origin,
-				mount_id=mount_id,
-			):
+			with PulseContext.update(render=self, route=mount.route_snapshot()):
 				res = cb.fn(*args[: cb.n_args])
 				if iscoroutine(res):
 
@@ -763,7 +780,11 @@ class RenderSession:
 						if exc:
 							report(exc, True)
 
-					self.create_task(res, name=f"callback:{key}", on_done=_on_done)
+					self.create_task(
+						res,
+						name=f"callback:{key}",
+						on_done=_on_done,
+					)
 		except Exception as e:
 			report(e)
 

--- a/packages/pulse/python/src/pulse/routing.py
+++ b/packages/pulse/python/src/pulse/routing.py
@@ -614,3 +614,63 @@ class RouteContext:
 			f"query='{self.query}', queryParams={self.queryParams}, "
 			f"pathParams={self.pathParams}, catchall={self.catchall})"
 		)
+
+
+@dataclass(frozen=True)
+class RouteOrigin:
+	"""Immutable snapshot of the route context that originated work."""
+
+	info: RouteInfo
+	pulse_route: Route | Layout
+	route_path: str
+
+	@classmethod
+	def from_route(cls, route: RouteContext) -> "RouteOrigin":
+		return cls(
+			info={
+				"pathname": route.pathname,
+				"hash": route.hash,
+				"query": route.query,
+				"queryParams": dict(route.queryParams),
+				"pathParams": dict(route.pathParams),
+				"catchall": list(route.catchall),
+			},
+			pulse_route=route.pulse_route,
+			route_path=route.route_path,
+		)
+
+	@property
+	def pathname(self) -> str:
+		return self.info["pathname"]
+
+	@property
+	def hash(self) -> str:
+		return self.info["hash"]
+
+	@property
+	def query(self) -> str:
+		return self.info["query"]
+
+	@property
+	def queryParams(self) -> dict[str, str]:
+		return self.info["queryParams"]
+
+	@property
+	def pathParams(self) -> dict[str, str]:
+		return self.info["pathParams"]
+
+	@property
+	def catchall(self) -> list[str]:
+		return self.info["catchall"]
+
+	@override
+	def __str__(self) -> str:
+		return f"RouteOrigin(pathname='{self.pathname}', params={self.pathParams})"
+
+	@override
+	def __repr__(self) -> str:
+		return (
+			f"RouteOrigin(pathname='{self.pathname}', hash='{self.hash}', "
+			f"query='{self.query}', queryParams={self.queryParams}, "
+			f"pathParams={self.pathParams}, catchall={self.catchall})"
+		)

--- a/packages/pulse/python/src/pulse/routing.py
+++ b/packages/pulse/python/src/pulse/routing.py
@@ -1,15 +1,12 @@
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, TypedDict, cast, override
+from typing import TypedDict, cast, override
 
 from pulse.component import Component
 from pulse.env import env
+from pulse.reactive import Untrack
 from pulse.reactive_extensions import ReactiveDict
-
-if TYPE_CHECKING:
-	from pulse.render_session import RenderSession
-	from pulse.state.query_param import QueryParamSync
 
 # angle brackets cannot appear in a regular URL path, this ensures no name conflicts
 LAYOUT_INDICATOR = "<layout>"
@@ -549,21 +546,20 @@ class RouteContext:
 	info: RouteInfo
 	pulse_route: Route | Layout
 	route_path: str
-	query_param_sync: "QueryParamSync"
+	mount_id: str | None
 
 	def __init__(
 		self,
 		info: RouteInfo,
 		pulse_route: Route | Layout,
-		render: "RenderSession",
 		route_path: str | None = None,
+		*,
+		mount_id: str | None = None,
 	):
-		self.info = cast(RouteInfo, cast(object, ReactiveDict(info)))
+		self.info = cast(RouteInfo, cast(object, ReactiveDict(copy_route_info(info))))
 		self.pulse_route = pulse_route
 		self.route_path = ensure_absolute_path(route_path or pulse_route.unique_path())
-		from pulse.state.query_param import QueryParamSync
-
-		self.query_param_sync = QueryParamSync(render, self)
+		self.mount_id = mount_id
 
 	def update(self, info: RouteInfo) -> None:
 		"""Update the route info with new values.
@@ -572,6 +568,15 @@ class RouteContext:
 			info: New route info to apply.
 		"""
 		self.info.update(info)
+
+	def snapshot(self, *, mount_id: str | None = None) -> "RouteContext":
+		with Untrack():
+			return RouteContext(
+				self.info,
+				self.pulse_route,
+				self.route_path,
+				mount_id=self.mount_id if mount_id is None else mount_id,
+			)
 
 	@property
 	def pathname(self) -> str:
@@ -616,61 +621,12 @@ class RouteContext:
 		)
 
 
-@dataclass(frozen=True)
-class RouteOrigin:
-	"""Immutable snapshot of the route context that originated work."""
-
-	info: RouteInfo
-	pulse_route: Route | Layout
-	route_path: str
-
-	@classmethod
-	def from_route(cls, route: RouteContext) -> "RouteOrigin":
-		return cls(
-			info={
-				"pathname": route.pathname,
-				"hash": route.hash,
-				"query": route.query,
-				"queryParams": dict(route.queryParams),
-				"pathParams": dict(route.pathParams),
-				"catchall": list(route.catchall),
-			},
-			pulse_route=route.pulse_route,
-			route_path=route.route_path,
-		)
-
-	@property
-	def pathname(self) -> str:
-		return self.info["pathname"]
-
-	@property
-	def hash(self) -> str:
-		return self.info["hash"]
-
-	@property
-	def query(self) -> str:
-		return self.info["query"]
-
-	@property
-	def queryParams(self) -> dict[str, str]:
-		return self.info["queryParams"]
-
-	@property
-	def pathParams(self) -> dict[str, str]:
-		return self.info["pathParams"]
-
-	@property
-	def catchall(self) -> list[str]:
-		return self.info["catchall"]
-
-	@override
-	def __str__(self) -> str:
-		return f"RouteOrigin(pathname='{self.pathname}', params={self.pathParams})"
-
-	@override
-	def __repr__(self) -> str:
-		return (
-			f"RouteOrigin(pathname='{self.pathname}', hash='{self.hash}', "
-			f"query='{self.query}', queryParams={self.queryParams}, "
-			f"pathParams={self.pathParams}, catchall={self.catchall})"
-		)
+def copy_route_info(info: RouteInfo) -> RouteInfo:
+	return {
+		"pathname": info["pathname"],
+		"hash": info["hash"],
+		"query": info["query"],
+		"queryParams": dict(info["queryParams"]),
+		"pathParams": dict(info["pathParams"]),
+		"catchall": list(info["catchall"]),
+	}

--- a/packages/pulse/python/src/pulse/scheduling.py
+++ b/packages/pulse/python/src/pulse/scheduling.py
@@ -1,7 +1,9 @@
 import asyncio
+import inspect
 import os
-from collections.abc import Awaitable, Callable
-from typing import Any, ParamSpec, Protocol, TypeVar, override
+from collections.abc import Awaitable, Callable, Coroutine
+from contextvars import Context, copy_context
+from typing import Any, ParamSpec, Protocol, TypeVar, cast, override
 
 from anyio import from_thread
 
@@ -36,7 +38,7 @@ def call_soon(
 ) -> TimerHandleLike | None:
 	"""Schedule a callback to run ASAP on the main event loop from any thread."""
 	_, timer_registry = _resolve_registries()
-	return timer_registry.call_soon(fn, *args, **kwargs)
+	return timer_registry.call_soon(fn, *args, context=copy_context(), **kwargs)
 
 
 def create_task(
@@ -69,7 +71,7 @@ def later(
 	"""
 
 	_, timer_registry = _resolve_registries()
-	return timer_registry.later(delay, fn, *args, **kwargs)
+	return timer_registry.later(delay, fn, *args, context=copy_context(), **kwargs)
 
 
 class RepeatHandle:
@@ -104,7 +106,7 @@ def repeat(interval: float, fn: Callable[P, Any], *args: P.args, **kwargs: P.kwa
 	"""
 
 	_, timer_registry = _resolve_registries()
-	return timer_registry.repeat(interval, fn, *args, **kwargs)
+	return timer_registry.repeat(interval, fn, *args, context=copy_context(), **kwargs)
 
 
 class TaskRegistry:
@@ -126,25 +128,32 @@ class TaskRegistry:
 		*,
 		name: str | None = None,
 		on_done: Callable[[asyncio.Task[T]], None] | None = None,
+		context: Context | None = None,
 	) -> asyncio.Task[T]:
 		"""Create and schedule a coroutine task on the main loop from any thread."""
-		try:
-			asyncio.get_running_loop()
-			task = asyncio.ensure_future(coroutine)
+
+		def _create() -> asyncio.Task[T]:
+			if asyncio.iscoroutine(coroutine):
+				task = asyncio.get_running_loop().create_task(
+					cast(Coroutine[Any, Any, T], coroutine),
+					context=context,
+				)
+			else:
+				task = asyncio.ensure_future(coroutine)
 			if name is not None:
 				task.set_name(name)
 			if on_done:
 				task.add_done_callback(on_done)
+			return task
+
+		try:
+			asyncio.get_running_loop()
+			task = _create()
 		except RuntimeError:
 
 			async def _runner():
 				asyncio.get_running_loop()
-				task = asyncio.ensure_future(coroutine)
-				if name is not None:
-					task.set_name(name)
-				if on_done:
-					task.add_done_callback(on_done)
-				return task
+				return _create()
 
 			task = from_thread.run(_runner)
 
@@ -190,17 +199,24 @@ class TimerRegistry:
 	def later(
 		self,
 		delay: float,
-		fn: Callable[P, Any],
-		*args: P.args,
-		**kwargs: P.kwargs,
+		fn: Callable[..., Any],
+		*args: Any,
+		context: Context | None = None,
+		**kwargs: Any,
 	) -> TimerHandleLike:
-		return self._schedule(delay, fn, args, dict(kwargs), untrack=True)
+		return self._schedule(
+			delay, fn, args, dict(kwargs), context=context, untrack=True
+		)
 
 	def call_soon(
-		self, fn: Callable[P, Any], *args: P.args, **kwargs: P.kwargs
+		self,
+		fn: Callable[..., Any],
+		*args: Any,
+		context: Context | None = None,
+		**kwargs: Any,
 	) -> TimerHandleLike | None:
 		def _schedule():
-			return self._schedule_soon(fn, args, dict(kwargs))
+			return self._schedule_soon(fn, args, dict(kwargs), context=context)
 
 		try:
 			asyncio.get_running_loop()
@@ -218,7 +234,12 @@ class TimerRegistry:
 				return None
 
 	def repeat(
-		self, interval: float, fn: Callable[P, Any], *args: P.args, **kwargs: P.kwargs
+		self,
+		interval: float,
+		fn: Callable[..., Any],
+		*args: Any,
+		context: Context | None = None,
+		**kwargs: Any,
 	) -> RepeatHandle:
 		from pulse.reactive import Untrack
 
@@ -227,6 +248,11 @@ class TimerRegistry:
 
 		async def _runner():
 			nonlocal handle
+			target = fn
+			if context is not None:
+				from pulse.context import wrap_with_forked_context
+
+				target = wrap_with_forked_context(fn)
 			try:
 				while not handle.cancelled:
 					# Start counting the next interval AFTER the previous execution completes
@@ -235,9 +261,16 @@ class TimerRegistry:
 						break
 					try:
 						with Untrack():
-							result = fn(*args, **kwargs)
-							if asyncio.iscoroutine(result):
-								await result
+							if context is None:
+								result = target(*args, **kwargs)
+							else:
+								result = context.run(target, *args, **kwargs)
+							if inspect.isawaitable(result):
+								if context is None:
+									await result
+								else:
+									task = context.run(asyncio.ensure_future, result)
+									await task
 					except asyncio.CancelledError:
 						# Propagate to outer handler to finish cleanly
 						raise
@@ -269,6 +302,7 @@ class TimerRegistry:
 		args: tuple[Any, ...],
 		kwargs: dict[str, Any],
 		*,
+		context: Context | None,
 		untrack: bool,
 	) -> TimerHandleLike:
 		"""
@@ -288,7 +322,15 @@ class TimerRegistry:
 				raise RuntimeError("later() requires an event loop") from exc
 
 		tracked_box: list[TimerHandleLike] = []
-		_run = self._prepare_run(loop, tracked_box, fn, args, kwargs, untrack=untrack)
+		_run = self._prepare_run(
+			loop,
+			tracked_box,
+			fn,
+			args,
+			kwargs,
+			context=context,
+			untrack=untrack,
+		)
 
 		handle = loop.call_later(delay, _run)
 		tracked = _TrackedTimerHandle(handle, self)
@@ -301,6 +343,8 @@ class TimerRegistry:
 		fn: Callable[..., Any],
 		args: tuple[Any, ...],
 		kwargs: dict[str, Any],
+		*,
+		context: Context | None,
 	) -> TimerHandleLike:
 		try:
 			loop = asyncio.get_running_loop()
@@ -311,7 +355,15 @@ class TimerRegistry:
 				raise RuntimeError("call_soon() requires an event loop") from exc
 
 		tracked_box: list[TimerHandleLike] = []
-		_run = self._prepare_run(loop, tracked_box, fn, args, kwargs, untrack=False)
+		_run = self._prepare_run(
+			loop,
+			tracked_box,
+			fn,
+			args,
+			kwargs,
+			context=context,
+			untrack=False,
+		)
 
 		handle = loop.call_soon(_run)
 		tracked = _TrackedHandle(handle, self, when=loop.time())
@@ -327,19 +379,32 @@ class TimerRegistry:
 		args: tuple[Any, ...],
 		kwargs: dict[str, Any],
 		*,
+		context: Context | None,
 		untrack: bool,
 	) -> Callable[[], None]:
 		def _run():
 			from pulse.reactive import Untrack
 
+			target = fn
+			if context is not None:
+				from pulse.context import wrap_with_forked_context
+
+				target = wrap_with_forked_context(fn)
+
 			try:
 				if untrack:
 					with Untrack():
-						res = fn(*args, **kwargs)
+						if context is None:
+							res = target(*args, **kwargs)
+						else:
+							res = context.run(target, *args, **kwargs)
 				else:
-					res = fn(*args, **kwargs)
-				if asyncio.iscoroutine(res):
-					task = self._tasks.create_task(res)
+					if context is None:
+						res = target(*args, **kwargs)
+					else:
+						res = context.run(target, *args, **kwargs)
+				if inspect.isawaitable(res):
+					task = self._tasks.create_task(res, context=context)
 
 					def _log_task_exception(t: asyncio.Task[Any]):
 						try:

--- a/packages/pulse/python/src/pulse/scheduling.py
+++ b/packages/pulse/python/src/pulse/scheduling.py
@@ -241,18 +241,12 @@ class TimerRegistry:
 		context: Context | None = None,
 		**kwargs: Any,
 	) -> RepeatHandle:
-		from pulse.reactive import Untrack
-
 		loop = asyncio.get_running_loop()
 		handle = RepeatHandle()
 
 		async def _runner():
 			nonlocal handle
-			target = fn
-			if context is not None:
-				from pulse.context import wrap_with_forked_context
-
-				target = wrap_with_forked_context(fn)
+			target = self._context_target(fn, context)
 			try:
 				while not handle.cancelled:
 					# Start counting the next interval AFTER the previous execution completes
@@ -260,17 +254,19 @@ class TimerRegistry:
 					if handle.cancelled:
 						break
 					try:
-						with Untrack():
+						result = self._call_target(
+							target,
+							args,
+							kwargs,
+							context=context,
+							untrack=True,
+						)
+						if inspect.isawaitable(result):
 							if context is None:
-								result = target(*args, **kwargs)
+								await result
 							else:
-								result = context.run(target, *args, **kwargs)
-							if inspect.isawaitable(result):
-								if context is None:
-									await result
-								else:
-									task = context.run(asyncio.ensure_future, result)
-									await task
+								task = context.run(asyncio.ensure_future, result)
+								await task
 					except asyncio.CancelledError:
 						# Propagate to outer handler to finish cleanly
 						raise
@@ -382,27 +378,17 @@ class TimerRegistry:
 		context: Context | None,
 		untrack: bool,
 	) -> Callable[[], None]:
+		target = self._context_target(fn, context)
+
 		def _run():
-			from pulse.reactive import Untrack
-
-			target = fn
-			if context is not None:
-				from pulse.context import wrap_with_forked_context
-
-				target = wrap_with_forked_context(fn)
-
 			try:
-				if untrack:
-					with Untrack():
-						if context is None:
-							res = target(*args, **kwargs)
-						else:
-							res = context.run(target, *args, **kwargs)
-				else:
-					if context is None:
-						res = target(*args, **kwargs)
-					else:
-						res = context.run(target, *args, **kwargs)
+				res = self._call_target(
+					target,
+					args,
+					kwargs,
+					context=context,
+					untrack=untrack,
+				)
 				if inspect.isawaitable(res):
 					task = self._tasks.create_task(res, context=context)
 
@@ -435,6 +421,36 @@ class TimerRegistry:
 				self.discard(tracked_box[0] if tracked_box else None)
 
 		return _run
+
+	def _context_target(
+		self, fn: Callable[..., Any], context: Context | None
+	) -> Callable[..., Any]:
+		if context is None:
+			return fn
+		from pulse.context import wrap_with_forked_context
+
+		return wrap_with_forked_context(fn)
+
+	def _call_target(
+		self,
+		target: Callable[..., Any],
+		args: tuple[Any, ...],
+		kwargs: dict[str, Any],
+		*,
+		context: Context | None,
+		untrack: bool,
+	) -> Any:
+		from pulse.reactive import Untrack
+
+		def invoke() -> Any:
+			if context is None:
+				return target(*args, **kwargs)
+			return context.run(target, *args, **kwargs)
+
+		if untrack:
+			with Untrack():
+				return invoke()
+		return invoke()
 
 
 class _TrackedTimerHandle:

--- a/packages/pulse/python/src/pulse/state/property.py
+++ b/packages/pulse/python/src/pulse/state/property.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Generic, Never, TypeVar, override
 
+from pulse.context import wrap_with_forked_context
 from pulse.reactive import AsyncEffect, Computed, Effect, Signal
 from pulse.reactive_extensions import ReactiveProperty
 
@@ -192,20 +193,21 @@ class StateEffect(Generic[T], InitializableProperty):
 
 	@override
 	def initialize(self, state: "State", name: str):
-		bound_method = self.fn.__get__(state, state.__class__)
-		# Select sync/async effect type based on bound method
-		if inspect.iscoroutinefunction(bound_method):
-			effect: Effect = AsyncEffect(
-				bound_method,  # type: ignore[arg-type]
-				name=self.name or f"{state.__class__.__name__}.{name}",
-				lazy=self.lazy,
-				on_error=self.on_error,
-				deps=self.deps,
-				update_deps=self.update_deps,
-				interval=self.interval,
-			)
-		else:
-			effect = Effect(
+		bound_method = wrap_with_forked_context(self.fn.__get__(state, state.__class__))
+
+		def create_effect() -> Effect:
+			# Select sync/async effect type based on bound method
+			if inspect.iscoroutinefunction(bound_method):
+				return AsyncEffect(
+					bound_method,  # type: ignore[arg-type]
+					name=self.name or f"{state.__class__.__name__}.{name}",
+					lazy=self.lazy,
+					on_error=self.on_error,
+					deps=self.deps,
+					update_deps=self.update_deps,
+					interval=self.interval,
+				)
+			return Effect(
 				bound_method,  # type: ignore[arg-type]
 				name=self.name or f"{state.__class__.__name__}.{name}",
 				immediate=self.immediate,
@@ -215,4 +217,6 @@ class StateEffect(Generic[T], InitializableProperty):
 				update_deps=self.update_deps,
 				interval=self.interval,
 			)
+
+		effect = create_effect()
 		setattr(state, name, effect)

--- a/packages/pulse/python/src/pulse/state/query_param.py
+++ b/packages/pulse/python/src/pulse/state/query_param.py
@@ -26,6 +26,7 @@ from pulse.helpers import Disposable, values_equal
 from pulse.messages import ServerNavigateToMessage
 from pulse.reactive import Effect, Scope, Signal, Untrack
 from pulse.reactive_extensions import reactive, unwrap
+from pulse.routing import RouteOrigin
 from pulse.state.property import InitializableProperty, StateProperty
 
 T = TypeVar("T")
@@ -488,11 +489,9 @@ class QueryParamSync(Disposable):
 			info = self.route.info
 			raw_params = info["queryParams"]
 			current_params = dict(cast(Mapping[str, str], raw_params))
-			pathname = info["pathname"]
-			source_route_path = self.route.route_path
-			source_path = pathname
-			mount = self.render.route_mounts.get(source_route_path)
-			source_mount_id = mount.mount_id if mount is not None else None
+			origin = RouteOrigin.from_route(self.route)
+			mount = self.render.route_mounts.get(origin.route_path)
+			mount_id = mount.mount_id if mount is not None else None
 			hash_frag = info["hash"]
 		query_params = dict(current_params)
 		for binding in self._bindings.values():
@@ -514,7 +513,7 @@ class QueryParamSync(Disposable):
 
 		if query_params == current_params:
 			return
-		path = pathname
+		path = origin.pathname
 		query = urlencode(query_params)
 		if query:
 			path += "?" + query
@@ -528,11 +527,11 @@ class QueryParamSync(Disposable):
 			path=path,
 			replace=True,
 			hard=False,
-			sourceRoutePath=source_route_path,
-			sourcePath=source_path,
+			sourceRoutePath=origin.route_path,
+			sourcePath=origin.pathname,
 		)
-		if source_mount_id is not None:
-			message["sourceMountId"] = source_mount_id
+		if mount_id is not None:
+			message["sourceMountId"] = mount_id
 		self.render.send(message)
 
 	@override

--- a/packages/pulse/python/src/pulse/state/query_param.py
+++ b/packages/pulse/python/src/pulse/state/query_param.py
@@ -26,7 +26,6 @@ from pulse.helpers import Disposable, values_equal
 from pulse.messages import ServerNavigateToMessage
 from pulse.reactive import Effect, Scope, Signal, Untrack
 from pulse.reactive_extensions import reactive, unwrap
-from pulse.routing import RouteOrigin
 from pulse.state.property import InitializableProperty, StateProperty
 
 T = TypeVar("T")
@@ -357,11 +356,11 @@ class QueryParamProperty(StateProperty, InitializableProperty):
 	@override
 	def initialize(self, state: "State", name: str) -> None:
 		ctx = PulseContext.get()
-		if ctx.render is None or ctx.route is None:
+		if ctx.render is None:
 			raise RuntimeError(
 				"QueryParam properties require a route render context. Create the state inside a component render."
 			)
-		sync = ctx.route.query_param_sync
+		sync = ctx.render.current_query_param_sync()
 		registration = sync.register(state, name, self)
 		setattr(state, f"_query_param_reg_{name}", registration)
 
@@ -489,9 +488,9 @@ class QueryParamSync(Disposable):
 			info = self.route.info
 			raw_params = info["queryParams"]
 			current_params = dict(cast(Mapping[str, str], raw_params))
-			origin = RouteOrigin.from_route(self.route)
-			mount = self.render.route_mounts.get(origin.route_path)
-			mount_id = mount.mount_id if mount is not None else None
+			pathname = self.route.pathname
+			route_path = self.route.route_path
+			mount_id = self.route.mount_id
 			hash_frag = info["hash"]
 		query_params = dict(current_params)
 		for binding in self._bindings.values():
@@ -513,7 +512,7 @@ class QueryParamSync(Disposable):
 
 		if query_params == current_params:
 			return
-		path = origin.pathname
+		path = pathname
 		query = urlencode(query_params)
 		if query:
 			path += "?" + query
@@ -527,8 +526,8 @@ class QueryParamSync(Disposable):
 			path=path,
 			replace=True,
 			hard=False,
-			sourceRoutePath=origin.route_path,
-			sourcePath=origin.pathname,
+			sourceRoutePath=route_path,
+			sourcePath=pathname,
 		)
 		if mount_id is not None:
 			message["sourceMountId"] = mount_id

--- a/packages/pulse/python/tests/test_hooks.py
+++ b/packages/pulse/python/tests/test_hooks.py
@@ -48,7 +48,7 @@ def make_route_context(route_info: RouteInfo):
 	route = Route("/", ps.component(render))
 	routes = RouteTree([route])
 	session = RenderSession("test", routes)
-	route_ctx = RouteContext(route_info, route, session)
+	route_ctx = RouteContext(route_info, route)
 	app = ps.App(routes=[route])
 	return app, session, route_ctx, route
 

--- a/packages/pulse/python/tests/test_inline_effects.py
+++ b/packages/pulse/python/tests/test_inline_effects.py
@@ -4,6 +4,7 @@ from typing import cast
 import pulse as ps
 import pytest
 from pulse import HookContext, Signal
+from pulse.context import PULSE_CONTEXT
 from pulse.reactive import AsyncEffect, Batch, Computed, Effect
 from pulse.test_helpers import wait_for
 
@@ -422,6 +423,21 @@ class TestContextDetection:
 
 		assert runs["count"] == 1
 		assert isinstance(module_effect, Effect)
+
+	def test_standalone_immediate_effect_runs_without_pulse_context(self):
+		runs = {"count": 0}
+		token = PULSE_CONTEXT.set(None)
+		try:
+
+			@ps.effect(immediate=True)
+			def standalone_effect():
+				runs["count"] += 1
+
+		finally:
+			PULSE_CONTEXT.reset(token)
+
+		assert runs["count"] == 1
+		assert isinstance(standalone_effect, Effect)
 
 	def test_state_class_effect_unchanged(self):
 		from pulse.state.property import StateEffect

--- a/packages/pulse/python/tests/test_mutation.py
+++ b/packages/pulse/python/tests/test_mutation.py
@@ -1,10 +1,11 @@
+import asyncio
 from collections.abc import Awaitable, Callable
 from typing import ParamSpec, TypeVar
 
 import pulse as ps
 import pytest
 from pulse.render_session import RenderSession
-from pulse.routing import RouteTree
+from pulse.routing import Route, RouteContext, RouteInfo, RouteTree
 from pulse.test_helpers import wait_for
 
 P = ParamSpec("P")
@@ -31,6 +32,17 @@ def with_render_session(fn: Callable[P, Awaitable[R]]):
 			return await fn(*args, **kwargs)
 
 	return wrapper
+
+
+def make_route_info(query: str) -> RouteInfo:
+	return {
+		"pathname": "/items",
+		"hash": "",
+		"query": query,
+		"queryParams": {"q": query},
+		"pathParams": {},
+		"catchall": [],
+	}
 
 
 @pytest.mark.asyncio
@@ -237,3 +249,42 @@ async def test_mutation_with_parameters():
 
 	# Check data property
 	assert mutation.data == 9
+
+
+@pytest.mark.asyncio
+@with_render_session
+async def test_mutation_forks_context_for_full_execution():
+	seen: list[str] = []
+	started = asyncio.Event()
+	continue_mutation = asyncio.Event()
+	route = Route("items", ps.component(lambda: ps.div()))
+	route_ctx = RouteContext(make_route_info("one"), route, "/items")
+
+	class S(ps.State):
+		@ps.mutation
+		async def load(self) -> str:
+			ctx = ps.PulseContext.get()
+			assert ctx.route is not None
+			seen.append(ctx.route.query)
+			started.set()
+			await continue_mutation.wait()
+			ctx = ps.PulseContext.get()
+			assert ctx.route is not None
+			seen.append(ctx.route.query)
+			return "ok"
+
+		@load.on_success
+		def _on_success(self, _data: str):
+			ctx = ps.PulseContext.get()
+			assert ctx.route is not None
+			seen.append(ctx.route.query)
+
+	s = S()
+	with ps.PulseContext.update(route=route_ctx):
+		task = asyncio.create_task(s.load())
+		assert await wait_for(lambda: started.is_set(), timeout=0.2)
+		route_ctx.update(make_route_info("two"))
+		continue_mutation.set()
+		assert await task == "ok"
+
+	assert seen == ["one", "one", "one"]

--- a/packages/pulse/python/tests/test_query_param.py
+++ b/packages/pulse/python/tests/test_query_param.py
@@ -41,9 +41,9 @@ def make_context(route_info: RouteInfo):
 	return app, session, route_ctx
 
 
-def flush_query_param_sync(route_ctx: RouteContext) -> None:
+def flush_query_param_sync(session: RenderSession, route_ctx: RouteContext) -> None:
 	flush_effects()
-	effect = route_ctx.query_param_sync._state_effect  # pyright: ignore[reportPrivateUsage]
+	effect = session.route_mounts[route_ctx.route_path].query_params._state_effect  # pyright: ignore[reportPrivateUsage]
 	if effect is not None:
 		effect.flush()
 
@@ -66,7 +66,7 @@ class TestQueryParam:
 			flush_effects()
 			messages.clear()
 			state.q = "next"
-			flush_query_param_sync(route_ctx)
+			flush_query_param_sync(session, route_ctx)
 
 		assert len(messages) == 1
 		msg = messages[0]
@@ -126,7 +126,7 @@ class TestQueryParam:
 			flush_effects()
 			messages.clear()
 			state.tags = ["x,y", "z\\w"]
-			flush_query_param_sync(route_ctx)
+			flush_query_param_sync(session, route_ctx)
 
 		assert len(messages) == 1
 		msg = messages[0]
@@ -148,7 +148,7 @@ class TestQueryParam:
 			flush_effects()
 			messages.clear()
 			state.tags.append("alpha")
-			flush_query_param_sync(route_ctx)
+			flush_query_param_sync(session, route_ctx)
 
 		assert len(messages) == 1
 		msg = messages[0]
@@ -172,7 +172,7 @@ class TestQueryParam:
 			flush_effects()
 			messages.clear()
 			state.q = "hello"
-			flush_query_param_sync(route_ctx)
+			flush_query_param_sync(session, route_ctx)
 
 		assert len(messages) == 1
 		msg = messages[0]
@@ -205,7 +205,7 @@ class TestQueryParam:
 			flush_effects()
 			messages.clear()
 			state.tags = []
-			flush_query_param_sync(route_ctx)
+			flush_query_param_sync(session, route_ctx)
 
 		assert len(messages) == 1
 		msg = messages[0]
@@ -228,7 +228,7 @@ class TestQueryParam:
 			state = QState()
 			messages.clear()
 			state.q = "next"
-			flush_query_param_sync(route_ctx)
+			flush_query_param_sync(session, route_ctx)
 
 		assert len(messages) == 1
 		msg = messages[0]

--- a/packages/pulse/python/tests/test_query_param.py
+++ b/packages/pulse/python/tests/test_query_param.py
@@ -73,6 +73,7 @@ class TestQueryParam:
 		assert msg["type"] == "navigate_to"
 		assert msg.get("sourceRoutePath") == "/"
 		assert msg.get("sourcePath") == "/"
+		assert isinstance(msg.get("sourceMountId"), str)
 		parsed = urlparse(str(msg["path"]))
 		query = parse_qs(parsed.query)
 		assert query["q"] == ["next"]

--- a/packages/pulse/python/tests/test_render_session.py
+++ b/packages/pulse/python/tests/test_render_session.py
@@ -15,7 +15,7 @@ from pulse import javascript
 from pulse.hooks.runtime import NotFoundInterrupt, RedirectInterrupt
 from pulse.messages import ServerMessage
 from pulse.render_session import RenderSession
-from pulse.routing import Route, RouteInfo, RouteTree
+from pulse.routing import Route, RouteInfo, RouteOrigin, RouteTree
 from pulse.test_helpers import wait_for
 
 
@@ -144,7 +144,7 @@ def first_callback_key(session: RenderSession, path: str) -> str:
 
 
 @pytest.mark.asyncio
-async def test_pulse_context_update_can_clear_route_source():
+async def test_pulse_context_update_can_clear_route_origin():
 	routes = RouteTree([Route("a", simple_component)])
 	session = RenderSession("test-id", routes)
 
@@ -156,21 +156,47 @@ async def test_pulse_context_update_can_clear_route_source():
 	with ps.PulseContext.update(
 		render=session,
 		route=route,
-		source_route_path=route.route_path,
-		source_path=route.pathname,
-		source_mount_id=session.route_mounts["/a"].mount_id,
+		origin=RouteOrigin.from_route(route),
+		mount_id=session.route_mounts["/a"].mount_id,
 	):
 		with ps.PulseContext.update(
 			route=None,
-			source_route_path=None,
-			source_path=None,
-			source_mount_id=None,
+			origin=None,
+			mount_id=None,
 		):
 			ctx = ps.PulseContext.get()
 			assert ctx.route is None
-			assert ctx.source_route_path is None
-			assert ctx.source_path is None
-			assert ctx.source_mount_id is None
+			assert ctx.origin is None
+			assert ctx.mount_id is None
+
+	session.close()
+
+
+def test_route_origin_snapshots_route_context():
+	routes = RouteTree([Route("items/:id/*", simple_component)])
+	session = RenderSession("test-id", routes)
+	first_info = make_route_info("/items/123/a", path_params={"id": "123"})
+	first_info["catchall"] = ["a"]
+	first_info["queryParams"] = {"q": "one"}
+	first_info["query"] = "q=one"
+	next_info = make_route_info("/items/456/b", path_params={"id": "456"})
+	next_info["catchall"] = ["b"]
+	next_info["queryParams"] = {"q": "two"}
+	next_info["query"] = "q=two"
+
+	with ps.PulseContext.update(render=session):
+		session.prerender(["/items/:id/*"], first_info)
+		session.attach("/items/:id/*", first_info)
+
+	route = session.route_mounts["/items/:id/*"].route
+	origin = RouteOrigin.from_route(route)
+	route.update(next_info)
+
+	assert origin.route_path == "/items/:id/*"
+	assert origin.pathname == "/items/123/a"
+	assert origin.queryParams == {"q": "one"}
+	assert origin.pathParams == {"id": "123"}
+	assert origin.catchall == ["a"]
 
 	session.close()
 
@@ -584,8 +610,7 @@ def test_route_bound_navigation_validates_source_route_identity():
 	with ps.PulseContext.update(
 		render=session,
 		route=mount.route,
-		source_route_path=mount.route.route_path,
-		source_path=mount.route.pathname,
+		origin=RouteOrigin.from_route(mount.route),
 	):
 		session.detach("/a")
 		ps.navigate("/after")
@@ -696,8 +721,7 @@ def test_queued_route_bound_navigation_is_revalidated_on_reconnect():
 	with ps.PulseContext.update(
 		render=session,
 		route=mount.route,
-		source_route_path=mount.route.route_path,
-		source_path=mount.route.pathname,
+		origin=RouteOrigin.from_route(mount.route),
 	):
 		ps.navigate("/after")
 

--- a/packages/pulse/python/tests/test_render_session.py
+++ b/packages/pulse/python/tests/test_render_session.py
@@ -6,16 +6,20 @@ Each session mounts both routes and mutates state via callbacks. We assert
 that updates from one session do not leak into the other.
 """
 
+import ast
 import asyncio
+import inspect
 from typing import Any, cast, override
 
 import pulse as ps
+import pulse.reactive as reactive_module
 import pytest
 from pulse import javascript
 from pulse.hooks.runtime import NotFoundInterrupt, RedirectInterrupt
 from pulse.messages import ServerMessage
+from pulse.reactive import flush_effects
 from pulse.render_session import RenderSession
-from pulse.routing import Route, RouteInfo, RouteOrigin, RouteTree
+from pulse.routing import Route, RouteInfo, RouteTree
 from pulse.test_helpers import wait_for
 
 
@@ -75,6 +79,16 @@ def make_route_info(
 def transition_mount_to_idle(session: RenderSession, path: str) -> None:
 	mount = session.route_mounts[path]
 	mount.to_idle()
+
+
+def test_reactive_module_does_not_import_pulse_context():
+	source = inspect.getsource(reactive_module)
+	tree = ast.parse(source)
+	for node in ast.walk(tree):
+		if isinstance(node, ast.Import):
+			assert all(alias.name != "pulse.context" for alias in node.names)
+		if isinstance(node, ast.ImportFrom):
+			assert node.module != "pulse.context"
 
 
 # TODO: clean this up - this was refactored using GPT-5 and is thus quite hacky
@@ -144,7 +158,7 @@ def first_callback_key(session: RenderSession, path: str) -> str:
 
 
 @pytest.mark.asyncio
-async def test_pulse_context_update_can_clear_route_origin():
+async def test_pulse_context_update_can_clear_route():
 	routes = RouteTree([Route("a", simple_component)])
 	session = RenderSession("test-id", routes)
 
@@ -153,26 +167,15 @@ async def test_pulse_context_update_can_clear_route_origin():
 		session.attach("/a", make_route_info("/a"))
 
 	route = session.route_mounts["/a"].route
-	with ps.PulseContext.update(
-		render=session,
-		route=route,
-		origin=RouteOrigin.from_route(route),
-		mount_id=session.route_mounts["/a"].mount_id,
-	):
-		with ps.PulseContext.update(
-			route=None,
-			origin=None,
-			mount_id=None,
-		):
+	with ps.PulseContext.update(render=session, route=route):
+		with ps.PulseContext.update(route=None):
 			ctx = ps.PulseContext.get()
 			assert ctx.route is None
-			assert ctx.origin is None
-			assert ctx.mount_id is None
 
 	session.close()
 
 
-def test_route_origin_snapshots_route_context():
+def test_route_context_snapshot_does_not_track_route_updates():
 	routes = RouteTree([Route("items/:id/*", simple_component)])
 	session = RenderSession("test-id", routes)
 	first_info = make_route_info("/items/123/a", path_params={"id": "123"})
@@ -189,14 +192,14 @@ def test_route_origin_snapshots_route_context():
 		session.attach("/items/:id/*", first_info)
 
 	route = session.route_mounts["/items/:id/*"].route
-	origin = RouteOrigin.from_route(route)
+	snapshot = route.snapshot()
 	route.update(next_info)
 
-	assert origin.route_path == "/items/:id/*"
-	assert origin.pathname == "/items/123/a"
-	assert origin.queryParams == {"q": "one"}
-	assert origin.pathParams == {"id": "123"}
-	assert origin.catchall == ["a"]
+	assert snapshot.route_path == "/items/:id/*"
+	assert snapshot.pathname == "/items/123/a"
+	assert snapshot.queryParams == {"q": "one"}
+	assert snapshot.pathParams == {"id": "123"}
+	assert snapshot.catchall == ["a"]
 
 	session.close()
 
@@ -607,11 +610,7 @@ def test_route_bound_navigation_validates_source_route_identity():
 		session.attach("/b", route_info)
 
 	mount = session.route_mounts["/a"]
-	with ps.PulseContext.update(
-		render=session,
-		route=mount.route,
-		origin=RouteOrigin.from_route(mount.route),
-	):
+	with ps.PulseContext.update(render=session, route=mount.route_snapshot()):
 		session.detach("/a")
 		ps.navigate("/after")
 
@@ -669,12 +668,15 @@ async def test_async_callback_navigation_after_route_update_is_ignored_by_defaul
 	started = asyncio.Event()
 	release = asyncio.Event()
 	completed = asyncio.Event()
+	seen_ids: list[str] = []
 
 	@ps.component
 	def Page():
 		async def on_click():
+			seen_ids.append(ps.route()["pathParams"]["id"])
 			started.set()
 			await release.wait()
+			seen_ids.append(ps.route()["pathParams"]["id"])
 			ps.navigate("/after")
 			completed.set()
 
@@ -702,6 +704,293 @@ async def test_async_callback_navigation_after_route_update_is_ignored_by_defaul
 
 	assert not [msg for msg in messages if msg["type"] == "navigate_to"]
 	assert not [msg for msg in messages if msg["type"] == "server_error"]
+	assert seen_ids == ["123", "123"]
+
+	session.close()
+
+
+@pytest.mark.asyncio
+async def test_async_effect_sees_route_snapshot_after_route_update():
+	started = asyncio.Event()
+	release = asyncio.Event()
+	completed = asyncio.Event()
+	seen_ids: list[str] = []
+
+	@ps.component
+	def Page():
+		@ps.effect
+		async def load():  # pyright: ignore[reportUnusedFunction]
+			seen_ids.append(ps.route()["pathParams"]["id"])
+			started.set()
+			await release.wait()
+			seen_ids.append(ps.route()["pathParams"]["id"])
+			completed.set()
+
+		return ps.div()
+
+	routes = RouteTree([Route("items/:id", Page)])
+	session = RenderSession("test-id", routes)
+	first_info = make_route_info("/items/123", path_params={"id": "123"})
+	next_info = make_route_info("/items/456", path_params={"id": "456"})
+
+	with ps.PulseContext.update(render=session):
+		session.prerender(["/items/:id"], first_info)
+		session.attach("/items/:id", first_info)
+
+	await started.wait()
+	session.attach("/items/:id", next_info)
+	release.set()
+	await asyncio.wait_for(completed.wait(), timeout=0.2)
+	await asyncio.sleep(0)
+
+	assert seen_ids == ["123", "123"]
+
+	session.close()
+
+
+@pytest.mark.asyncio
+async def test_state_async_effect_sees_route_snapshot_after_route_update():
+	started = asyncio.Event()
+	release = asyncio.Event()
+	completed = asyncio.Event()
+	seen_ids: list[str] = []
+
+	class RouteState(ps.State):
+		@ps.effect
+		async def load(self):
+			seen_ids.append(ps.route()["pathParams"]["id"])
+			started.set()
+			await release.wait()
+			seen_ids.append(ps.route()["pathParams"]["id"])
+			completed.set()
+
+	@ps.component
+	def Page():
+		ps.state(RouteState)
+		return ps.div()
+
+	routes = RouteTree([Route("items/:id", Page)])
+	session = RenderSession("test-id", routes)
+	first_info = make_route_info("/items/123", path_params={"id": "123"})
+	next_info = make_route_info("/items/456", path_params={"id": "456"})
+
+	with ps.PulseContext.update(render=session):
+		session.prerender(["/items/:id"], first_info)
+		session.attach("/items/:id", first_info)
+
+	await started.wait()
+	session.attach("/items/:id", next_info)
+	release.set()
+	await asyncio.wait_for(completed.wait(), timeout=0.2)
+
+	assert seen_ids == ["123", "123"]
+
+	session.close()
+
+
+@pytest.mark.asyncio
+async def test_state_constructor_task_sees_route_snapshot_after_route_update():
+	started = asyncio.Event()
+	release = asyncio.Event()
+	completed = asyncio.Event()
+	seen_ids: list[str] = []
+
+	class RouteState(ps.State):
+		_task: asyncio.Task[None]
+
+		def __init__(self):
+			async def work():
+				seen_ids.append(ps.route()["pathParams"]["id"])
+				started.set()
+				await release.wait()
+				seen_ids.append(ps.route()["pathParams"]["id"])
+				completed.set()
+
+			self._task = asyncio.create_task(work())
+
+	@ps.component
+	def Page():
+		state = ps.state(RouteState)
+		return ps.div(str(state._task.done()))  # pyright: ignore[reportPrivateUsage]
+
+	routes = RouteTree([Route("items/:id", Page)])
+	session = RenderSession("test-id", routes)
+	first_info = make_route_info("/items/123", path_params={"id": "123"})
+	next_info = make_route_info("/items/456", path_params={"id": "456"})
+
+	with ps.PulseContext.update(render=session):
+		session.prerender(["/items/:id"], first_info)
+		session.attach("/items/:id", first_info)
+
+	session.attach("/items/:id", next_info)
+	await started.wait()
+	release.set()
+	await asyncio.wait_for(completed.wait(), timeout=0.2)
+
+	assert seen_ids == ["123", "123"]
+
+	session.close()
+
+
+@pytest.mark.asyncio
+async def test_setup_task_sees_route_snapshot_after_route_update():
+	started = asyncio.Event()
+	release = asyncio.Event()
+	completed = asyncio.Event()
+	seen_ids: list[str] = []
+
+	@ps.component
+	def Page():
+		def init():
+			async def work():
+				seen_ids.append(ps.route()["pathParams"]["id"])
+				started.set()
+				await release.wait()
+				seen_ids.append(ps.route()["pathParams"]["id"])
+				completed.set()
+
+			return asyncio.create_task(work())
+
+		task = ps.setup(init)
+		return ps.div(str(task.done()))
+
+	routes = RouteTree([Route("items/:id", Page)])
+	session = RenderSession("test-id", routes)
+	first_info = make_route_info("/items/123", path_params={"id": "123"})
+	next_info = make_route_info("/items/456", path_params={"id": "456"})
+
+	with ps.PulseContext.update(render=session):
+		session.prerender(["/items/:id"], first_info)
+		session.attach("/items/:id", first_info)
+
+	session.attach("/items/:id", next_info)
+	await started.wait()
+	release.set()
+	await asyncio.wait_for(completed.wait(), timeout=0.2)
+
+	assert seen_ids == ["123", "123"]
+
+	session.close()
+
+
+@pytest.mark.asyncio
+async def test_init_effect_sees_route_snapshot_after_route_update():
+	started = asyncio.Event()
+	release = asyncio.Event()
+	completed = asyncio.Event()
+	seen_ids: list[str] = []
+
+	@ps.component
+	def Page():
+		async def work():
+			seen_ids.append(ps.route()["pathParams"]["id"])
+			started.set()
+			await release.wait()
+			seen_ids.append(ps.route()["pathParams"]["id"])
+			completed.set()
+
+		with ps.init():
+			effect = ps.AsyncEffect(work, name="init-work")
+
+		return ps.div(str(effect.runs))
+
+	routes = RouteTree([Route("items/:id", Page)])
+	session = RenderSession("test-id", routes)
+	first_info = make_route_info("/items/123", path_params={"id": "123"})
+	next_info = make_route_info("/items/456", path_params={"id": "456"})
+
+	with ps.PulseContext.update(render=session):
+		session.prerender(["/items/:id"], first_info)
+		session.attach("/items/:id", first_info)
+
+	session.attach("/items/:id", next_info)
+	await started.wait()
+	release.set()
+	await asyncio.wait_for(completed.wait(), timeout=0.2)
+
+	assert seen_ids == ["456", "456"]
+
+	session.close()
+
+
+@pytest.mark.asyncio
+async def test_later_callback_sees_route_snapshot_after_route_update():
+	started = asyncio.Event()
+	completed = asyncio.Event()
+	seen_ids: list[str] = []
+
+	@ps.component
+	def Page():
+		def on_click():
+			def run_later():
+				seen_ids.append(ps.route()["pathParams"]["id"])
+				completed.set()
+
+			started.set()
+			ps.later(0.01, run_later)
+
+		return ps.button(onClick=on_click)["go"]
+
+	routes = RouteTree([Route("items/:id", Page)])
+	session = RenderSession("test-id", routes)
+	first_info = make_route_info("/items/123", path_params={"id": "123"})
+	next_info = make_route_info("/items/456", path_params={"id": "456"})
+
+	with ps.PulseContext.update(render=session):
+		session.prerender(["/items/:id"], first_info)
+		session.attach("/items/:id", first_info)
+
+	session.execute_callback(
+		"/items/:id", first_callback_key(session, "/items/:id"), []
+	)
+	await started.wait()
+	session.attach("/items/:id", next_info)
+	await asyncio.wait_for(completed.wait(), timeout=0.2)
+
+	assert seen_ids == ["123"]
+
+	session.close()
+
+
+@pytest.mark.asyncio
+async def test_async_repeat_callback_sees_route_snapshot_after_route_update():
+	started = asyncio.Event()
+	completed = asyncio.Event()
+	seen_ids: list[str] = []
+	handle_box: list[Any] = []
+
+	@ps.component
+	def Page():
+		def on_click():
+			async def run_repeat():
+				seen_ids.append(ps.route()["pathParams"]["id"])
+				await asyncio.sleep(0)
+				seen_ids.append(ps.route()["pathParams"]["id"])
+				handle_box[0].cancel()
+				completed.set()
+
+			started.set()
+			handle_box.append(ps.repeat(0.01, run_repeat))
+
+		return ps.button(onClick=on_click)["go"]
+
+	routes = RouteTree([Route("items/:id", Page)])
+	session = RenderSession("test-id", routes)
+	first_info = make_route_info("/items/123", path_params={"id": "123"})
+	next_info = make_route_info("/items/456", path_params={"id": "456"})
+
+	with ps.PulseContext.update(render=session):
+		session.prerender(["/items/:id"], first_info)
+		session.attach("/items/:id", first_info)
+
+	session.execute_callback(
+		"/items/:id", first_callback_key(session, "/items/:id"), []
+	)
+	await started.wait()
+	session.attach("/items/:id", next_info)
+	await asyncio.wait_for(completed.wait(), timeout=0.2)
+
+	assert seen_ids == ["123", "123"]
 
 	session.close()
 
@@ -718,11 +1007,7 @@ def test_queued_route_bound_navigation_is_revalidated_on_reconnect():
 
 	session.disconnect()
 	mount = session.route_mounts["/a"]
-	with ps.PulseContext.update(
-		render=session,
-		route=mount.route,
-		origin=RouteOrigin.from_route(mount.route),
-	):
+	with ps.PulseContext.update(render=session, route=mount.route_snapshot()):
 		ps.navigate("/after")
 
 	session.detach("/a")
@@ -1422,6 +1707,101 @@ async def test_session_close_cancels_cleanup_timers():
 
 	await asyncio.sleep(0.1)
 	assert state_box[0].fired is False
+
+
+@pytest.mark.asyncio
+async def test_later_forks_latest_context_for_async_callback_lifetime():
+	routes = RouteTree([Route("a", simple_component)])
+	session = RenderSession("test-id", routes)
+	seen: list[str] = []
+	started = asyncio.Event()
+	continue_callback = asyncio.Event()
+	done = asyncio.Event()
+
+	async def on_fire() -> None:
+		ctx = ps.PulseContext.get()
+		assert ctx.route is not None
+		seen.append(ctx.route.query)
+		started.set()
+		await continue_callback.wait()
+		ctx = ps.PulseContext.get()
+		assert ctx.route is not None
+		seen.append(ctx.route.query)
+		done.set()
+
+	initial_info = make_route_info("/a")
+	initial_info["query"] = "one"
+	with ps.PulseContext.update(render=session):
+		session.prerender(["/a"], initial_info)
+		session.attach("/a", initial_info)
+
+	mount = session.route_mounts["/a"]
+	with ps.PulseContext.update(render=session, route=mount.route):
+		ps.later(0.01, on_fire)
+
+	next_info = make_route_info("/a")
+	next_info["query"] = "two"
+	session.update_route("/a", next_info)
+
+	assert await wait_for(lambda: started.is_set(), timeout=0.2)
+
+	final_info = make_route_info("/a")
+	final_info["query"] = "three"
+	session.update_route("/a", final_info)
+	continue_callback.set()
+
+	assert await wait_for(lambda: done.is_set(), timeout=0.2)
+	assert seen == ["two", "two"]
+
+	session.close()
+
+
+@pytest.mark.asyncio
+async def test_inline_effect_forks_latest_context_at_execution_start():
+	trigger = ps.Signal(0)
+	seen: list[str] = []
+
+	@ps.component
+	def component():
+		@ps.effect
+		def watch_route():
+			trigger()
+			ctx = ps.PulseContext.get()
+			assert ctx.route is not None
+			seen.append(ctx.route.query)
+
+		_ = watch_route
+		return ps.div()
+
+	routes = RouteTree([Route("a", component)])
+	session = RenderSession("test-id", routes)
+	initial_info = make_route_info("/a")
+	initial_info["query"] = "one"
+
+	try:
+		with ps.PulseContext.update(render=session):
+			session.prerender(["/a"], initial_info)
+			session.attach("/a", initial_info)
+
+		mount = session.route_mounts["/a"]
+		with ps.PulseContext.update(render=session, route=mount.route):
+			flush_effects()
+
+		assert seen == ["one"]
+
+		with ps.PulseContext.update(render=session, route=mount.route):
+			trigger.write(1)
+
+		next_info = make_route_info("/a")
+		next_info["query"] = "two"
+		session.update_route("/a", next_info)
+
+		with ps.PulseContext.update(render=session, route=mount.route):
+			flush_effects()
+
+		assert seen == ["one", "two"]
+	finally:
+		session.close()
 
 
 def test_handle_api_result_ignores_unknown_id():

--- a/uv.lock
+++ b/uv.lock
@@ -1323,7 +1323,7 @@ requires-dist = [
 
 [[package]]
 name = "pulse-framework"
-version = "0.1.95"
+version = "0.1.100"
 source = { editable = "packages/pulse/python" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- add immutable RouteOrigin snapshots for callback/render source identity
- move PulseContext source identity to origin/mount_id
- update guarded navigation, query-param sync, form submissions, render/callback contexts, and channel callbacks to use origin/mount_id

## Verification
- uv run pytest packages/pulse/python/tests/test_render_session.py::test_pulse_context_update_can_clear_route_origin packages/pulse/python/tests/test_render_session.py::test_route_origin_snapshots_route_context packages/pulse/python/tests/test_render_session.py::test_route_bound_navigation_uses_current_path_for_dynamic_routes packages/pulse/python/tests/test_render_session.py::test_route_bound_navigation_validates_source_route_identity packages/pulse/python/tests/test_render_session.py::test_async_callback_navigation_after_same_url_remount_is_ignored packages/pulse/python/tests/test_render_session.py::test_async_callback_navigation_after_route_update_is_ignored_by_default packages/pulse/python/tests/test_render_session.py::test_queued_route_bound_navigation_is_revalidated_on_reconnect
- uv run pytest packages/pulse/python/tests/test_query_param.py::TestQueryParam::test_state_to_url_preserves_params packages/pulse/python/tests/test_query_param.py::TestQueryParam::test_url_to_state_updates
- uv run pytest packages/pulse/python/tests/test_channels.py
- make test
- make all
- uv run pulse run examples/main.py, agent-browser open/click Counter/Increment/Query, stopped server