### PR TITLE
Add renderable payload serialization

### DIFF
--- a/docs/content/docs/reference/pulse-client/serialization.mdx
+++ b/docs/content/docs/reference/pulse-client/serialization.mdx
@@ -5,7 +5,7 @@ description: "Wire format for Pulse client-server communication"
 
 # Serialization
 
-Pulse uses a custom serialization format for WebSocket messages. This format handles JavaScript types that JSON doesn't support natively, like `Date`, `Set`, `Map`, and object references.
+Pulse uses a custom serialization format for WebSocket messages. This format handles JavaScript types that JSON doesn't support natively, like `Date`, `Set`, `Map`, object references, and server-rendered Pulse node payloads.
 
 ---
 
@@ -28,8 +28,8 @@ function serialize(data: Serializable): Serialized
 ### Returns
 
 ```ts
-type Serialized = [[number[], number[], number[], number[]], PlainJSON];
-//                  ^refs     ^dates    ^sets     ^maps     ^payload
+type Serialized = [[number[], number[], number[], number[], number[]], PlainJSON];
+//                  ^refs     ^dates    ^sets     ^maps     ^pulseNodes ^payload
 ```
 
 A tuple containing:
@@ -43,7 +43,7 @@ A tuple containing:
 | `null`, `undefined` | Passed through |
 | `boolean`, `string` | Passed through |
 | `number` | Passed through (NaN becomes null, Infinity throws) |
-| `Date` | Converted to timestamp |
+| `Date` | Converted to an ISO 8601 string |
 | `Array` | Recursively processed |
 | `Set` | Converted to array |
 | `Map` | Converted to object (string keys only) |
@@ -63,7 +63,7 @@ const data = {
 };
 
 const serialized = serialize(data);
-// [[[], [0], [1], [2]], { name: "Alice", createdAt: 1705276800000, tags: ["admin", "active"], metadata: { version: 1 } }]
+// [[[], [2], [3], [6], []], { name: "Alice", createdAt: "2024-01-15T00:00:00.000Z", tags: ["admin", "active"], metadata: { version: 1 } }]
 ```
 
 ### Circular References
@@ -87,7 +87,7 @@ serialize({ value: Infinity });
 
 // NaN is converted to null (with no error)
 serialize({ value: NaN });
-// [[[], [], [], []], { value: null }]
+// [[[], [], [], [], []], { value: null }]
 ```
 
 ---
@@ -114,12 +114,16 @@ function deserialize<T>(payload: Serialized, options?: DeserializationOptions): 
 ```ts
 interface DeserializationOptions {
   coerceNullsToUndefined?: boolean;
+  registry?: ComponentRegistry;
+  renderer?: Pick<VDOMRenderer, "renderNode">;
 }
 ```
 
 | Option | Default | Description |
 |--------|---------|-------------|
 | `coerceNullsToUndefined` | `false` | Convert `null` values to `undefined` |
+| `registry` | `undefined` | Component registry used to render serialized Pulse nodes |
+| `renderer` | `undefined` | Renderer used to render serialized Pulse nodes |
 
 ### Returns
 
@@ -131,10 +135,10 @@ The reconstructed JavaScript value with proper types restored.
 import { deserialize } from "pulse-ui-client";
 
 const serialized: Serialized = [
-  [[], [0], [1], [2]],
+  [[], [2], [3], [6], []],
   {
     name: "Alice",
-    createdAt: 1705276800000,
+    createdAt: "2024-01-15T00:00:00.000Z",
     tags: ["admin", "active"],
     metadata: { version: 1 },
   },
@@ -148,6 +152,16 @@ const data = deserialize(serialized);
 //   metadata: Map([["version", 1]]) // Map restored
 // }
 ```
+
+### Pulse node payloads
+
+Python can serialize Pulse `Element`, `PulseNode`, and VDOM expression payloads inside ordinary data. Those entries are marked in the `pulseNodes` metadata slot. During deserialization, pass either a route registry or renderer so the client can turn the VDOM into React nodes:
+
+```ts
+const data = deserialize(payload, { registry });
+```
+
+If the payload contains Pulse node metadata and you do not pass `registry` or `renderer`, `deserialize()` throws.
 
 ### Null Coercion
 
@@ -173,6 +187,7 @@ type Serialized = [
     number[],  // dates: indices of Date objects
     number[],  // sets: indices of Set objects
     number[],  // maps: indices of Map objects
+    number[],  // pulseNodes: indices of VDOM payloads
   ],
   PlainJSON    // The actual data as JSON
 ];
@@ -180,7 +195,7 @@ type Serialized = [
 
 ### Index Tracking
 
-During serialization, a global counter increments for each visited node. The metadata arrays record which indices are special types:
+During serialization, a global counter increments for each visited payload slot. The metadata arrays record which indices are special types:
 
 ```ts
 // Example: { date: new Date(), items: new Set([1, 2]) }
@@ -190,8 +205,8 @@ During serialization, a global counter increments for each visited node. The met
 
 // Serialized:
 [
-  [[], [1], [2], []],  // dates=[1], sets=[2]
-  { date: 1705276800000, items: [1, 2] }
+  [[], [1], [2], [], []],  // dates=[1], sets=[2]
+  { date: "2024-01-15T00:00:00.000Z", items: [1, 2] }
 ]
 ```
 
@@ -204,7 +219,7 @@ a.ref = b;  // circular
 
 // Serialized:
 [
-  [[3], [], [], []],  // refs=[3] (index 3 is a back-reference)
+  [[4], [], [], [], []],  // refs=[4] (index 4 is a back-reference)
   { name: "a", ref: { name: "b", ref: 0 } }
   //                              ^ references index 0
 ]

--- a/docs/content/docs/reference/pulse-client/types.mdx
+++ b/docs/content/docs/reference/pulse-client/types.mdx
@@ -656,7 +656,7 @@ type MessageListener = (message: ServerMessage) => void;
 Wire format for serialized data.
 
 ```ts
-type Serialized = [[number[], number[], number[], number[]], PlainJSON];
+type Serialized = [[number[], number[], number[], number[], number[]], PlainJSON];
 ```
 
 ### PlainJSON
@@ -676,6 +676,8 @@ Options for deserialization.
 ```ts
 interface DeserializationOptions {
   coerceNullsToUndefined?: boolean;
+  registry?: ComponentRegistry;
+  renderer?: Pick<VDOMRenderer, "renderNode">;
 }
 ```
 

--- a/docs/content/docs/reference/pulse/serializer.mdx
+++ b/docs/content/docs/reference/pulse/serializer.mdx
@@ -3,7 +3,7 @@ title: "Serializer"
 description: "Wire serialization helpers"
 ---
 
-Serialization utilities for converting Python objects to/from wire format. Handles shared references, cycles, dates, sets, and maps.
+Serialization utilities for converting Python objects to/from wire format. Handles shared references, cycles, dates, sets, maps, and Pulse renderable payloads.
 
 ## Functions
 
@@ -25,7 +25,9 @@ Serialize a Python value to wire format.
 **Supported types:**
 - Primitives: `None`, `bool`, `int`, `float`, `str`
 - Collections: `list`, `tuple`, `dict`, `set`
-- `datetime.datetime` (converted to milliseconds since Unix epoch)
+- `datetime.datetime` (converted to UTC ISO 8601 strings)
+- `datetime.date` (converted to ISO date strings)
+- Pulse renderables: `Element`, `PulseNode`, and VDOM `Expr`
 - Dataclasses (serialized as dict of fields)
 - Objects with `__dict__` (public attributes only)
 
@@ -33,6 +35,7 @@ Serialize a Python value to wire format.
 - `NaN` floats serialize as `None`
 - `Infinity` raises `ValueError`
 - Dict keys must be strings
+- Pulse renderables are snapshot-rendered; callbacks and refs are stripped
 - Private attributes (starting with `_`) are excluded from object serialization
 - Shared references and cycles are preserved
 
@@ -65,6 +68,7 @@ Deserialize wire format back to Python values.
 
 **Notes:**
 - `datetime` values are reconstructed as UTC-aware
+- `date` values are reconstructed as `datetime.date`
 - `set` values are reconstructed as Python sets
 - Shared references and cycles are restored
 
@@ -79,11 +83,11 @@ restored = ps.deserialize(serialized)
 ### Serialized
 
 ```python
-Serialized = tuple[tuple[list[int], list[int], list[int], list[int]], PlainJSON]
+Serialized = tuple[tuple[list[int], list[int], list[int], list[int], list[int]], PlainJSON]
 ```
 
 Serialized payload structure:
-- First element: metadata tuple of `(refs, dates, sets, maps)` - lists of indices
+- First element: metadata tuple of `(refs, dates, sets, maps, pulse_nodes)` - lists of indices
 - Second element: JSON-compatible payload
 
 ### PlainJSON
@@ -99,15 +103,16 @@ JSON-compatible type alias.
 The serialized format is a tuple:
 
 ```
-((refs, dates, sets, maps), payload)
+((refs, dates, sets, maps, pulse_nodes), payload)
 ```
 
 - `refs` - Indices where the value is a reference to a previously visited node
-- `dates` - Indices that are `datetime` objects (stored as millisecond timestamps)
+- `dates` - Indices that are `datetime` or `date` objects
 - `sets` - Indices that are `set` objects (stored as arrays)
 - `maps` - Indices that are `Map` objects (for JS interop)
+- `pulse_nodes` - Indices that are VDOM payloads and should render on the JS client
 
 This format preserves:
 - Shared references (same object referenced multiple times)
 - Circular references
-- Type information for dates and sets
+- Type information for dates, sets, maps, and Pulse nodes

--- a/packages/pulse/js/src/renderer.tsx
+++ b/packages/pulse/js/src/renderer.tsx
@@ -76,6 +76,16 @@ export class VDOMRenderer {
 		});
 	}
 
+	static snapshot(registry: ComponentRegistry = {}): VDOMRenderer {
+		const client = {
+			invokeCallback() {},
+			_ensureChannelEntry(channelId: string) {
+				throw new Error(`[Pulse] Snapshot VDOM cannot bind ref channel '${channelId}'`);
+			},
+		} as unknown as PulseSocketIOClient;
+		return new VDOMRenderer(client, "", registry);
+	}
+
 	getObject(key: string): unknown {
 		const obj = (this.#registry as any)[key];
 		if (obj === undefined) {

--- a/packages/pulse/js/src/serialize/serializer.test.ts
+++ b/packages/pulse/js/src/serialize/serializer.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import React from "react";
 import { deserialize, serialize, type Serialized } from "./serializer";
 
 describe("v4 serialization", () => {
@@ -141,13 +142,20 @@ describe("v4 serialization", () => {
 		expect(parsed.when).toBe(parsed.same);
 	});
 	it("decodes date literals as UTC midnight dates", () => {
-		const ser: Serialized = [[[], [0], [], []], "2024-01-02"];
+		const ser: Serialized = [[[], [0], [], [], []], "2024-01-02"];
 		const parsed = deserialize(ser) as Date;
 		expect(parsed).toBeInstanceOf(Date);
 		expect(parsed.toISOString()).toBe("2024-01-02T00:00:00.000Z");
 	});
+	it("decodes dates after primitive siblings", () => {
+		const ser = serialize(["x", new Date(Date.UTC(2024, 0, 2))]);
+		const parsed = deserialize(ser) as [string, Date];
+		expect(parsed[0]).toBe("x");
+		expect(parsed[1]).toBeInstanceOf(Date);
+		expect(parsed[1].toISOString()).toBe("2024-01-02T00:00:00.000Z");
+	});
 	it("throws on invalid date literals", () => {
-		const ser: Serialized = [[[], [0], [], []], "2024-02-30"];
+		const ser: Serialized = [[[], [0], [], [], []], "2024-02-30"];
 		expect(() => deserialize(ser)).toThrow("Invalid date literal: 2024-02-30");
 	});
 
@@ -200,5 +208,85 @@ describe("v4 serialization", () => {
 		const ser = serialize(data);
 		const parsed = deserialize(ser);
 		expect(parsed).toEqual(data);
+	});
+
+	it("leaves user VDOM-looking dictionaries alone without metadata", () => {
+		const payload: Serialized = [[[], [], [], [], []], { __pulse_vdom__: { tag: "span" } }];
+		expect(deserialize<any>(payload)).toEqual({ __pulse_vdom__: { tag: "span" } });
+	});
+
+	it("throws when pulse node metadata is present without a renderer or registry", () => {
+		const payload: Serialized = [
+			[[], [], [], [], [1]],
+			{ title: { tag: "span", children: ["Feedback"] } },
+		];
+		expect(() => deserialize(payload)).toThrow(
+			"Payload contains VDOM nodes but no renderer or registry was provided",
+		);
+	});
+
+	it("renders pulse node metadata with a one-shot renderer from a registry", () => {
+		const Badge = (props: { label: string }) => React.createElement("strong", props.label);
+		const payload: Serialized = [
+			[[], [], [], [], [1]],
+			{ title: { tag: "$$Badge", props: { label: "Feedback" } } },
+		];
+		const parsed = deserialize(payload, { registry: { Badge } }) as any;
+		expect(React.isValidElement(parsed.title)).toBe(true);
+		expect(parsed.title.type).toBe(Badge);
+		expect(parsed.title.props.label).toBe("Feedback");
+	});
+
+	it("reconstructs pulse node props before rendering VDOM", () => {
+		const Badge = (_props: { when: Date; tags: Set<string> }) => null;
+		const payload: Serialized = [
+			[[], [4], [5], [], [1]],
+			{
+				title: {
+					tag: "$$Badge",
+					props: {
+						when: "2024-04-05T06:07:08.000Z",
+						tags: ["saved"],
+					},
+				},
+			},
+		];
+		const parsed = deserialize(payload, { registry: { Badge } }) as any;
+		expect(parsed.title.type).toBe(Badge);
+		expect(parsed.title.props.when).toBeInstanceOf(Date);
+		expect(parsed.title.props.when.toISOString()).toBe("2024-04-05T06:07:08.000Z");
+		expect(parsed.title.props.tags).toBeInstanceOf(Set);
+		expect(Array.from(parsed.title.props.tags)).toEqual(["saved"]);
+	});
+
+	it("renders pulse nodes without consuming primitive children as traversal nodes", () => {
+		const payload: Serialized = [
+			[[], [5], [], [], [1]],
+			[{ tag: "span", children: ["x"] }, "2024-01-02"],
+		];
+		const parsed = deserialize(payload, { registry: {} }) as any;
+		expect(React.isValidElement(parsed[0])).toBe(true);
+		expect(parsed[0].props.children).toBe("x");
+		expect(parsed[1]).toBeInstanceOf(Date);
+		expect(parsed[1].toISOString()).toBe("2024-01-02T00:00:00.000Z");
+	});
+
+	it("preserves repeated pulse node references", () => {
+		const payload: Serialized = [
+			[[5], [], [], [], [1]],
+			[{ tag: "span", children: ["x"] }, 1],
+		];
+		const parsed = deserialize(payload, { registry: {} }) as any;
+		expect(React.isValidElement(parsed[0])).toBe(true);
+		expect(parsed[0].props.children).toBe("x");
+		expect(parsed[1]).toBe(parsed[0]);
+	});
+
+	it("requires the route-local registry for imported component pulse nodes", () => {
+		const payload: Serialized = [
+			[[], [], [], [], [1]],
+			{ title: { tag: "$$RouteOnly", props: { value: 1 } } },
+		];
+		expect(() => deserialize(payload, { registry: {} })).toThrow("Missing component 'RouteOnly'");
 	});
 });

--- a/packages/pulse/js/src/serialize/serializer.ts
+++ b/packages/pulse/js/src/serialize/serializer.ts
@@ -1,9 +1,13 @@
+import type { ReactNode } from "react";
+import { VDOMRenderer } from "../renderer";
+import type { ComponentRegistry, VDOMNode } from "../vdom";
+
 export type Primitive = number | string | boolean | null | undefined;
 export type JSON<T> = T | Array<JSON<T>> | { [K: string]: JSON<T> };
 export type PlainJSON = JSON<Primitive>;
 export type Serializable = any;
 
-export type Serialized = [[number[], number[], number[], number[]], PlainJSON];
+export type Serialized = [[number[], number[], number[], number[], number[]], PlainJSON];
 
 export function serialize(data: Serializable): Serialized {
 	const seen = new Map<any, number>();
@@ -11,11 +15,13 @@ export function serialize(data: Serializable): Serialized {
 	const dates: number[] = [];
 	const sets: number[] = [];
 	const maps: number[] = [];
+	const pulseNodes: number[] = [];
 
-	// Single global counter - increments once per node visit
+	// Single global counter - increments once per payload slot visit
 	let globalIndex = 0;
 
 	function process(value: Serializable, context?: string): PlainJSON {
+		const idx = globalIndex++;
 		if (value == null || typeof value === "string" || typeof value === "boolean") {
 			return value;
 		}
@@ -34,7 +40,6 @@ export function serialize(data: Serializable): Serialized {
 			return value;
 		}
 
-		const idx = globalIndex++;
 		const prevRef = seen.get(value);
 		if (prevRef !== undefined) {
 			// Make sure to push the current index, but use the ref's index as the value!
@@ -93,33 +98,60 @@ export function serialize(data: Serializable): Serialized {
 	}
 
 	const payload = process(data);
-	return [[refs, dates, sets, maps], payload];
+	return [[refs, dates, sets, maps, pulseNodes], payload];
 }
 
 export interface DeserializationOptions {
 	coerceNullsToUndefined?: boolean;
+	registry?: ComponentRegistry;
+	renderer?: Pick<VDOMRenderer, "renderNode">;
 }
 
 export function deserialize<Data extends Serializable = Serializable>(
 	payload: Serialized,
 	options?: DeserializationOptions,
 ): Data {
-	const [[refsA, datesA, setsA, mapsA], data] = payload;
+	const [metadata, data] = payload;
+	const [refsA, datesA, setsA, mapsA, pulseNodesA] = metadata;
 
 	const refs = new Set(refsA);
 	const dates = new Set(datesA);
 	const sets = new Set(setsA);
 	const maps = new Set(mapsA);
+	const pulseNodes = new Set(pulseNodesA);
+	const pulseRenderer = options?.renderer
+		? options.renderer
+		: options?.registry
+			? VDOMRenderer.snapshot(options.registry)
+			: undefined;
+	if (pulseNodes.size > 0 && !pulseRenderer) {
+		throw new Error("[Pulse] Payload contains VDOM nodes but no renderer or registry was provided");
+	}
 
 	const objects: Array<any> = [];
+	let globalIndex = 0;
 
 	function reconstruct(value: PlainJSON): any {
-		const idx = objects.length;
+		const idx = globalIndex++;
+		const shouldRenderPulseNode = pulseNodes.has(idx);
 		if (refs.has(idx)) {
-			// We increment the counter on refs during serialization. We're never
-			// going to use this entry, so we can just push null.
-			objects.push(null);
-			return objects[value as number];
+			if (typeof value !== "number") {
+				throw new Error("Reference payload must be a numeric index");
+			}
+			objects[idx] = null;
+			if (!(value in objects)) {
+				throw new Error(`Dangling reference to index ${value}`);
+			}
+			return objects[value];
+		}
+
+		function finish(result: any) {
+			if (!shouldRenderPulseNode) {
+				return result;
+			}
+			const node = pulseRenderer!.renderNode(result as VDOMNode) as ReactNode;
+			objects[idx] = node;
+			return node;
 		}
 
 		if (dates.has(idx)) {
@@ -130,23 +162,21 @@ export function deserialize<Data extends Serializable = Serializable>(
 			if (literal) {
 				const [y, m, d] = literal;
 				const dt = new Date(Date.UTC(y, m - 1, d));
-				objects.push(dt);
+				objects[idx] = dt;
 				return dt;
 			}
 			if (isDateLiteral(value)) {
 				throw new Error(`Invalid date literal: ${value}`);
 			}
 			const dt = new Date(value);
-			objects.push(dt);
+			objects[idx] = dt;
 			return dt;
 		}
 
-		if (
-			value == null ||
-			typeof value === "number" ||
-			typeof value === "string" ||
-			typeof value === "boolean"
-		) {
+		if (isPrimitive(value)) {
+			if (shouldRenderPulseNode) {
+				throw new Error("Pulse node payload must be a VDOM node");
+			}
 			if (options?.coerceNullsToUndefined) {
 				return value ?? undefined;
 			}
@@ -156,48 +186,57 @@ export function deserialize<Data extends Serializable = Serializable>(
 		if (Array.isArray(value)) {
 			if (sets.has(idx)) {
 				const result = new Set();
-				objects.push(result);
+				objects[idx] = result;
 				for (let i = 0; i < value.length; i++) {
 					result.add(reconstruct(value[i]));
 				}
-				return result;
+				return finish(result);
 			}
 
 			const length = value.length;
 			const arr = new Array(length);
-			objects.push(arr);
+			objects[idx] = arr;
 			for (let i = 0; i < length; i++) {
 				arr[i] = reconstruct(value[i]);
 			}
-			return arr;
+			return finish(arr);
 		}
 
 		if (typeof value === "object") {
 			if (maps.has(idx)) {
 				const result = new Map<string, any>();
-				objects.push(result);
+				objects[idx] = result;
 				const keys = Object.keys(value);
 				for (let i = 0; i < keys.length; i++) {
 					const key = keys[i];
 					result.set(key, reconstruct(value[key]));
 				}
-				return result;
+				return finish(result);
 			}
 
 			const result: Record<string, any> = {};
-			objects.push(result);
+			objects[idx] = result;
 			const keys = Object.keys(value);
 			for (let i = 0; i < keys.length; i++) {
 				const key = keys[i];
 				result[key] = reconstruct(value[key]);
 			}
-			return result;
+			return finish(result);
 		}
 
 		throw new Error(`Unsupported value in deserialization: ${value}`);
 	}
 
 	return reconstruct(data);
+}
+
+function isPrimitive(value: PlainJSON): value is Primitive {
+	return (
+		value == null ||
+		typeof value === "number" ||
+		typeof value === "string" ||
+		typeof value === "boolean"
+	);
 }
 
 const DATE_LITERAL_RE = /^\d{4}-\d{2}-\d{2}$/;

--- a/packages/pulse/python/src/pulse/renderer.py
+++ b/packages/pulse/python/src/pulse/renderer.py
@@ -5,6 +5,7 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from types import NoneType
 from typing import Any, NamedTuple, TypeAlias, cast
+from typing import Literal as TypingLiteral
 
 from pulse.debounce import Debounced
 from pulse.helpers import values_equal
@@ -107,7 +108,10 @@ class RenderTree:
 
 
 class Renderer:
-	def __init__(self) -> None:
+	def __init__(
+		self, *, mode: TypingLiteral["persistent", "snapshot"] = "persistent"
+	) -> None:
+		self.mode: TypingLiteral["persistent", "snapshot"] = mode
 		self.callbacks: Callbacks = {}
 		self.operations: list[VDOMOperation] = []
 
@@ -417,6 +421,11 @@ class Renderer:
 				continue
 
 			if isinstance(value, RefHandle):
+				if self.mode == "snapshot":
+					if normalized is None:
+						normalized = current.copy()
+					normalized.pop(key, None)
+					continue
 				if key != "ref":
 					raise TypeError("RefHandle can only be used as the 'ref' prop")
 				eval_keys.add(key)
@@ -436,6 +445,11 @@ class Renderer:
 					}
 				continue
 			if isinstance(value, Debounced):
+				if self.mode == "snapshot":
+					if normalized is None:
+						normalized = current.copy()
+					normalized.pop(key, None)
+					continue
 				eval_keys.add(key)
 				if isinstance(old_value, (Element, PulseNode)):
 					unmount_element(old_value)
@@ -451,6 +465,11 @@ class Renderer:
 				continue
 
 			if callable(value):
+				if self.mode == "snapshot":
+					if normalized is None:
+						normalized = current.copy()
+					normalized.pop(key, None)
+					continue
 				eval_keys.add(key)
 				if isinstance(old_value, (Element, PulseNode)):
 					unmount_element(old_value)

--- a/packages/pulse/python/src/pulse/serializer.py
+++ b/packages/pulse/python/src/pulse/serializer.py
@@ -5,14 +5,14 @@ The format mirrors the TypeScript implementation in ``packages/pulse/js``.
 Serialized payload structure::
 
     (
-        ("refs|dates|sets|maps", payload),
+        ("refs|dates|sets|maps|pulse_nodes", payload),
     )
 
-- The first element is a compact metadata string with four pipe-separated
+- The first element is a compact metadata string with five pipe-separated
   comma-separated integer lists representing global node indices for:
-  ``refs``, ``dates``, ``sets``, ``maps``.
-- ``refs``  – indices where the payload entry is an integer pointing to a
-  previously visited node's index (shared refs/cycles).
+  ``refs``, ``dates``, ``sets``, ``maps``, ``pulse_nodes``.
+- ``refs``  – traversal indices where the payload entry is an integer pointing
+  to a previously visited node's index (shared refs/cycles).
 - ``dates`` – indices that should be materialised as temporal objects; the
   payload entry is an ISO 8601 string:
   - ``YYYY-MM-DD`` → ``datetime.date``
@@ -21,9 +21,11 @@ Serialized payload structure::
   items.
 - ``maps``  – indices that are ``Map`` instances; payload is an object mapping
   string keys to child payloads. Python reconstructs these as ``dict``.
+- ``pulse_nodes`` – indices that should be rendered as VDOM nodes by the JS
+  client.
 
-Nodes are assigned a single global index as they are visited (non-primitives
-only). This preserves shared references and cycles across nested structures
+Nodes are assigned a single global index as each payload slot is visited.
+This preserves shared references and cycles across nested structures
 containing primitives, lists/tuples, ``dict``/plain objects, ``set``, ``date``
 and ``datetime`` objects.
 """
@@ -34,11 +36,15 @@ import datetime as dt
 import math
 import types
 from dataclasses import fields, is_dataclass
-from typing import Any
+from typing import Any, TypeAlias
+
+from pulse.renderer import Renderer
+from pulse.transpiler.nodes import Element, Expr, PulseNode, Value, clone_renderable
 
 Primitive = int | float | str | bool | None
 PlainJSON = Primitive | list["PlainJSON"] | dict[str, "PlainJSON"]
-Serialized = tuple[tuple[list[int], list[int], list[int], list[int]], PlainJSON]
+SerializedMeta: TypeAlias = tuple[list[int], list[int], list[int], list[int], list[int]]
+Serialized = tuple[SerializedMeta, PlainJSON]
 
 __all__ = [
 	"serialize",
@@ -97,11 +103,19 @@ def serialize(data: Any) -> Serialized:
 	dates: list[int] = []
 	sets: list[int] = []
 	maps: list[int] = []
+	pulse_nodes: list[int] = []
 
 	global_index = 0
 
-	def process(value: Any) -> PlainJSON:
+	def process(value: Any) -> Any:
 		nonlocal global_index
+		unwrapped = unwrap_value(value)
+		if unwrapped is not value:
+			return process(unwrapped)
+
+		idx = global_index
+		global_index += 1
+
 		if value is None or isinstance(value, (bool, int, str)):
 			return value
 		if isinstance(value, float):
@@ -114,8 +128,27 @@ def serialize(data: Any) -> Serialized:
 				)
 			return value
 
-		idx = global_index
-		global_index += 1
+		if isinstance(value, (type, types.ModuleType)):
+			raise TypeError(f"Unsupported value in serialization: {type(value)!r}")
+
+		pulse_payload = None
+		if isinstance(value, Element):
+			pulse_payload = clone_renderable(value).render(Renderer(mode="snapshot"))
+		elif isinstance(value, PulseNode):
+			pulse_payload = clone_renderable(value).render(Renderer(mode="snapshot"))
+		elif isinstance(value, Expr):
+			pulse_payload = value.render()
+
+		if pulse_payload is not None and is_primitive(pulse_payload):
+			if isinstance(pulse_payload, float):
+				if math.isnan(pulse_payload):
+					return None
+				if math.isinf(pulse_payload):
+					raise ValueError(
+						f"Cannot serialize {pulse_payload}: Infinity is not valid JSON. "
+						+ "Replace with None or a sentinel value."
+					)
+			return pulse_payload
 
 		obj_id = id(value)
 		prev_ref = seen.get(obj_id)
@@ -123,6 +156,10 @@ def serialize(data: Any) -> Serialized:
 			refs.append(idx)
 			return prev_ref
 		seen[obj_id] = idx
+
+		if pulse_payload is not None:
+			pulse_nodes.append(idx)
+			value = pulse_payload
 
 		if isinstance(value, dt.datetime):
 			dates.append(idx)
@@ -161,7 +198,7 @@ def serialize(data: Any) -> Serialized:
 				dc_obj[f.name] = process(getattr(value, f.name))
 			return dc_obj
 
-		if callable(value) or isinstance(value, (type, types.ModuleType)):
+		if callable(value):
 			raise TypeError(f"Unsupported value in serialization: {type(value)!r}")
 
 		if hasattr(value, "__dict__"):
@@ -176,7 +213,7 @@ def serialize(data: Any) -> Serialized:
 
 	payload = process(data)
 
-	return ((refs, dates, sets, maps), payload)
+	return ((refs, dates, sets, maps, pulse_nodes), payload)
 
 
 def deserialize(
@@ -212,25 +249,26 @@ def deserialize(
 		restored = ps.deserialize(serialized)
 		```
 	"""
-	(refs, dates, sets, _maps), data = payload
+	(refs, dates, sets, _maps, _pulse_nodes), data = payload
 	refs = set(refs)
 	dates = set(dates)
 	sets = set(sets)
 	# we don't care about maps
 
-	objects: list[Any] = []
+	objects: dict[int, Any] = {}
+	global_index = 0
 
 	def reconstruct(value: PlainJSON) -> Any:
-		idx = len(objects)
+		nonlocal global_index
+		idx = global_index
+		global_index += 1
 
 		if idx in refs:
 			assert isinstance(value, (int, float)), (
 				"Reference payload must be numeric index"
 			)
-			# Placeholder to keep indices aligned
-			objects.append(None)
 			target_index = int(value)
-			assert 0 <= target_index < len(objects), (
+			assert target_index in objects, (
 				f"Dangling reference to index {target_index}"
 			)
 			return objects[target_index]
@@ -239,10 +277,10 @@ def deserialize(
 			assert isinstance(value, str), "Date payload must be an ISO string"
 			if _is_date_literal(value):
 				date_value = dt.date.fromisoformat(value)
-				objects.append(date_value)
+				objects[idx] = date_value
 				return date_value
 			dt_value = _datetime_from_iso(value)
-			objects.append(dt_value)
+			objects[idx] = dt_value
 			return dt_value
 
 		if value is None:
@@ -254,12 +292,12 @@ def deserialize(
 		if isinstance(value, list):
 			if idx in sets:
 				result_set: set[Any] = set()
-				objects.append(result_set)
+				objects[idx] = result_set
 				for entry in value:
 					result_set.add(reconstruct(entry))
 				return result_set
 			result_list: list[Any] = []
-			objects.append(result_list)
+			objects[idx] = result_list
 			for entry in value:
 				result_list.append(reconstruct(entry))
 			return result_list
@@ -267,7 +305,7 @@ def deserialize(
 		if isinstance(value, dict):
 			# Both maps and records are reconstructed as dictionaries in Python
 			result_dict: dict[str, Any] = {}
-			objects.append(result_dict)
+			objects[idx] = result_dict
 			for key, entry in value.items():
 				result_dict[str(key)] = reconstruct(entry)
 			return result_dict
@@ -275,6 +313,16 @@ def deserialize(
 		raise TypeError(f"Unsupported value in deserialization: {type(value)!r}")
 
 	return reconstruct(data)
+
+
+def unwrap_value(value: Any) -> Any:
+	if isinstance(value, Value):
+		return value.value
+	return value
+
+
+def is_primitive(value: Any) -> bool:
+	return value is None or isinstance(value, (bool, int, float, str))
 
 
 def _datetime_to_iso(value: dt.datetime) -> str:

--- a/packages/pulse/python/src/pulse/transpiler/nodes.py
+++ b/packages/pulse/python/src/pulse/transpiler/nodes.py
@@ -748,21 +748,20 @@ class Element(Expr):
 		return result
 
 	@override
-	def render(self):
-		"""Element rendering is handled by Renderer.render_node(), not render().
-
-		This method validates render-time constraints and raises TypeError
-		because Element produces VDOMElement, not VDOMExpr.
-		"""
+	def render(self, renderer: Any = None, path: str = ""):
+		"""Render this element as one-shot VDOM."""
 		# Validate key is string or numeric (not arbitrary Expr) during rendering
 		if self.key is not None and not isinstance(self.key, (str, int)):
 			raise TypeError(
 				f"Element key must be a string or int for rendering, got {type(self.key).__name__}. "
 				+ "Expression keys are only valid during transpilation (emit)."
 			)
-		raise TypeError(
-			"Element cannot be rendered as VDOMExpr; use Renderer.render_node() instead"
-		)
+		if renderer is None:
+			from pulse.renderer import Renderer
+
+			renderer = Renderer(mode="snapshot")
+		vdom, _normalized = renderer.render_node(self, path)
+		return vdom
 
 
 @dataclass(slots=True)
@@ -811,6 +810,51 @@ class PulseNode:
 			key=self.key,
 			name=self.name,
 		)
+
+	def render(self, renderer: Any = None, path: str = ""):
+		"""Render this component as one-shot VDOM."""
+		if renderer is None:
+			from pulse.renderer import Renderer
+
+			renderer = Renderer(mode="snapshot")
+		vdom, _normalized = renderer.render_component(self, path)
+		return vdom
+
+
+def clone_renderable(value: Any) -> Any:
+	if isinstance(value, Element):
+		props = None
+		if isinstance(value.props, dict):
+			props = {key: clone_renderable(entry) for key, entry in value.props.items()}
+		elif value.props is not None:
+			props = [
+				prop
+				if isinstance(prop, Spread)
+				else (prop[0], clone_renderable(prop[1]))
+				for prop in value.props
+			]
+		children = (
+			[clone_renderable(child) for child in value.children]
+			if value.children is not None
+			else None
+		)
+		return Element(
+			tag=value.tag,
+			props=props,
+			children=children,
+			key=value.key,
+		)
+	if isinstance(value, PulseNode):
+		return PulseNode(
+			fn=value.fn,
+			args=tuple(clone_renderable(arg) for arg in value.args),
+			kwargs={
+				key: clone_renderable(entry) for key, entry in value.kwargs.items()
+			},
+			key=value.key,
+			name=value.name,
+		)
+	return value
 
 
 # =============================================================================

--- a/packages/pulse/python/tests/test_serializer.py
+++ b/packages/pulse/python/tests/test_serializer.py
@@ -1,7 +1,15 @@
 import datetime as dt
 
+import pulse as ps
 import pytest
+from pulse.renderer import Renderer
 from pulse.serializer import deserialize, serialize
+from pulse.transpiler.nodes import Call, Identifier, Literal
+
+
+def pulse_nodes(meta: tuple[list[int], ...]) -> list[int]:
+	assert len(meta) == 5
+	return meta[4]
 
 
 def test_primitives_roundtrip_v3():
@@ -113,9 +121,17 @@ def test_date_roundtrip_v4():
 	assert parsed["day"] == day
 
 
+def test_date_after_primitive_preserves_traversal_index():
+	day = dt.date(2024, 1, 2)
+	payload = serialize(["x", day])
+	parsed = deserialize(payload)
+
+	assert parsed == ["x", day]
+
+
 def test_unsupported_values_raise_v3():
 	with pytest.raises(TypeError):
-		serialize({"x": lambda: None})
+		serialize(lambda: None)
 
 
 class TestNaNAndInfinity:
@@ -151,3 +167,120 @@ class TestNaNAndInfinity:
 		payload = serialize(data)
 		parsed = deserialize(payload)
 		assert parsed == data
+
+
+def test_user_vdom_sentinel_dict_remains_plain_data():
+	data = {"__pulse_vdom__": {"tag": "span"}}
+	(meta, payload) = serialize(data)
+	assert pulse_nodes(meta) == []
+	assert deserialize((meta, payload)) == data
+
+
+def test_nested_expr_serializes_with_pulse_node_metadata():
+	(meta, payload) = serialize({"value": Identifier("window")})
+	assert pulse_nodes(meta) == [1]
+	assert payload == {"value": {"t": "id", "name": "window"}}
+
+
+def test_nested_element_serializes_with_pulse_node_metadata():
+	(meta, payload) = serialize({"title": ps.span("Feedback")})
+	assert pulse_nodes(meta) == [1]
+	assert payload == {"title": {"tag": "span", "children": ["Feedback"]}}
+
+
+def test_snapshot_rendering_strips_callbacks_from_vdom_output():
+	(meta, payload) = serialize({"button": ps.button("Save", onClick=lambda: None)})
+	assert pulse_nodes(meta) == [1]
+	assert payload == {"button": {"tag": "button", "children": ["Save"]}}
+
+
+def test_snapshot_rendering_does_not_mutate_original_element():
+	def handler() -> None:
+		pass
+
+	button = ps.button("Save", onClick=handler)
+	serialize({"button": button})
+
+	assert button.props_dict()["onClick"] is handler
+	vdom = button.render(Renderer())
+	assert vdom["props"]["onClick"] == "$cb"
+	assert vdom["eval"] == ["onClick"]
+
+
+def test_snapshot_rendering_does_not_mutate_original_pulse_node():
+	@ps.component
+	def Label():
+		return ps.span("Saved")
+
+	node = Label()
+	serialize({"label": node})
+
+	assert node.hooks is None
+	assert node.contents is None
+
+
+def test_plain_payload_callbacks_are_unsupported():
+	def on_open(_notification: object) -> None:
+		pass
+
+	with pytest.raises(TypeError):
+		serialize(
+			{
+				"title": ps.span("Feedback"),
+				"message": "Done",
+				"onOpen": on_open,
+			}
+		)
+
+
+def test_snapshot_vdom_payload_is_recursively_serialized():
+	when = dt.datetime(2024, 4, 5, 6, 7, 8, tzinfo=dt.UTC)
+
+	(meta, payload) = serialize(
+		{
+			"title": ps.span(when),
+		}
+	)
+	assert pulse_nodes(meta) == [1]
+	assert meta[1] == [4]
+	assert payload == {
+		"title": {"tag": "span", "children": ["2024-04-05T06:07:08.000Z"]},
+	}
+	parsed = deserialize((meta, payload))
+	assert parsed["title"]["children"] == [when]
+
+
+def test_renderable_before_date_preserves_traversal_index():
+	day = dt.date(2024, 1, 2)
+	(meta, payload) = serialize([ps.span("x"), day])
+
+	assert pulse_nodes(meta) == [1]
+	assert meta[1] == [5]
+	assert payload == [{"tag": "span", "children": ["x"]}, "2024-01-02"]
+	assert deserialize((meta, payload)) == [
+		{"tag": "span", "children": ["x"]},
+		day,
+	]
+
+
+def test_reused_renderable_serializes_as_ref_to_pulse_node():
+	span = ps.span("x")
+	(meta, payload) = serialize([span, span])
+
+	assert pulse_nodes(meta) == [1]
+	assert meta[0] == [5]
+	assert payload == [{"tag": "span", "children": ["x"]}, 1]
+	parsed = deserialize((meta, payload))
+	assert parsed[0] is parsed[1]
+
+
+def test_js_exec_expr_can_include_element_payload():
+	expr = Call(Identifier("show"), [ps.span("Feedback"), Literal("Done")])
+	assert expr.render() == {
+		"t": "call",
+		"callee": {"t": "id", "name": "show"},
+		"args": [
+			{"tag": "span", "children": ["Feedback"]},
+			"Done",
+		],
+	}

--- a/skills/pulse/references/helpers.md
+++ b/skills/pulse/references/helpers.md
@@ -146,7 +146,9 @@ serialized = ps.serialize(data)
 **Supported types:**
 - Primitives: `None`, `bool`, `int`, `float`, `str`
 - Collections: `list`, `tuple`, `dict`, `set`
-- `datetime.datetime` (as milliseconds since Unix epoch)
+- `datetime.datetime` (as UTC ISO 8601 strings)
+- `datetime.date` (as ISO date strings)
+- Pulse renderables: `Element`, `PulseNode`, and VDOM `Expr`
 - Dataclasses (as dict of fields)
 - Objects with `__dict__` (public attributes only)
 
@@ -168,6 +170,7 @@ wire = ps.serialize(data)
 - `NaN` floats become `None`
 - `Infinity` raises `ValueError`
 - Dict keys must be strings
+- Pulse renderables are snapshot-rendered; callbacks and refs are stripped
 - Private attributes (`_name`) excluded
 - Shared references/cycles preserved
 


### PR DESCRIPTION
## Summary
- add 5-slot serializer metadata with pulse node payload indices
- snapshot-render Element, PulseNode, and Expr payloads while stripping callbacks and refs
- render serialized Pulse nodes in JS deserialization with a supplied renderer or registry
- document the updated wire format and deserialization options

## Validation
- uv run pytest packages/pulse/python/tests/test_serializer.py
- bun test packages/pulse/js/src/serialize/serializer.test.ts
- uv run pytest packages/pulse/python/tests/test_renderer.py
- bun test packages/pulse/js/src/renderer.test.tsx
- make test
- make all
- uv run pulse run examples/main.py, verified with agent-browser at http://localhost:8002