### PR TITLE
Use channel hooks in Mantine bridges

### DIFF
--- a/packages/pulse-mantine/js/src/combobox.tsx
+++ b/packages/pulse-mantine/js/src/combobox.tsx
@@ -1,5 +1,5 @@
 import { Combobox as MantineCombobox, useCombobox } from "@mantine/core";
-import { usePulseClient, type ChannelBridge } from "pulse-ui-client";
+import { usePulseChannel, type ChannelBridge } from "pulse-ui-client";
 import { type ComponentPropsWithoutRef, useEffect, useRef } from "react";
 
 type DropdownEventSource = "keyboard" | "mouse" | "unknown";
@@ -38,7 +38,7 @@ export function Combobox({
 	scrollBehavior,
 	...rest
 }: PulseComboboxProps) {
-	const client = usePulseClient();
+	const channel = usePulseChannel(channelId);
 	const channelRef = useRef<ChannelBridge | null>(null);
 
 	const combobox = useCombobox({
@@ -61,7 +61,7 @@ export function Combobox({
 	});
 
 	useEffect(() => {
-		const channel = client.acquireChannel(channelId);
+		if (!channel) return;
 		channelRef.current = channel;
 		const cleanups = [
 			channel.on("openDropdown", (payload: OptionalEventSourcePayload) => {
@@ -111,9 +111,8 @@ export function Combobox({
 			if (channelRef.current === channel) {
 				channelRef.current = null;
 			}
-			client.releaseChannel(channelId);
 		};
-	}, [client, channelId, combobox]);
+	}, [channel, combobox]);
 
 	return <MantineCombobox {...(rest as any)} store={combobox} />;
 }

--- a/packages/pulse-mantine/js/src/form/form.tsx
+++ b/packages/pulse-mantine/js/src/form/form.tsx
@@ -3,7 +3,7 @@ import { useForm } from "@mantine/form";
 import {
 	serialize,
 	submitForm,
-	usePulseClient,
+	usePulseChannel,
 	type ChannelBridge,
 } from "pulse-ui-client";
 import {
@@ -63,7 +63,7 @@ export function Form<TValues extends Record<string, any> = Record<string, any>>(
 	cascadeUpdates,
 	...formProps
 }: MantineFormProps<TValues>) {
-	const client = usePulseClient();
+	const channel = usePulseChannel(channelId);
 	const channelRef = useRef<ChannelBridge | null>(null);
 	const formRef = useRef<UseFormReturnType<TValues> | null>(null);
 	// Timers for server-validation per path
@@ -291,78 +291,91 @@ export function Form<TValues extends Record<string, any> = Record<string, any>>(
 	}, []);
 
 	useEffect(() => {
-		const channel = client.acquireChannel(channelId);
+		if (!channel) return;
 		channelRef.current = channel;
 		const cleanups = [
 			channel.on("setValues", (payload: { values: TValues }) => {
-				if (payload?.values !== undefined) {
-					form.setValues(payload.values);
-					// Always sync back after programmatic value updates
-					sendSync("change");
-				}
+				const currentForm = formRef.current;
+				if (payload?.values === undefined || !currentForm) return;
+				currentForm.setValues(payload.values);
+				// Always sync back after programmatic value updates
+				sendSync("change");
 			}),
 			channel.on("setFieldValue", (payload: { path: string; value: any }) => {
-				if (!payload) return;
-				form.setFieldValue(payload.path, payload.value);
+				const currentForm = formRef.current;
+				if (!payload || !currentForm) return;
+				currentForm.setFieldValue(payload.path, payload.value);
 				sendSync("change", payload.path);
 			}),
 			channel.on("insertListItem", (payload: { path: string; item: any; index?: number }) => {
-				if (!payload) return;
-				form.insertListItem(payload.path, payload.item, payload.index);
+				const currentForm = formRef.current;
+				if (!payload || !currentForm) return;
+				currentForm.insertListItem(payload.path, payload.item, payload.index);
 				sendSync("change", payload.path);
 			}),
 			channel.on("removeListItem", (payload: { path: string; index: number }) => {
-				if (!payload) return;
-				form.removeListItem(payload.path, payload.index);
+				const currentForm = formRef.current;
+				if (!payload || !currentForm) return;
+				currentForm.removeListItem(payload.path, payload.index);
 				sendSync("change", payload.path);
 			}),
 			channel.on("reorderListItem", (payload: { path: string; from: number; to: number }) => {
-				if (!payload) return;
-				form.reorderListItem(payload.path, {
+				const currentForm = formRef.current;
+				if (!payload || !currentForm) return;
+				currentForm.reorderListItem(payload.path, {
 					from: payload.from,
 					to: payload.to,
 				});
 				sendSync("change", payload.path);
 			}),
 			channel.on("setErrors", (payload: { errors: Record<string, any> }) => {
-				if (!payload) return;
-				form.setErrors(payload.errors);
+				const currentForm = formRef.current;
+				if (!payload || !currentForm) return;
+				currentForm.setErrors(payload.errors);
 			}),
 			channel.on("setFieldError", (payload: { path: string; error: any }) => {
-				if (!payload) return;
-				form.setFieldError(payload.path, payload.error);
+				const currentForm = formRef.current;
+				if (!payload || !currentForm) return;
+				currentForm.setFieldError(payload.path, payload.error);
 			}),
 			channel.on("clearErrors", (payload?: { paths?: string[] }) => {
+				const currentForm = formRef.current;
+				if (!currentForm) return;
 				const paths = payload?.paths;
 				if (Array.isArray(paths) && paths.length > 0) {
 					paths.forEach((p) => {
-						form.clearFieldError(p);
+						currentForm.clearFieldError(p);
 					});
 				} else {
-					form.clearErrors();
+					currentForm.clearErrors();
 				}
 			}),
 			channel.on("setTouched", (payload: { touched: Record<string, boolean> }) => {
-				if (!payload) return;
-				form.setTouched(payload.touched);
+				const currentForm = formRef.current;
+				if (!payload || !currentForm) return;
+				currentForm.setTouched(payload.touched);
 			}),
 			channel.on("validate", () => {
+				const currentForm = formRef.current;
+				if (!currentForm) return;
 				// Client-side validation of all fields. Server-side validation is triggered on Python side.
-				form.validate();
+				currentForm.validate();
 			}),
 			channel.on("reset", (payload?: { initialValues?: TValues }) => {
+				const currentForm = formRef.current;
+				if (!currentForm) return;
 				if (payload?.initialValues) {
 					// Same behavior as form.reset(), except we allow modifying the initialValues
-					form.resetTouched();
-					form.resetDirty();
-					form.setValues(payload.initialValues);
+					currentForm.resetTouched();
+					currentForm.resetDirty();
+					currentForm.setValues(payload.initialValues);
 					sendSync("change");
 				} else {
-					form.reset();
+					currentForm.reset();
 					sendSync("change");
 				}
 			}),
-			channel.on("getFormValues", () => form.getValues()),
+			channel.on("getFormValues", () => formRef.current?.getValues()),
 		];
 
 		return () => {
@@ -370,9 +383,8 @@ export function Form<TValues extends Record<string, any> = Record<string, any>>(
 			if (channelRef.current === channel) {
 				channelRef.current = null;
 			}
-			client.releaseChannel(channelId);
 		};
-	}, [client, channelId, form, sendSync]);
+	}, [channel, sendSync]);
 
 	const submitHandler = useMemo(
 		() =>

--- a/packages/pulse-mantine/js/src/notifications.tsx
+++ b/packages/pulse-mantine/js/src/notifications.tsx
@@ -5,7 +5,7 @@ import {
 	type NotificationsProps,
 	notifications as notificationsApi,
 } from "@mantine/notifications";
-import { usePulseClient, type ChannelBridge } from "pulse-ui-client";
+import { usePulseChannel, type ChannelBridge } from "pulse-ui-client";
 import { useEffect, useRef } from "react";
 
 type NotificationUpdatePayload = Parameters<typeof notificationsApi.update>[0];
@@ -38,13 +38,12 @@ export function Notifications({ channelId, ...props }: PulseNotificationsProps) 
 
 function ConnectedNotifications({ channelId, ...props }: ConnectedNotificationsProps) {
 	const { store = defaultStore, ...rest } = props;
-	const client = usePulseClient();
+	const channel = usePulseChannel(channelId);
 	const channelRef = useRef<ChannelBridge | null>(null);
 
 	useEffect(() => {
-		if (!channelId) return;
+		if (!channel) return;
 
-		const channel = client.acquireChannel(channelId);
 		channelRef.current = channel;
 		const cleanups = [
 			channel.on("show", (payload: unknown) => {
@@ -97,9 +96,8 @@ function ConnectedNotifications({ channelId, ...props }: ConnectedNotificationsP
 			if (channelRef.current === channel) {
 				channelRef.current = null;
 			}
-			client.releaseChannel(channelId);
 		};
-	}, [client, channelId, store]);
+	}, [channel, store]);
 
 	return <MantineNotifications {...rest} store={store} />;
 }

--- a/packages/pulse-mantine/js/src/tree.tsx
+++ b/packages/pulse-mantine/js/src/tree.tsx
@@ -1,5 +1,5 @@
 import { Tree as MantineTree, useTree } from "@mantine/core";
-import { usePulseClient, type ChannelBridge } from "pulse-ui-client";
+import { usePulseChannel, type ChannelBridge } from "pulse-ui-client";
 import { type ComponentPropsWithoutRef, useEffect, useRef } from "react";
 
 type ExpandedState = Record<string, boolean>;
@@ -59,7 +59,7 @@ function ConnectedTree({
 	autoSync = true,
 	...rest
 }: ConnectedTreeProps) {
-	const client = usePulseClient();
+	const channel = usePulseChannel(channelId);
 	const channelRef = useRef<ChannelBridge | null>(null);
 
 	// Create controller with initial state and wire auto-sync callbacks
@@ -80,8 +80,7 @@ function ConnectedTree({
 
 	// Server -> client imperative API
 	useEffect(() => {
-		if (!channelId) return;
-		const channel = client.acquireChannel(channelId);
+		if (!channel) return;
 		channelRef.current = channel;
 		const cleanups = [
 			channel.on("toggleExpanded", (payload: { value: string }) => {
@@ -163,9 +162,8 @@ function ConnectedTree({
 			if (channelRef.current === channel) {
 				channelRef.current = null;
 			}
-			client.releaseChannel(channelId);
 		};
-	}, [client, channelId, tree]);
+	}, [channel, tree]);
 
 	return <MantineTree {...(rest as any)} tree={tree as any} />;
 }


### PR DESCRIPTION
## Summary
- Migrate Mantine combobox, form, notifications, and tree bridges to use usePulseChannel()
- Guard ChannelBridge usage while the hook returns null before acquisition
- Use formRef.current in form channel handlers to avoid stale form closures

## Verification
- bunx tsc --noEmit -p packages/pulse-mantine/js/tsconfig.json
- uv run pytest packages/pulse-mantine/python/tests/test_form.py packages/pulse-mantine/python/tests/test_combobox_store.py
- bun test
- make test
- make all
- agent-browser smoke: examples/main.py loaded, Counter route incremented
- agent-browser smoke: generated and loaded examples/pulse-mantine/07-combobox.py, exercised combobox controls
- agent-browser smoke: generated and loaded examples/pulse-mantine/01-basic-form.py, filled/submitted form values