### PR TITLE
Split channel hook manager API

### DIFF
--- a/docs/content/docs/reference/pulse-client/hooks.mdx
+++ b/docs/content/docs/reference/pulse-client/hooks.mdx
@@ -105,7 +105,7 @@ Hook to subscribe to a Pulse channel for bidirectional communication. Channels e
 ```ts
 import { usePulseChannel } from "pulse-ui-client";
 
-function usePulseChannel(channelId: string): ChannelBridge
+function usePulseChannel(channelId: string): ChannelBridge | null
 ```
 
 ### Parameters
@@ -116,22 +116,21 @@ function usePulseChannel(channelId: string): ChannelBridge
 
 ### Returns
 
-Returns a `ChannelBridge` instance for sending and receiving messages.
+Returns `null` during the first render, then a `ChannelBridge` instance after the channel is acquired.
 
 ### Throws
 
 - Throws if `channelId` is empty
 - Throws if used outside of a `PulseProvider`
+- Throws if used outside of a `PulseView`
 
 ### Lifecycle
 
 The hook manages channel subscription automatically:
 
-1. On mount: acquires a reference to the channel
-2. On unmount: releases the reference
-3. When all references are released: channel closes
-
-Multiple components can subscribe to the same channel. The channel stays open as long as at least one component is subscribed.
+1. On mount: acquires the channel for the current `PulseView` path
+2. On unmount: releases the channel lease
+3. When the lease is released: the client bridge closes
 
 ### Example: Chat Room
 
@@ -150,6 +149,8 @@ function ChatRoom({ roomId }: { roomId: string }) {
   const [messages, setMessages] = useState<Message[]>([]);
 
   useEffect(() => {
+    if (!channel) return;
+
     // Listen for new messages
     const unsubscribe = channel.on("message", (msg: Message) => {
       setMessages((prev) => [...prev, msg]);
@@ -159,6 +160,7 @@ function ChatRoom({ roomId }: { roomId: string }) {
   }, [channel]);
 
   const sendMessage = (text: string) => {
+    if (!channel) return;
     channel.emit("message", { text });
   };
 
@@ -192,6 +194,8 @@ function UserSearch() {
   const [loading, setLoading] = useState(false);
 
   const search = async (query: string) => {
+    if (!channel) return;
+
     setLoading(true);
     try {
       const users = await channel.request("search", { query });

--- a/packages/pulse/js/README.md
+++ b/packages/pulse/js/README.md
@@ -41,7 +41,6 @@ src/
 ├── form.tsx            # PulseForm component
 ├── helpers.ts          # Route info extraction utilities
 ├── vdom.ts             # VDOM types (VDOMNode, VDOMElement)
-├── usePulseChannel.ts  # React hook for channels
 │
 └── serialize/          # Data serialization
     ├── serializer.ts   # Main serialize/deserialize
@@ -106,16 +105,20 @@ import { usePulseChannel } from "pulse-client";
 
 function Chat() {
   const channel = usePulseChannel("chat");
+  if (!channel) return null;
+
   channel.on("new_message", (msg) => { /* handle */ });
   channel.emit("message", { text: "Hello" });
 }
 ```
 
+`usePulseChannel` must run under a `PulseView`. It returns `null` before the channel is acquired.
+
 ## Main Exports
 
 **Components**: `PulseProvider`, `PulseView`, `PulseForm`, `RenderLazy`
 
-**Hooks**: `usePulseClient()`, `usePulseChannel(name)`
+**Hooks**: `usePulseClient()`, `usePulseViewPath()`, `usePulseChannelManager()`, `usePulseChannelManagerForPath(path)`, `usePulseChannel(name)`
 
 **Functions**: `serialize`, `deserialize`, `extractServerRouteInfo`, `submitForm`
 

--- a/packages/pulse/js/src/channel.test.ts
+++ b/packages/pulse/js/src/channel.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from "bun:test";
-import { ChannelBridge, PulseChannelResetError } from "./channel";
+import {
+	ChannelBridge,
+	createPulseChannelManager,
+	PulseChannelResetError,
+} from "./channel";
 import { PulseSocketIOClient } from "./client";
-import type { ClientChannelMessage } from "./messages";
+import type { ClientChannelMessage, ClientMessage } from "./messages";
 
 function makeClient() {
 	const sent: ClientChannelMessage[] = [];
@@ -84,13 +88,119 @@ describe("ChannelBridge", () => {
 			},
 		);
 
-		const first = client.acquireChannel("chan-1");
-		client.releaseChannel("chan-1");
+		const first = client.acquireChannel("chan-1", "/view");
+		client.releaseChannel("chan-1", "/view");
 
 		expect(() => first.on("event", vi.fn())).toThrow(PulseChannelResetError);
 
-		const second = client.acquireChannel("chan-1");
+		const second = client.acquireChannel("chan-1", "/view");
 		expect(second).not.toBe(first);
 		expect(() => second.on("event", vi.fn())).not.toThrow();
+	});
+
+	it("rejects duplicate client channel acquisitions", () => {
+		const client = new PulseSocketIOClient(
+			"http://pulse.test",
+			{},
+			vi.fn() as any,
+			{
+				initialConnectingDelay: 0,
+				initialErrorDelay: 0,
+				reconnectErrorDelay: 0,
+			},
+		);
+
+		client.acquireChannel("chan-1", "/a");
+
+		expect(() => client.acquireChannel("chan-1", "/b")).toThrow(
+			"Pulse channel 'chan-1' is already acquired",
+		);
+	});
+
+	it("channel manager acquires with its view path and releases idempotently", () => {
+		const client = new PulseSocketIOClient(
+			"http://pulse.test",
+			{},
+			vi.fn() as any,
+			{
+				initialConnectingDelay: 0,
+				initialErrorDelay: 0,
+				reconnectErrorDelay: 0,
+			},
+		);
+		const sent: ClientMessage[] = [];
+		vi.spyOn(client, "sendMessage").mockImplementation((message: any) => {
+			sent.push(message);
+		});
+
+		const manager = createPulseChannelManager(client, "/view");
+		const lease = manager.acquire("chan-1");
+		lease.release();
+		lease.release();
+
+		expect(sent).toEqual([
+			expect.objectContaining({
+				type: "channel_message",
+				channel: "chan-1",
+				event: "__close__",
+			}),
+		]);
+		expect(sent as any[]).not.toContainEqual(
+			expect.objectContaining({ type: "channel_connect" }),
+		);
+		expect(sent as any[]).not.toContainEqual(
+			expect.objectContaining({ type: "channel_disconnect" }),
+		);
+	});
+
+	it("channel manager rejects duplicate acquires", () => {
+		const client = new PulseSocketIOClient(
+			"http://pulse.test",
+			{},
+			vi.fn() as any,
+			{
+				initialConnectingDelay: 0,
+				initialErrorDelay: 0,
+				reconnectErrorDelay: 0,
+			},
+		);
+
+		const manager = createPulseChannelManager(client, "/view");
+		manager.acquire("chan-1");
+
+		expect(() => manager.acquire("chan-1")).toThrow(
+			"PulseChannelManager already acquired channel 'chan-1'",
+		);
+	});
+
+	it("channel manager disposes outstanding leases", () => {
+		const client = new PulseSocketIOClient(
+			"http://pulse.test",
+			{},
+			vi.fn() as any,
+			{
+				initialConnectingDelay: 0,
+				initialErrorDelay: 0,
+				reconnectErrorDelay: 0,
+			},
+		);
+		const sent: ClientMessage[] = [];
+		vi.spyOn(client, "sendMessage").mockImplementation((message: any) => {
+			sent.push(message);
+		});
+
+		const manager = createPulseChannelManager(client, "/view");
+		manager.acquire("chan-a");
+		const released = manager.acquire("chan-b");
+		released.release();
+		manager.dispose();
+		manager.dispose();
+
+		expect(
+			sent
+				.filter((message) => message.type === "channel_message")
+				.map((message) => message.channel),
+		).toEqual(["chan-b", "chan-a"]);
+		expect(() => manager.acquire("chan-c")).toThrow("PulseChannelManager is disposed");
 	});
 });

--- a/packages/pulse/js/src/channel.ts
+++ b/packages/pulse/js/src/channel.ts
@@ -1,11 +1,9 @@
-import { useEffect, useState } from "react";
 import type { PulseSocketIOClient } from "./client";
 import type {
 	ServerChannelMessage,
 	ServerChannelRequestMessage,
 	ServerChannelResponseMessage,
 } from "./messages";
-import { usePulseClient } from "./pulse";
 
 export class PulseChannelResetError extends Error {
 	constructor(message: string) {
@@ -15,6 +13,16 @@ export class PulseChannelResetError extends Error {
 }
 
 export type ChannelEventHandler = (payload: any) => any | Promise<any>;
+
+export type PulseChannelLease = {
+	bridge: ChannelBridge;
+	release: () => void;
+};
+
+export interface PulseChannelManager {
+	acquire(channelId: string): PulseChannelLease;
+	dispose(): void;
+}
 
 interface PendingRequest {
 	resolve: (value: any) => void;
@@ -237,32 +245,73 @@ export class ChannelBridge {
 			return;
 		}
 		this.closed = true;
-		for (const request of this.pending.values()) {
-			request.reject(reason);
-		}
-		this.pending.clear();
+		this.rejectPending(reason);
 		this.handlers.clear();
 		this.backlog = [];
 		// No-op: owning client manages registry lifecycle.
 	}
+
+	private rejectPending(reason: PulseChannelResetError): void {
+		for (const request of this.pending.values()) {
+			request.reject(reason);
+		}
+		this.pending.clear();
+	}
 }
 
-export function usePulseChannel(channelId: string): ChannelBridge | null {
-	const client = usePulseClient();
+class ClientPulseChannelManager implements PulseChannelManager {
+	#client: PulseSocketIOClient;
+	#path: string;
+	#leases = new Map<string, { channelId: string; released: boolean }>();
+	#disposed = false;
 
-	const [bridge, setBridge] = useState<ChannelBridge | null>(null);
+	constructor(client: PulseSocketIOClient, path: string) {
+		this.#client = client;
+		this.#path = path;
+	}
 
-	useEffect(() => {
+	acquire(channelId: string): PulseChannelLease {
 		if (!channelId) {
-			throw new Error("usePulseChannel requires a non-empty channelId");
+			throw new Error("PulseChannelManager.acquire requires a non-empty channelId");
 		}
-		const acquired = client.acquireChannel(channelId);
-		setBridge(acquired);
-		return () => {
-			setBridge((current) => (current === acquired ? null : current));
-			client.releaseChannel(channelId);
+		if (this.#disposed) {
+			throw new Error("PulseChannelManager is disposed");
+		}
+		if (this.#leases.has(channelId)) {
+			throw new Error(`PulseChannelManager already acquired channel '${channelId}'`);
+		}
+		const bridge = this.#client.acquireChannel(channelId, this.#path);
+		const lease = { channelId, released: false };
+		this.#leases.set(channelId, lease);
+		return {
+			bridge,
+			release: () => {
+				this.#release(lease);
+			},
 		};
-	}, [client, channelId]);
+	}
 
-	return bridge;
+	dispose(): void {
+		if (this.#disposed) return;
+		this.#disposed = true;
+		const leases = [...this.#leases.values()];
+		this.#leases.clear();
+		for (const lease of leases) {
+			this.#release(lease);
+		}
+	}
+
+	#release(lease: { channelId: string; released: boolean }): void {
+		if (lease.released) return;
+		lease.released = true;
+		this.#leases.delete(lease.channelId);
+		this.#client.releaseChannel(lease.channelId, this.#path);
+	}
+}
+
+export function createPulseChannelManager(
+	client: PulseSocketIOClient,
+	path: string,
+): PulseChannelManager {
+	return new ClientPulseChannelManager(client, path);
 }

--- a/packages/pulse/js/src/client.tsx
+++ b/packages/pulse/js/src/client.tsx
@@ -61,7 +61,7 @@ export class PulseSocketIOClient {
 	#socket: Socket | null = null;
 	#messageQueue: ClientMessage[];
 	#connectionListeners: Set<ConnectionStatusListener> = new Set();
-	#channels: Map<string, { bridge: ChannelBridge; refCount: number }> = new Map();
+	#channels: Map<string, { path: string; bridge: ChannelBridge }> = new Map();
 	#url: string;
 	#frameworkNavigate: NavigateFunction;
 	#directives: Directives;
@@ -254,6 +254,11 @@ export class PulseSocketIOClient {
 		this.#activeAttachIds.delete(path);
 		this.#ackedAttachIds.delete(path);
 		this.#pendingCallbacks.delete(path);
+		for (const [channel, endpoint] of [...this.#channels]) {
+			if (endpoint.path === path) {
+				this.#releaseChannel(channel, endpoint);
+			}
+		}
 		void this.sendMessage({ type: "detach", path });
 	}
 
@@ -461,49 +466,28 @@ export class PulseSocketIOClient {
 		this.sendMessage(msg);
 	}
 
-	public acquireChannel(id: string): ChannelBridge {
-		const entry = this.#ensureChannelEntry(id);
-		entry.refCount += 1;
-		return entry.bridge;
+	public acquireChannel(id: string, path = ""): ChannelBridge {
+		if (this.#channels.has(id)) {
+			throw new Error(`Pulse channel '${id}' is already acquired`);
+		}
+		const bridge = new ChannelBridge(this, id);
+		this.#channels.set(id, { path, bridge });
+		return bridge;
 	}
 
-	public releaseChannel(id: string): void {
-		const entry = this.#channels.get(id);
-		if (!entry) {
+	public releaseChannel(id: string, path = ""): void {
+		const endpoint = this.#channels.get(id);
+		if (!endpoint || endpoint.path !== path) {
 			return;
 		}
-		entry.refCount = Math.max(0, entry.refCount - 1);
-		if (entry.refCount === 0) {
-			entry.bridge.dispose(new PulseChannelResetError("Channel released"));
-			this.sendMessage({
-				type: "channel_message",
-				channel: id,
-				event: "__close__",
-				payload: { reason: "refcount_zero" },
-			});
-			this.#channels.delete(id);
-		}
-	}
-
-	#ensureChannelEntry(id: string): {
-		bridge: ChannelBridge;
-		refCount: number;
-	} {
-		let entry = this.#channels.get(id);
-		if (!entry) {
-			entry = {
-				bridge: new ChannelBridge(this, id),
-				refCount: 0,
-			};
-			this.#channels.set(id, entry);
-		}
-		return entry;
+		this.#releaseChannel(id, endpoint);
 	}
 
 	#routeChannelMessage(message: ServerChannelMessage): void {
-		const entry = this.#ensureChannelEntry(message.channel);
-		const closed = entry.bridge.handleServerMessage(message);
-		if (closed && entry.refCount === 0) {
+		const endpoint = this.#channels.get(message.channel);
+		if (!endpoint) return;
+		const closed = endpoint.bridge.handleServerMessage(message);
+		if (closed) {
 			this.#channels.delete(message.channel);
 		}
 	}
@@ -559,10 +543,17 @@ export class PulseSocketIOClient {
 		}
 	}
 
-	_ensureChannelEntry(id: string): {
-		bridge: ChannelBridge;
-		refCount: number;
-	} {
-		return this.#ensureChannelEntry(id);
+	#releaseChannel(
+		id: string,
+		endpoint: { path: string; bridge: ChannelBridge },
+	): void {
+		this.#channels.delete(id);
+		endpoint.bridge.dispose(new PulseChannelResetError("Channel released"));
+		this.sendMessage({
+			type: "channel_message",
+			channel: id,
+			event: "__close__",
+			payload: { reason: "refcount_zero" },
+		});
 	}
 }

--- a/packages/pulse/js/src/index.ts
+++ b/packages/pulse/js/src/index.ts
@@ -1,7 +1,7 @@
 // Public API surface for pulse-client
 
-export type { ChannelBridge } from "./channel";
-export { PulseChannelResetError, usePulseChannel } from "./channel";
+export type { ChannelBridge, PulseChannelLease, PulseChannelManager } from "./channel";
+export { PulseChannelResetError } from "./channel";
 // Client implementation (types only - implementation is internal)
 export type {
 	ConnectionStatusListener,
@@ -38,7 +38,16 @@ export type {
 } from "./messages";
 export type { PulseConfig, PulsePrerender, PulseProviderProps } from "./pulse";
 // Core React bindings
-export { PulseProvider, PulseView, usePulseClient } from "./pulse";
+export {
+	PulseViewPathContext,
+	PulseProvider,
+	PulseView,
+	usePulseChannel,
+	usePulseChannelManager,
+	usePulseChannelManagerForPath,
+	usePulseClient,
+	usePulseViewPath,
+} from "./pulse";
 // Renderer helpers
 // Renderer (structural expressions + eval-keyed props)
 export { VDOMRenderer } from "./renderer";

--- a/packages/pulse/js/src/pulse.test.tsx
+++ b/packages/pulse/js/src/pulse.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "bun:test";
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router";
+import { PulseProvider, PulseView, usePulseChannel, usePulseViewPath } from "./pulse";
+
+vi.mock("socket.io-client", () => ({
+	io: () => ({
+		connected: false,
+		disconnect: vi.fn(),
+		emit: vi.fn(),
+		on: vi.fn(),
+	}),
+}));
+
+describe("PulseView channel hooks", () => {
+	it("provides view path context and returns null before channel effect runs", async () => {
+		const states: Array<{ path: string; channel: string | null }> = [];
+
+		function Probe() {
+			const path = usePulseViewPath();
+			const channel = usePulseChannel("chan-1");
+			states.push({ path, channel: channel?.id ?? null });
+			return <div data-testid="channel">{channel?.id ?? "null"}</div>;
+		}
+
+		render(
+			<MemoryRouter initialEntries={["/test"]}>
+				<PulseProvider
+					config={{
+						serverAddress: "http://pulse.test",
+						apiPrefix: "/api",
+						connectionStatus: {
+							initialConnectingDelay: 100000,
+							initialErrorDelay: 100000,
+							reconnectErrorDelay: 100000,
+						},
+					}}
+					prerender={{
+						directives: {},
+						views: {
+							"/test": {
+								vdom: { tag: "$$Probe" },
+							},
+						},
+					}}
+				>
+					<PulseView path="/test" registry={{ Probe }} />
+				</PulseProvider>
+			</MemoryRouter>,
+		);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("channel")).toHaveTextContent("chan-1");
+		});
+		expect(states[0]).toEqual({ path: "/test", channel: null });
+		expect(states.at(-1)).toEqual({ path: "/test", channel: "chan-1" });
+	});
+});

--- a/packages/pulse/js/src/pulse.tsx
+++ b/packages/pulse/js/src/pulse.tsx
@@ -9,6 +9,11 @@ import {
 	useState,
 } from "react";
 import { useLocation, useNavigate, useParams } from "react-router";
+import {
+	createPulseChannelManager,
+	type ChannelBridge,
+	type PulseChannelManager,
+} from "./channel";
 import { type ConnectionStatus, type Directives, PulseSocketIOClient } from "./client";
 import type { RouteInfo } from "./helpers";
 import type { ServerError } from "./messages";
@@ -46,6 +51,7 @@ export type PulsePrerender = {
 // Context for the client, provided by PulseProvider
 const PulseClientContext = createContext<PulseSocketIOClient | null>(null);
 const PulsePrerenderContext = createContext<PulsePrerender | null>(null);
+export const PulseViewPathContext = createContext<string | null>(null);
 
 export const usePulseClient = () => {
 	const client = useContext(PulseClientContext);
@@ -66,6 +72,63 @@ export const usePulsePrerender = (path: string) => {
 	}
 	return view;
 };
+
+export const usePulseViewPath = () => {
+	const path = useContext(PulseViewPathContext);
+	if (!path) {
+		throw new Error("usePulseViewPath must be used within a PulseView");
+	}
+	return path;
+};
+
+export function usePulseChannelManager(): PulseChannelManager {
+	const path = usePulseViewPath();
+	return usePulseChannelManagerForPath(path);
+}
+
+export function usePulseChannelManagerForPath(path: string): PulseChannelManager {
+	const client = usePulseClient();
+	const manager = useMemo(() => createPulseChannelManager(client, path), [client, path]);
+	const pendingDispose = useRef<{
+		manager: PulseChannelManager;
+		timer: ReturnType<typeof setTimeout>;
+	} | null>(null);
+	useEffect(() => {
+		if (pendingDispose.current?.manager === manager) {
+			clearTimeout(pendingDispose.current.timer);
+			pendingDispose.current = null;
+		}
+		return () => {
+			const timer = setTimeout(() => {
+				manager.dispose();
+				if (pendingDispose.current?.manager === manager) {
+					pendingDispose.current = null;
+				}
+			}, 0);
+			pendingDispose.current = { manager, timer };
+		};
+	}, [manager]);
+	return manager;
+}
+
+export function usePulseChannel(channelId: string): ChannelBridge | null {
+	const manager = usePulseChannelManager();
+	const [bridge, setBridge] = useState<ChannelBridge | null>(null);
+
+	useEffect(() => {
+		if (!channelId) {
+			throw new Error("usePulseChannel requires a non-empty channelId");
+		}
+		const lease = manager.acquire(channelId);
+		setBridge(lease.bridge);
+		return () => {
+			setBridge((current) => (current === lease.bridge ? null : current));
+			lease.release();
+		};
+	}, [manager, channelId]);
+
+	return bridge;
+}
 
 // =================================================================
 // Provider
@@ -166,10 +229,11 @@ export interface PulseViewProps {
 
 export function PulseView({ path, registry }: PulseViewProps) {
 	const client = usePulseClient();
+	const channels = usePulseChannelManagerForPath(path);
 	const initialView = usePulsePrerender(path);
 	const renderer = useMemo(
-		() => new VDOMRenderer(client, path, registry),
-		[client, path, registry],
+		() => new VDOMRenderer(client, channels, path, registry),
+		[client, channels, path, registry],
 	);
 	const [tree, setTree] = useState<ReactNode>(() => renderer.init(initialView));
 	const [serverError, setServerError] = useState<ServerError | null>(null);
@@ -256,7 +320,7 @@ export function PulseView({ path, registry }: PulseViewProps) {
 		return <ServerErrorPopup error={serverError} />;
 	}
 
-	return tree;
+	return <PulseViewPathContext.Provider value={path}>{tree}</PulseViewPathContext.Provider>;
 }
 
 function ServerErrorPopup({ error }: { error: ServerError }) {

--- a/packages/pulse/js/src/ref.test.ts
+++ b/packages/pulse/js/src/ref.test.ts
@@ -39,10 +39,24 @@ class FakeBridge {
 	}
 }
 
+function makeRegistry(bridge: FakeBridge, acquire = vi.fn(), release = vi.fn()) {
+	return {
+		registry: new RefRegistry({
+			acquire: (channelId: string) => {
+				acquire(channelId);
+				return { bridge, release } as any;
+			},
+			dispose() {},
+		}),
+		acquire,
+		release,
+	};
+}
+
 describe("RefRegistry", () => {
 	it("emits mount and unmount", () => {
 		const bridge = new FakeBridge();
-		const registry = new RefRegistry(() => bridge as any);
+		const { registry } = makeRegistry(bridge);
 		const cb = registry.getCallback("chan-1", "ref-1");
 
 		cb({});
@@ -56,7 +70,7 @@ describe("RefRegistry", () => {
 
 	it("handles request ops", () => {
 		const bridge = new FakeBridge();
-		const registry = new RefRegistry(() => bridge as any);
+		const { registry } = makeRegistry(bridge);
 		const cb = registry.getCallback("chan-1", "ref-1");
 
 		const element = {
@@ -75,7 +89,7 @@ describe("RefRegistry", () => {
 
 	it("handles call ops", () => {
 		const bridge = new FakeBridge();
-		const registry = new RefRegistry(() => bridge as any);
+		const { registry } = makeRegistry(bridge);
 		const cb = registry.getCallback("chan-1", "ref-1");
 
 		const focus = vi.fn();
@@ -92,12 +106,25 @@ describe("RefRegistry", () => {
 
 	it("locks to a single channel until disposed", () => {
 		const bridge = new FakeBridge();
-		const registry = new RefRegistry(() => bridge as any);
-		registry.getCallback("chan-1", "ref-1");
-		expect(() => registry.getCallback("chan-2", "ref-2")).toThrow(
+		const { registry } = makeRegistry(bridge);
+		registry.getCallback("chan-1", "ref-1")({});
+		expect(() => registry.getCallback("chan-2", "ref-2")({})).toThrow(
 			"[Pulse] Ref channel changed unexpectedly",
 		);
 		registry.dispose();
-		expect(() => registry.getCallback("chan-2", "ref-2")).not.toThrow();
+		expect(() => registry.getCallback("chan-2", "ref-2")({})).not.toThrow();
+	});
+
+	it("acquires lazily when the ref mounts and releases on dispose", () => {
+		const bridge = new FakeBridge();
+		const { registry, acquire, release } = makeRegistry(bridge);
+		const cb = registry.getCallback("chan-1", "ref-1");
+
+		expect(acquire).not.toHaveBeenCalled();
+		cb({});
+		expect(acquire).toHaveBeenCalledWith("chan-1");
+
+		registry.dispose();
+		expect(release).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/pulse/js/src/ref.tsx
+++ b/packages/pulse/js/src/ref.tsx
@@ -1,4 +1,4 @@
-import type { ChannelBridge } from "./channel";
+import type { ChannelBridge, PulseChannelLease, PulseChannelManager } from "./channel";
 import type { PulseRefSpec } from "./vdom";
 
 type RefPayload = {
@@ -10,11 +10,10 @@ type RefPayload = {
 type RefOpResult = any;
 
 type RefEntry = {
+	channelId: string;
 	node: any;
 	callback: (node: any) => void;
 };
-
-type ChannelBridgeProvider = (channelId: string) => ChannelBridge;
 
 const ATTR_ALIASES: Record<string, string> = {
 	className: "class",
@@ -180,24 +179,30 @@ export function isPulseRefSpec(v: unknown): v is PulseRefSpec {
 }
 
 export class RefRegistry {
-	#getBridge: ChannelBridgeProvider;
+	#channels: PulseChannelManager;
 	#bridge: ChannelBridge | null = null;
+	#releaseBridge: (() => void) | null = null;
 	#channelId: string | null = null;
 	#entries: Map<string, RefEntry> = new Map();
 	#cleanup: Array<() => void> = [];
 
-	constructor(getBridge: ChannelBridgeProvider) {
-		this.#getBridge = getBridge;
+	constructor(channels: PulseChannelManager) {
+		this.#channels = channels;
 	}
 
 	getCallback(channelId: string, refId: string): (node: any) => void {
-		this.#ensureChannel(channelId);
 		let entry = this.#entries.get(refId);
+		if (entry && entry.channelId !== channelId) {
+			throw new Error("[Pulse] Ref channel changed unexpectedly");
+		}
 		if (!entry) {
 			const callback = (node: any) => {
+				if (node) {
+					this.#ensureChannel(channelId);
+				}
 				this.#setNode(refId, node ?? null);
 			};
-			entry = { node: null, callback };
+			entry = { channelId, node: null, callback };
 			this.#entries.set(refId, entry);
 		}
 		return entry.callback;
@@ -214,14 +219,15 @@ export class RefRegistry {
 			}
 			return;
 		}
-		const bridge = this.#getBridge(channelId);
-		this.#bridge = bridge;
+		const lease: PulseChannelLease = this.#channels.acquire(channelId);
+		this.#bridge = lease.bridge;
+		this.#releaseBridge = lease.release;
 		this.#channelId = channelId;
 		this.#cleanup.push(
-			bridge.on("ref:call", (payload) => {
+			lease.bridge.on("ref:call", (payload) => {
 				this.#handleCall(payload);
 			}),
-			bridge.on("ref:request", (payload) => {
+			lease.bridge.on("ref:request", (payload) => {
 				return this.#handleRequest(payload);
 			}),
 		);
@@ -230,6 +236,8 @@ export class RefRegistry {
 	#teardown(): void {
 		for (const fn of this.#cleanup) fn();
 		this.#cleanup = [];
+		this.#releaseBridge?.();
+		this.#releaseBridge = null;
 		this.#entries.clear();
 		this.#bridge = null;
 		this.#channelId = null;

--- a/packages/pulse/js/src/renderer.test.tsx
+++ b/packages/pulse/js/src/renderer.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "bun:test";
 import React from "react";
-import { ChannelBridge } from "./channel";
+import { ChannelBridge, createPulseChannelManager } from "./channel";
 import { VDOMRenderer } from "./renderer";
 
 import type { VDOMNode, VDOMUpdate } from "./vdom";
@@ -20,21 +20,24 @@ describe("VDOMRenderer", () => {
 		const client: any = {
 			sendMessage,
 			invokeCallback,
-			_ensureChannelEntry: (id: string) => {
-				let bridge = bridges.get(id);
+			acquireChannel: (id: string, path: string) => {
+				const key = `${path}:${id}`;
+				let bridge = bridges.get(key);
 				if (!bridge) {
 					bridge = new ChannelBridge(client, id);
-					bridges.set(id, bridge);
+					bridges.set(key, bridge);
 				}
-				return { bridge, refCount: 0 };
+				return bridge;
 			},
+			releaseChannel: vi.fn(),
 		};
 		return { client, invokeCallback, sent };
 	}
 
 	function makeRenderer(registry: Record<string, unknown> = {}) {
 		const { client, invokeCallback, sent } = makeClient();
-		const renderer = new VDOMRenderer(client, "/test", registry);
+		const channels = createPulseChannelManager(client, "/test");
+		const renderer = new VDOMRenderer(client, channels, "/test", registry);
 		return { renderer, invokeCallback, sent };
 	}
 
@@ -149,8 +152,18 @@ describe("VDOMRenderer", () => {
 
 	it("handles multiple ref channels across renderers", () => {
 		const shared = makeClient();
-		const rendererA = new VDOMRenderer(shared.client, "/a", {});
-		const rendererB = new VDOMRenderer(shared.client, "/b", {});
+		const rendererA = new VDOMRenderer(
+			shared.client,
+			createPulseChannelManager(shared.client, "/a"),
+			"/a",
+			{},
+		);
+		const rendererB = new VDOMRenderer(
+			shared.client,
+			createPulseChannelManager(shared.client, "/b"),
+			"/b",
+			{},
+		);
 
 		const treeA = rendererA.renderNode({
 			tag: "input",

--- a/packages/pulse/js/src/renderer.tsx
+++ b/packages/pulse/js/src/renderer.tsx
@@ -7,6 +7,7 @@ import {
 	type ReactElement,
 	type ReactNode,
 } from "react";
+import type { PulseChannelManager } from "./channel";
 import type { PulseSocketIOClient } from "./client";
 import type { PulsePrerenderView } from "./pulse";
 import { isPulseRefSpec, RefRegistry } from "./ref";
@@ -65,15 +66,31 @@ export class VDOMRenderer {
 	// Track eval keys + callback entries per ReactElement (not real props).
 	#metaMap: WeakMap<ReactElement, ElementMeta>;
 
-	constructor(client: PulseSocketIOClient, path: string, registry: ComponentRegistry = {}) {
+	constructor(
+		client: PulseSocketIOClient,
+		channels: PulseChannelManager,
+		path: string,
+		registry: ComponentRegistry = {},
+	) {
 		this.#client = client;
 		this.#path = path;
 		this.#registry = registry;
 		this.#callbackEntries = new Set();
 		this.#metaMap = new WeakMap();
-		this.#refRegistry = new RefRegistry((channelId) => {
-			return this.#client._ensureChannelEntry(channelId).bridge;
-		});
+		this.#refRegistry = new RefRegistry(channels);
+	}
+
+	static snapshot(registry: ComponentRegistry = {}): VDOMRenderer {
+		const client = {
+			invokeCallback() {},
+		} as unknown as PulseSocketIOClient;
+		const channels: PulseChannelManager = {
+			acquire(channelId: string) {
+				throw new Error(`[Pulse] Snapshot VDOM cannot bind ref channel '${channelId}'`);
+			},
+			dispose() {},
+		};
+		return new VDOMRenderer(client, channels, "", registry);
 	}
 
 	getObject(key: string): unknown {

--- a/skills/pulse/references/channels.md
+++ b/skills/pulse/references/channels.md
@@ -85,15 +85,22 @@ def ChatClient(*, channelId: str):
 
     # Send event to server
     def sendMessage(text: str):
+        if not bridge:
+            return
         bridge.emit("client:message", {"text": text})
 
     # Request with response
     async def askServer():
+        if not bridge:
+            return
         response = await bridge.request("client:request", {"data": "..."})
         print(response)
 
     # Listen for server events
     def setupListeners():
+        if not bridge:
+            return
+
         def onNotify(payload):
             print("Server notified:", payload)
 
@@ -150,6 +157,9 @@ def ChatWidget(*, channelId: str):
     draft, setDraft = useState("")
 
     def subscribe():
+        if not bridge:
+            return
+
         def onMessage(msg):
             setMessages(lambda prev: [*prev, msg])
 
@@ -158,7 +168,7 @@ def ChatWidget(*, channelId: str):
     useEffect(subscribe, [bridge])
 
     def send():
-        if draft.strip():
+        if bridge and draft.strip():
             bridge.emit("client:send", {"text": draft})
             setDraft("")
 


### PR DESCRIPTION
## Summary
- add PulseView path context plus channel manager/channel hook APIs
- make client channel ownership path-aware without adding channel_connect/channel_disconnect protocol messages
- route VDOM refs through channel leases and release on renderer disposal
- update client channel docs and skill reference for nullable usePulseChannel

## Verification
- bun test packages/pulse/js/src/channel.test.ts packages/pulse/js/src/ref.test.ts packages/pulse/js/src/renderer.test.tsx packages/pulse/js/src/pulse.test.tsx
- make test
- make all
- uv run pulse run examples/main.py; agent-browser verified /counter renders and Increment updates count