### PR TITLE
Add explicit channel lifecycle

### DIFF
--- a/packages/pulse-mantine/python/tests/test_combobox_store.py
+++ b/packages/pulse-mantine/python/tests/test_combobox_store.py
@@ -34,6 +34,12 @@ def build_context():
 	return app, render, session, real_render
 
 
+def connect_channel(real_render: ps.RenderSession, channel_id: str) -> None:
+	real_render.channels.handle_client_connect(
+		{"type": "channel_connect", "channel": channel_id, "path": "/"}
+	)
+
+
 @pytest.mark.asyncio
 async def test_combobox_store_emits_actions():
 	app, render, session, real_render = build_context()
@@ -44,6 +50,7 @@ async def test_combobox_store_emits_actions():
 		render=real_render,
 	):
 		store = ComboboxStore()
+		connect_channel(real_render, store._channel.id)
 		store.open_dropdown("keyboard")
 		store.select_option(3)
 
@@ -67,6 +74,7 @@ async def test_combobox_store_optional_payloads():
 		render=real_render,
 	):
 		store = ComboboxStore()
+		connect_channel(real_render, store._channel.id)
 		store.open_dropdown()
 		store.update_selected_option_index()
 
@@ -90,6 +98,7 @@ async def test_combobox_store_request_roundtrip():
 		render=real_render,
 	):
 		store = ComboboxStore()
+		connect_channel(real_render, store._channel.id)
 		pending = asyncio.create_task(store.get_dropdown_opened())
 
 	await asyncio.sleep(0)
@@ -134,6 +143,7 @@ async def test_combobox_store_callbacks():
 			onDropdownOpen=lambda source: opened_sources.append(source),
 			onDropdownClose=lambda source: closed_sources.append(source),
 		)
+		connect_channel(real_render, store._channel.id)
 
 	with ps.PulseContext(
 		app=app,

--- a/packages/pulse-mantine/python/tests/test_form.py
+++ b/packages/pulse-mantine/python/tests/test_form.py
@@ -33,6 +33,7 @@ def build_context():
 
 	real_render = ps.RenderSession(render.id, routes, server_address="http://localhost")
 	real_render.send = render.send  # pyright: ignore[reportAttributeAccessIssue]
+	real_render.connect(render.send)
 	with ps.PulseContext(app=app):
 		real_render.prerender(
 			["/"],
@@ -48,12 +49,19 @@ def build_context():
 				},
 			),
 		)
+		real_render.attach("/", route.default_route_info())
 	route_ctx = real_render.route_mounts["/"].route
 
 	app.render_sessions[render.id] = real_render
 	app._render_to_user[render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
 	app.user_sessions[session.sid] = session  # pyright: ignore[reportArgumentType]
 	return app, render, session, real_render, route_ctx
+
+
+def connect_channel(real_render: ps.RenderSession, channel_id: str) -> None:
+	real_render.channels.handle_client_connect(
+		{"type": "channel_connect", "channel": channel_id, "path": "/"}
+	)
 
 
 def test_form_recreates_channel_after_client_release():
@@ -81,6 +89,8 @@ def test_form_recreates_channel_after_client_release():
 		render=real_render,
 		route=route_ctx,
 	):
+		form.render()
+		connect_channel(real_render, form._channel.id)
 		form.reset()
 
 	assert not form._channel.closed
@@ -110,6 +120,7 @@ async def test_form_sync_handler_survives_channel_recreation():
 		route=route_ctx,
 	):
 		form.render()
+		connect_channel(real_render, form._channel.id)
 		real_render.channels.handle_client_event(
 			render=real_render,
 			session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]

--- a/packages/pulse/js/src/channel.test.ts
+++ b/packages/pulse/js/src/channel.test.ts
@@ -5,15 +5,15 @@ import {
 	PulseChannelResetError,
 } from "./channel";
 import { PulseSocketIOClient } from "./client";
-import type { ClientChannelMessage, ClientMessage } from "./messages";
+import type { ClientMessage } from "./messages";
 
 function makeClient() {
-	const sent: ClientChannelMessage[] = [];
-	const sendMessage = vi.fn(async (message: ClientChannelMessage) => {
+	const sent: ClientMessage[] = [];
+	const sendMessage = vi.fn(async (message: ClientMessage) => {
 		sent.push(message);
 	});
 	const client = { sendMessage } as any;
-	const bridge = new ChannelBridge(client, "chan-1");
+	const bridge = new ChannelBridge(client, "chan-1", "/view");
 	return { bridge, sent, sendMessage };
 }
 
@@ -22,7 +22,15 @@ describe("ChannelBridge", () => {
 		const { bridge, sent } = makeClient();
 		const pending = bridge.request("echo", { foo: 1 });
 		expect(sent).toHaveLength(1);
-		const requestId = sent[0]!.requestId!;
+		expect(sent[0]).toEqual(
+			expect.objectContaining({
+				type: "channel_message",
+				channel: "chan-1",
+				event: "echo",
+			}),
+		);
+		expect(sent[0]).not.toHaveProperty("path");
+		const requestId = (sent[0] as any).requestId!;
 		bridge.handleServerMessage({
 			type: "channel_message",
 			channel: "chan-1",
@@ -76,6 +84,24 @@ describe("ChannelBridge", () => {
 		await expect(pending).rejects.toBeInstanceOf(PulseChannelResetError);
 	});
 
+	it("rejects pending requests on transport disconnect without closing", async () => {
+		const { bridge, sent } = makeClient();
+		const pending = bridge.request("during-disconnect");
+		bridge.handleDisconnect(new PulseChannelResetError("Connection lost"));
+
+		await expect(pending).rejects.toBeInstanceOf(PulseChannelResetError);
+		expect(() => bridge.on("event", vi.fn())).not.toThrow();
+
+		bridge.emit("after-reconnect", { ok: true });
+		expect(sent.at(-1)).toEqual(
+			expect.objectContaining({
+				type: "channel_message",
+				channel: "chan-1",
+				event: "after-reconnect",
+			}),
+		);
+	});
+
 	it("reacquires a fresh bridge after release closes a channel", () => {
 		const client = new PulseSocketIOClient(
 			"http://pulse.test",
@@ -98,7 +124,7 @@ describe("ChannelBridge", () => {
 		expect(() => second.on("event", vi.fn())).not.toThrow();
 	});
 
-	it("rejects duplicate client channel acquisitions", () => {
+	it("connects once per channel id and rejects duplicate endpoints", () => {
 		const client = new PulseSocketIOClient(
 			"http://pulse.test",
 			{},
@@ -109,12 +135,26 @@ describe("ChannelBridge", () => {
 				reconnectErrorDelay: 0,
 			},
 		);
+		const sent: ClientMessage[] = [];
+		vi.spyOn(client, "sendMessage").mockImplementation((message: any) => {
+			sent.push(message);
+		});
 
-		client.acquireChannel("chan-1", "/a");
+		const first = client.acquireChannel("chan-1", "/a");
 
 		expect(() => client.acquireChannel("chan-1", "/b")).toThrow(
 			"Pulse channel 'chan-1' is already acquired",
 		);
+		expect(() => first.on("event", vi.fn())).not.toThrow();
+		expect(sent).toEqual([
+			expect.objectContaining({ type: "channel_connect", channel: "chan-1", path: "/a" }),
+		]);
+
+		client.releaseChannel("chan-1", "/a");
+		expect(sent.at(-1)).toEqual({
+			type: "channel_disconnect",
+			channel: "chan-1",
+		});
 	});
 
 	it("channel manager acquires with its view path and releases idempotently", () => {
@@ -139,18 +179,9 @@ describe("ChannelBridge", () => {
 		lease.release();
 
 		expect(sent).toEqual([
-			expect.objectContaining({
-				type: "channel_message",
-				channel: "chan-1",
-				event: "__close__",
-			}),
+			expect.objectContaining({ type: "channel_connect", path: "/view" }),
+			expect.objectContaining({ type: "channel_disconnect", channel: "chan-1" }),
 		]);
-		expect(sent as any[]).not.toContainEqual(
-			expect.objectContaining({ type: "channel_connect" }),
-		);
-		expect(sent as any[]).not.toContainEqual(
-			expect.objectContaining({ type: "channel_disconnect" }),
-		);
 	});
 
 	it("channel manager rejects duplicate acquires", () => {
@@ -164,6 +195,7 @@ describe("ChannelBridge", () => {
 				reconnectErrorDelay: 0,
 			},
 		);
+		vi.spyOn(client, "sendMessage").mockImplementation(() => {});
 
 		const manager = createPulseChannelManager(client, "/view");
 		manager.acquire("chan-1");
@@ -198,7 +230,7 @@ describe("ChannelBridge", () => {
 
 		expect(
 			sent
-				.filter((message) => message.type === "channel_message")
+				.filter((message) => message.type === "channel_disconnect")
 				.map((message) => message.channel),
 		).toEqual(["chan-b", "chan-a"]);
 		expect(() => manager.acquire("chan-c")).toThrow("PulseChannelManager is disposed");

--- a/packages/pulse/js/src/channel.ts
+++ b/packages/pulse/js/src/channel.ts
@@ -67,6 +67,7 @@ export class ChannelBridge {
 	constructor(
 		private client: PulseSocketIOClient,
 		public readonly id: string,
+		public readonly path: string,
 	) {}
 
 	emit(event: string, payload?: any): void {
@@ -142,7 +143,7 @@ export class ChannelBridge {
 	}
 
 	handleDisconnect(reason: PulseChannelResetError): void {
-		this.close(reason);
+		this.rejectPending(reason);
 	}
 
 	dispose(reason: PulseChannelResetError): void {

--- a/packages/pulse/js/src/client.test.ts
+++ b/packages/pulse/js/src/client.test.ts
@@ -127,4 +127,41 @@ describe("PulseSocketIOClient attach ack", () => {
 			"detach",
 		]);
 	});
+
+	it("coalesces queued channel lifecycle messages on initial connect", async () => {
+		const client = await makeClient();
+		const connected = client.connect();
+
+		client.acquireChannel("chan-1", "/view");
+		client.releaseChannel("chan-1", "/view");
+		client.acquireChannel("chan-1", "/view");
+
+		socket.trigger("connect");
+		await connected;
+
+		expect(sentMessages()).toEqual([
+			{ type: "channel_connect", channel: "chan-1", path: "/view" },
+		]);
+	});
+
+	it("rejects channel requests on transport disconnect and reconnects endpoint", async () => {
+		const client = await makeClient();
+		const connected = client.connect();
+		socket.trigger("connect");
+		await connected;
+
+		const bridge = client.acquireChannel("chan-1", "/view");
+		const pending = bridge.request("needs-response");
+
+		socket.trigger("disconnect");
+		await expect(pending).rejects.toThrow("Connection lost");
+
+		socket.emitted = [];
+		socket.trigger("connect");
+
+		expect(sentMessages()).toEqual([
+			{ type: "channel_connect", channel: "chan-1", path: "/view" },
+		]);
+		expect(() => bridge.emit("after-reconnect")).not.toThrow();
+	});
 });

--- a/packages/pulse/js/src/client.tsx
+++ b/packages/pulse/js/src/client.tsx
@@ -167,10 +167,26 @@ export class PulseSocketIOClient {
 				for (const [path, route] of this.#activeViews) {
 					this.#sendAttach(path, route.routeInfo, socket);
 				}
+				for (const [channel, endpoint] of this.#channels) {
+					socket.emit(
+						"message",
+						serialize({
+							type: "channel_connect",
+							channel,
+							path: endpoint.path,
+						}),
+					);
+				}
 
 				for (const payload of this.#messageQueue) {
 					// Already sent above
 					if (payload.type === "attach" && this.#activeViews.has(payload.path)) {
+						continue;
+					}
+					if (
+						payload.type === "channel_connect" ||
+						payload.type === "channel_disconnect"
+					) {
 						continue;
 					}
 					// We're reattaching all the routes, so no need to send update
@@ -470,8 +486,13 @@ export class PulseSocketIOClient {
 		if (this.#channels.has(id)) {
 			throw new Error(`Pulse channel '${id}' is already acquired`);
 		}
-		const bridge = new ChannelBridge(this, id);
+		const bridge = new ChannelBridge(this, id, path);
 		this.#channels.set(id, { path, bridge });
+		this.sendMessage({
+			type: "channel_connect",
+			channel: id,
+			path,
+		});
 		return bridge;
 	}
 
@@ -550,10 +571,8 @@ export class PulseSocketIOClient {
 		this.#channels.delete(id);
 		endpoint.bridge.dispose(new PulseChannelResetError("Channel released"));
 		this.sendMessage({
-			type: "channel_message",
+			type: "channel_disconnect",
 			channel: id,
-			event: "__close__",
-			payload: { reason: "refcount_zero" },
 		});
 	}
 }

--- a/packages/pulse/js/src/messages.ts
+++ b/packages/pulse/js/src/messages.ts
@@ -156,6 +156,17 @@ export interface ClientChannelResponseMessage {
 
 export type ClientChannelMessage = ClientChannelRequestMessage | ClientChannelResponseMessage;
 
+export interface ClientChannelConnectMessage {
+	type: "channel_connect";
+	channel: string;
+	path: string;
+}
+
+export interface ClientChannelDisconnectMessage {
+	type: "channel_disconnect";
+	channel: string;
+}
+
 export interface ClientJsResultMessage {
 	type: "js_result";
 	id: string;
@@ -171,4 +182,6 @@ export type ClientMessage =
 	| ClientApiResultMessage
 	| ClientChannelRequestMessage
 	| ClientChannelResponseMessage
+	| ClientChannelConnectMessage
+	| ClientChannelDisconnectMessage
 	| ClientJsResultMessage;

--- a/packages/pulse/js/src/renderer.test.tsx
+++ b/packages/pulse/js/src/renderer.test.tsx
@@ -24,7 +24,7 @@ describe("VDOMRenderer", () => {
 				const key = `${path}:${id}`;
 				let bridge = bridges.get(key);
 				if (!bridge) {
-					bridge = new ChannelBridge(client, id);
+					bridge = new ChannelBridge(client, id, path);
 					bridges.set(key, bridge);
 				}
 				return bridge;

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -46,6 +46,8 @@ from pulse.helpers import (
 )
 from pulse.hooks.core import hooks
 from pulse.messages import (
+	ClientChannelConnectMessage,
+	ClientChannelDisconnectMessage,
 	ClientChannelMessage,
 	ClientChannelRequestMessage,
 	ClientChannelResponseMessage,
@@ -909,10 +911,25 @@ class App:
 			# Cancel any pending cleanup for active sessions (connected sessions stay alive)
 			self._cancel_render_cleanup(rid)
 			try:
-				if msg["type"] == "channel_message":
-					await self._handle_channel_message(render, session, msg)
+				if msg["type"] in (
+					"channel_message",
+					"channel_connect",
+					"channel_disconnect",
+				):
+					await self._handle_channel_message(
+						render,
+						session,
+						cast(
+							ClientChannelMessage
+							| ClientChannelConnectMessage
+							| ClientChannelDisconnectMessage,
+							msg,
+						),
+					)
 				else:
-					await self._handle_pulse_message(render, session, msg)
+					await self._handle_pulse_message(
+						render, session, cast(ClientPulseMessage, msg)
+					)
 			except Exception as e:
 				path = msg.get("path", "")
 				render.report_error(path, "server", e)
@@ -938,7 +955,6 @@ class App:
 				render.execute_callback(msg["path"], msg["callback"], msg["args"])
 			elif msg["type"] == "detach":
 				render.detach(msg["path"])
-				render.channels.remove_route(msg["path"])
 			elif msg["type"] == "api_result":
 				render.handle_api_result(dict(msg))
 			elif msg["type"] == "js_result":
@@ -975,8 +991,52 @@ class App:
 				)
 
 	async def _handle_channel_message(
-		self, render: RenderSession, session: UserSession, msg: ClientChannelMessage
+		self,
+		render: RenderSession,
+		session: UserSession,
+		msg: ClientChannelMessage
+		| ClientChannelConnectMessage
+		| ClientChannelDisconnectMessage,
 	) -> None:
+		if msg["type"] == "channel_connect":
+			channel_id = str(msg.get("channel", ""))
+
+			async def _next_connect() -> Ok[None]:
+				render.channels.handle_client_connect(msg)
+				return Ok(None)
+
+			with PulseContext.update(session=session, render=render):
+				res = await self.middleware.channel(
+					channel_id=channel_id,
+					event="__connect__",
+					payload=None,
+					request_id=None,
+					session=session.data,
+					next=_next_connect,
+				)
+
+			if isinstance(res, Deny):
+				render.channels.reject_client_connect(channel_id, "Denied")
+			return
+
+		if msg["type"] == "channel_disconnect":
+			channel_id = str(msg.get("channel", ""))
+
+			async def _next_disconnect() -> Ok[None]:
+				render.channels.handle_client_disconnect(msg)
+				return Ok(None)
+
+			with PulseContext.update(session=session, render=render):
+				await self.middleware.channel(
+					channel_id=channel_id,
+					event="__disconnect__",
+					payload=None,
+					request_id=None,
+					session=session.data,
+					next=_next_disconnect,
+				)
+			return
+
 		if msg.get("responseTo"):
 			msg = cast(ClientChannelResponseMessage, msg)
 			render.channels.handle_client_response(msg)

--- a/packages/pulse/python/src/pulse/channel.py
+++ b/packages/pulse/python/src/pulse/channel.py
@@ -4,16 +4,19 @@ import uuid
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from pulse.context import PulseContext
 from pulse.messages import (
+	ClientChannelConnectMessage,
+	ClientChannelDisconnectMessage,
 	ClientChannelRequestMessage,
 	ClientChannelResponseMessage,
 	ServerChannelMessage,
 	ServerChannelRequestMessage,
 	ServerChannelResponseMessage,
 )
+from pulse.routing import ensure_absolute_path
 from pulse.scheduling import create_future
 
 if TYPE_CHECKING:
@@ -95,8 +98,15 @@ class ChannelsManager:
 			raise ValueError(f"Channel id '{channel_id}' is already in use")
 
 		route_path: str | None = None
+		mount_id: str | None = None
 		if bind_route and ctx.route is not None:
 			route_path = ctx.route.route_path
+			mount_id = ctx.source_mount_id
+			if mount_id is None:
+				try:
+					mount_id = render.get_route_mount(route_path).mount_id
+				except ValueError:
+					mount_id = None
 
 		channel = Channel(
 			self,
@@ -104,6 +114,7 @@ class ChannelsManager:
 			render_id=render.id,
 			session_id=session.sid,
 			route_path=route_path,
+			mount_id=mount_id,
 		)
 		self._channels[channel_id] = channel
 		if route_path is not None:
@@ -123,6 +134,81 @@ class ChannelsManager:
 			channel.closed = True
 			self.dispose_channel(channel, reason="route.unmount")
 		self._channels_by_route.pop(path, None)
+
+	def rebind_route_mount(
+		self, path: str, old_mount_id: str, new_mount_id: str
+	) -> None:
+		path = ensure_absolute_path(path)
+		for channel_id in self._channels_by_route.get(path, set()):
+			channel = self._channels.get(channel_id)
+			if channel is not None and channel.mount_id == old_mount_id:
+				channel.mount_id = new_mount_id
+
+	def handle_client_connect(self, message: ClientChannelConnectMessage) -> None:
+		channel_id = str(message.get("channel"))
+		channel = self._channels.get(channel_id)
+		if channel is None or channel.closed:
+			return
+
+		path = ensure_absolute_path(str(message.get("path", "")))
+		if channel.route_path is not None and path != channel.route_path:
+			logger.warning(
+				"Rejecting channel connect for wrong path: %s path=%s owner=%s",
+				channel_id,
+				path,
+				channel.route_path,
+			)
+			return
+
+		if channel.route_path is not None:
+			mount = self._render_session.route_mounts.get(channel.route_path)
+			if (
+				mount is None
+				or mount.state != "active"
+				or mount.mount_id != channel.mount_id
+			):
+				logger.warning(
+					"Rejecting stale channel connect: %s path=%s", channel_id, path
+				)
+				return
+
+		channel.connected = True
+
+	def handle_client_disconnect(self, message: ClientChannelDisconnectMessage) -> None:
+		channel_id = str(message.get("channel"))
+		channel = self._channels.get(channel_id)
+		if channel is None:
+			return
+		channel.connected = False
+		self._cancel_pending_for_channel(
+			channel_id, message="Channel has no connected client"
+		)
+
+	def disconnect_all(self) -> None:
+		for channel in self._channels.values():
+			channel.connected = False
+			self._cancel_pending_for_channel(
+				channel.id, message="Channel has no connected client"
+			)
+
+	def reject_client_connect(self, channel_id: str, message: str) -> None:
+		channel = self._channels.get(channel_id)
+		if channel is None:
+			return
+		channel.connected = False
+		try:
+			self.send_to_client(
+				channel=channel,
+				msg=ServerChannelRequestMessage(
+					type="channel_message",
+					channel=channel.id,
+					event="__close__",
+					payload={"reason": message},
+				),
+				allow_unconnected=True,
+			)
+		except ChannelClosed:
+			return
 
 	# ------------------------------------------------------------------
 	def handle_client_response(self, message: ClientChannelResponseMessage) -> None:
@@ -145,7 +231,7 @@ class ChannelsManager:
 	) -> None:
 		channel_id = str(message.get("channel"))
 		channel = self._channels.get(channel_id)
-		if channel is None:
+		if channel is None or channel.closed:
 			if request_id := message.get("requestId"):
 				self._send_error_response(channel_id, request_id, "Channel closed")
 			return
@@ -156,20 +242,16 @@ class ChannelsManager:
 			)
 			return
 
+		if not channel.connected:
+			if request_id := message.get("requestId"):
+				self._send_error_response(
+					channel_id, request_id, "Channel has no connected client"
+				)
+			return
+
 		event = message["event"]
 		payload = message.get("payload")
 		request_id = message.get("requestId")
-
-		if event == "__close__":
-			reason: str | None = None
-			if isinstance(payload, str):
-				reason = payload
-			elif isinstance(payload, dict):
-				raw_reason = cast(Any, payload.get("reason"))
-				if raw_reason is not None:
-					reason = str(raw_reason)
-			self.release_channel(channel.id, reason=reason)
-			return
 
 		route_ctx = None
 		source_mount_id = None
@@ -209,10 +291,13 @@ class ChannelsManager:
 					responseTo=request_id,
 					payload=result,
 				)
-				self.send_to_client(
-					channel=channel,
-					msg=msg,
-				)
+				try:
+					self.send_to_client(
+						channel=channel,
+						msg=msg,
+					)
+				except ChannelClosed:
+					return
 
 		render.create_task(_invoke(), name=f"channel:{channel_id}:{event}")
 
@@ -265,6 +350,7 @@ class ChannelsManager:
 			self.send_to_client(
 				channel=channel,
 				msg=msg,
+				allow_unconnected=True,
 			)
 		except ChannelClosed:
 			self.resolve_pending_error(request_id, ChannelClosed(message))
@@ -272,12 +358,14 @@ class ChannelsManager:
 	def send_error(self, channel_id: str, request_id: str, message: str) -> None:
 		self._send_error_response(channel_id, request_id, message)
 
-	def _cancel_pending_for_channel(self, channel_id: str) -> None:
+	def _cancel_pending_for_channel(
+		self, channel_id: str, *, message: str = "Channel closed"
+	) -> None:
 		for key, pending in list(self.pending_requests.items()):
 			if pending.channel_id != channel_id:
 				continue
 			if not pending.future.done():
-				pending.future.set_exception(ChannelClosed("Channel closed"))
+				pending.future.set_exception(ChannelClosed(message))
 			self.pending_requests.pop(key, None)
 
 	# ------------------------------------------------------------------
@@ -322,28 +410,37 @@ class ChannelsManager:
 		# print(f"Disposing channel id={channel.id} render={channel.render_id} session={channel.session_id} route={channel.route_path} reason={reason or 'unspecified'} pending={pending}")
 		self._cleanup_channel_refs(channel)
 		self._cancel_pending_for_channel(channel.id)
-		self._channels.pop(channel.id, None)
 		# Notify client that the channel has been closed
-		try:
-			msg = ServerChannelRequestMessage(
-				type="channel_message",
-				channel=channel.id,
-				event="__close__",
-				payload=None,
-			)
-			self.send_to_client(
-				channel=channel,
-				msg=msg,
-			)
-		except Exception:
-			print(f"Failed to send close notification for channel {channel.id}")
+		if channel.connected:
+			try:
+				msg = ServerChannelRequestMessage(
+					type="channel_message",
+					channel=channel.id,
+					event="__close__",
+					payload=None,
+				)
+				self.send_to_client(
+					channel=channel,
+					msg=msg,
+					allow_unconnected=True,
+				)
+			except Exception:
+				print(f"Failed to send close notification for channel {channel.id}")
+		channel.connected = False
+		channel.clear_handlers()
+		self._channels.pop(channel.id, None)
 
 	def send_to_client(
 		self,
 		*,
 		channel: "Channel",
 		msg: ServerChannelMessage,
+		allow_unconnected: bool = False,
 	) -> None:
+		if channel.closed and not allow_unconnected:
+			raise ChannelClosed(f"Channel '{channel.id}' is closed")
+		if not allow_unconnected and not channel.connected:
+			raise ChannelClosed("Channel has no connected client")
 		self._render_session.send(msg)
 
 
@@ -380,6 +477,8 @@ class Channel:
 	render_id: str
 	session_id: str
 	route_path: str | None
+	mount_id: str | None
+	connected: bool
 	_handlers: dict[str, list[ChannelHandler]]
 	closed: bool
 
@@ -391,12 +490,15 @@ class Channel:
 		render_id: str,
 		session_id: str,
 		route_path: str | None,
+		mount_id: str | None,
 	) -> None:
 		self._manager = manager
 		self.id = identifier
 		self.render_id = render_id
 		self.session_id = session_id
 		self.route_path = route_path
+		self.mount_id = mount_id
+		self.connected = False
 		self._handlers = defaultdict(list)
 		self.closed = False
 
@@ -464,6 +566,7 @@ class Channel:
 		"""
 
 		self._ensure_open()
+		self._ensure_connected()
 		msg = ServerChannelRequestMessage(
 			type="channel_message",
 			channel=self.id,
@@ -504,9 +607,9 @@ class Channel:
 		"""
 
 		self._ensure_open()
+		self._ensure_connected()
 		request_id = uuid.uuid4().hex
 		fut = create_future()
-		self._manager.register_pending(request_id, fut, self.id)
 		msg = ServerChannelRequestMessage(
 			type="channel_message",
 			channel=self.id,
@@ -518,6 +621,7 @@ class Channel:
 			channel=self,
 			msg=msg,
 		)
+		self._manager.register_pending(request_id, fut, self.id)
 		try:
 			if timeout is None:
 				return await fut
@@ -548,6 +652,13 @@ class Channel:
 	def _ensure_open(self) -> None:
 		if self.closed:
 			raise ChannelClosed(f"Channel '{self.id}' is closed")
+
+	def _ensure_connected(self) -> None:
+		if not self.connected:
+			raise ChannelClosed("Channel has no connected client")
+
+	def clear_handlers(self) -> None:
+		self._handlers.clear()
 
 	async def dispatch(
 		self, event: str, payload: Any, request_id: str | None

--- a/packages/pulse/python/src/pulse/messages.py
+++ b/packages/pulse/python/src/pulse/messages.py
@@ -156,6 +156,17 @@ class ClientChannelResponseMessage(TypedDict):
 	error: NotRequired[Any]
 
 
+class ClientChannelConnectMessage(TypedDict):
+	type: Literal["channel_connect"]
+	channel: str
+	path: str
+
+
+class ClientChannelDisconnectMessage(TypedDict):
+	type: Literal["channel_disconnect"]
+	channel: str
+
+
 class ClientJsResultMessage(TypedDict):
 	"""Result of client-side JS execution."""
 
@@ -188,7 +199,12 @@ ClientPulseMessage = (
 	| ClientJsResultMessage
 )
 ClientChannelMessage = ClientChannelRequestMessage | ClientChannelResponseMessage
-ClientMessage = ClientPulseMessage | ClientChannelMessage
+ClientChannelLifecycleMessage = (
+	ClientChannelConnectMessage | ClientChannelDisconnectMessage
+)
+ClientMessage = (
+	ClientPulseMessage | ClientChannelMessage | ClientChannelLifecycleMessage
+)
 
 
 class PrerenderPayload(TypedDict):

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -341,6 +341,7 @@ class RenderSession:
 		"""WebSocket disconnected. Start queuing briefly before pausing."""
 		self._send_message = None
 		self.connected = False
+		self.channels.disconnect_all()
 
 		for mount in self.route_mounts.values():
 			if mount.state == "active":
@@ -525,6 +526,7 @@ class RenderSession:
 		if current is not mount:
 			return
 		try:
+			self.channels.remove_route(path)
 			self.route_mounts.pop(path, None)
 			self._ref_channels_by_route.pop(path, None)
 			mount.dispose()
@@ -534,11 +536,12 @@ class RenderSession:
 	def detach(self, path: str):
 		"""Client route unmounted. Dispose immediately outside dev StrictMode replay."""
 		path = ensure_absolute_path(path)
-		self._ref_channels_by_route.pop(path, None)
 		mount = self.route_mounts.get(path)
 		if not mount:
 			return
+		old_mount_id = mount.mount_id
 		mount.renew_mount_id()
+		self.channels.rebind_route_mount(path, old_mount_id, mount.mount_id)
 		if self.dev_strict_mode_detach_timeout > 0:
 			# React StrictMode in development intentionally replays mount effects as
 			# attach -> detach -> attach without another prerender. Keep the mount for

--- a/packages/pulse/python/tests/test_channels.py
+++ b/packages/pulse/python/tests/test_channels.py
@@ -1,11 +1,13 @@
 import asyncio
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any, cast, override
 
 import pulse as ps
 import pytest
-from pulse.channel import ChannelClosed
+from pulse.channel import Channel, ChannelClosed
 from pulse.messages import ClientChannelResponseMessage
+from pulse.render_session import RenderSession
+from pulse.test_helpers import wait_for
 from pulse.user_session import UserSession
 
 
@@ -18,6 +20,56 @@ class DummyRender:
 
 	def send(self, message: dict[str, Any]):
 		self.sent.append(message)
+
+
+def connect_channel(render: RenderSession, channel: Channel, path: str = "/") -> None:
+	render.channels.handle_client_connect(
+		{"type": "channel_connect", "channel": channel.id, "path": path}
+	)
+
+
+def make_route_render(
+	path: str = "/",
+	*,
+	dev_strict_mode_detach_timeout: float = 0.0,
+	middleware: ps.PulseMiddleware | None = None,
+) -> tuple[ps.App, RenderSession, UserSession]:
+	@ps.component
+	def view():
+		return ps.div()
+
+	app = ps.App([ps.Route(path, view)], middleware=middleware)
+	render = ps.RenderSession(
+		"render-1",
+		app.routes,
+		dev_strict_mode_detach_timeout=dev_strict_mode_detach_timeout,
+	)
+	session = cast(UserSession, cast(object, SimpleNamespace(sid="session-1", data={})))
+	render.connect(lambda _: None)
+	with ps.PulseContext(app=app, session=session, render=render):
+		render.prerender([path])
+		render.attach(path, app.routes.find(path).default_route_info())
+	return app, render, session
+
+
+def create_route_channel(
+	app: ps.App,
+	render: RenderSession,
+	session: UserSession,
+	identifier: str,
+	path: str = "/",
+) -> Channel:
+	mount = render.get_route_mount(path)
+	with ps.PulseContext(
+		app=app,
+		session=session,
+		render=render,
+		route=mount.route,
+		source_route_path=mount.route.route_path,
+		source_path=mount.route.pathname,
+		source_mount_id=mount.mount_id,
+	):
+		return render.channels.create(identifier)
 
 
 @pytest.mark.asyncio
@@ -39,6 +91,7 @@ async def test_channel_emit_sends_message():
 		render=real_render,
 	):
 		channel = real_render.channels.create("form-channel")
+		connect_channel(real_render, channel)
 		channel.emit("setValues", {"values": {"a": 1}})
 
 	assert len(render.sent) == 1
@@ -47,6 +100,73 @@ async def test_channel_emit_sends_message():
 	assert message["channel"] == "form-channel"
 	assert message["event"] == "setValues"
 	assert message["payload"] == {"values": {"a": 1}}
+
+
+def test_channel_emit_without_endpoint_raises_channel_closed():
+	app, render, session = make_route_render()
+	channel = create_route_channel(app, render, session, "closed-channel")
+
+	with pytest.raises(ChannelClosed, match="no connected client"):
+		channel.emit("notify", None)
+
+
+def test_connect_requires_matching_active_route_mount():
+	app, render, session = make_route_render()
+	channel = create_route_channel(app, render, session, "owned-channel")
+
+	render.channels.handle_client_connect(
+		{"type": "channel_connect", "channel": channel.id, "path": "/other"}
+	)
+	assert channel.connected is False
+
+	connect_channel(render, channel)
+	assert channel.connected is True
+
+
+@pytest.mark.asyncio
+async def test_dev_strict_mode_detach_preserves_route_channel_until_dispose():
+	app, render, session = make_route_render(dev_strict_mode_detach_timeout=0.01)
+	channel = create_route_channel(app, render, session, "strict-channel")
+	connect_channel(render, channel)
+
+	render.detach("/")
+
+	assert channel.closed is False
+	assert channel.connected is True
+	assert channel.id in render.channels._channels  # pyright: ignore[reportPrivateUsage]
+
+	await wait_for(lambda: channel.id not in render.channels._channels)  # pyright: ignore[reportPrivateUsage]
+	assert channel.closed is True
+
+
+def test_dev_strict_mode_replay_rebinds_route_channel_mount():
+	app, render, session = make_route_render(dev_strict_mode_detach_timeout=10.0)
+	channel = create_route_channel(app, render, session, "replay-channel")
+	connect_channel(render, channel)
+
+	render.detach("/")
+	render.channels.handle_client_disconnect(
+		{"type": "channel_disconnect", "channel": channel.id}
+	)
+	assert channel.closed is False
+	assert channel.connected is False
+
+	with ps.PulseContext(app=app, session=session, render=render):
+		render.attach("/", app.routes.find("/").default_route_info())
+	connect_channel(render, channel)
+
+	assert channel.connected is True
+
+
+def test_stale_connect_during_detach_grace_is_rejected():
+	app, render, session = make_route_render(dev_strict_mode_detach_timeout=10.0)
+	channel = create_route_channel(app, render, session, "stale-channel")
+
+	render.detach("/")
+	connect_channel(render, channel)
+
+	assert channel.connected is False
+	assert channel.closed is False
 
 
 @pytest.mark.asyncio
@@ -68,6 +188,7 @@ async def test_channel_request_resolves_on_response():
 		render=real_render,
 	):
 		channel = real_render.channels.create("req-channel")
+		connect_channel(real_render, channel)
 		pending = asyncio.create_task(channel.request("get", {"x": 1}))
 
 	await asyncio.sleep(0)
@@ -96,6 +217,45 @@ async def test_channel_request_resolves_on_response():
 
 
 @pytest.mark.asyncio
+async def test_channel_request_without_endpoint_raises_channel_closed():
+	app, render, session = make_route_render()
+	channel = create_route_channel(app, render, session, "req-closed")
+
+	with pytest.raises(ChannelClosed, match="no connected client"):
+		await channel.request("get", None)
+
+
+def test_client_request_without_connected_endpoint_gets_error_response():
+	app, render, session = make_route_render()
+	sent: list[dict[str, Any]] = []
+	render.send = sent.append  # pyright: ignore[reportAttributeAccessIssue]
+	channel = create_route_channel(app, render, session, "client-req-closed")
+
+	render.channels.handle_client_event(
+		render=render,
+		session=session,
+		message={
+			"type": "channel_message",
+			"channel": channel.id,
+			"event": "ping",
+			"payload": None,
+			"requestId": "client-req-1",
+		},
+	)
+
+	assert sent == [
+		{
+			"type": "channel_message",
+			"channel": channel.id,
+			"event": None,
+			"responseTo": "client-req-1",
+			"payload": None,
+			"error": "Channel has no connected client",
+		}
+	]
+
+
+@pytest.mark.asyncio
 async def test_channel_event_dispatch():
 	app = ps.App()
 	render = DummyRender()
@@ -116,6 +276,7 @@ async def test_channel_event_dispatch():
 		render=real_render,
 	):
 		channel = real_render.channels.create("event-channel")
+		connect_channel(real_render, channel)
 		channel.on("ping", lambda payload: received.append(payload))
 
 	with ps.PulseContext(
@@ -139,6 +300,108 @@ async def test_channel_event_dispatch():
 
 
 @pytest.mark.asyncio
+async def test_client_disconnect_rejects_pending_without_disposing_channel():
+	app, render, session = make_route_render()
+	sent: list[dict[str, Any]] = []
+	render.send = sent.append  # pyright: ignore[reportAttributeAccessIssue]
+	channel = create_route_channel(app, render, session, "disconnect-channel")
+	connect_channel(render, channel)
+	pending = asyncio.create_task(channel.request("get", None))
+
+	await asyncio.sleep(0)
+	render.channels.handle_client_disconnect(
+		{"type": "channel_disconnect", "channel": channel.id}
+	)
+
+	assert channel.closed is False
+	assert channel.connected is False
+	with pytest.raises(ChannelClosed, match="no connected client"):
+		await pending
+
+
+@pytest.mark.asyncio
+async def test_channel_lifecycle_runs_middleware_and_denial_notifies_client():
+	events: list[str] = []
+
+	class DenyConnectMiddleware(ps.PulseMiddleware):
+		@override
+		async def channel(
+			self,
+			*,
+			channel_id: str,
+			event: str,
+			payload: Any,
+			request_id: str | None,
+			session: dict[str, Any],
+			next: Any,
+		):
+			events.append(event)
+			if event == "__connect__":
+				return ps.Deny()
+			return await next()
+
+	app, render, session = make_route_render(middleware=DenyConnectMiddleware())
+	sent: list[dict[str, Any]] = []
+	render.send = sent.append  # pyright: ignore[reportAttributeAccessIssue]
+	channel = create_route_channel(app, render, session, "denied-channel")
+
+	await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
+		render,
+		session,
+		{"type": "channel_connect", "channel": channel.id, "path": "/"},
+	)
+
+	assert events == ["__connect__"]
+	assert channel.connected is False
+	assert sent == [
+		{
+			"type": "channel_message",
+			"channel": channel.id,
+			"event": "__close__",
+			"payload": {"reason": "Denied"},
+		}
+	]
+
+
+@pytest.mark.asyncio
+async def test_channel_connect_disconnect_lifecycle_middleware_events():
+	events: list[str] = []
+
+	class LogMiddleware(ps.PulseMiddleware):
+		@override
+		async def channel(
+			self,
+			*,
+			channel_id: str,
+			event: str,
+			payload: Any,
+			request_id: str | None,
+			session: dict[str, Any],
+			next: Any,
+		):
+			events.append(event)
+			return await next()
+
+	app, render, session = make_route_render(middleware=LogMiddleware())
+	channel = create_route_channel(app, render, session, "lifecycle-channel")
+
+	await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
+		render,
+		session,
+		{"type": "channel_connect", "channel": channel.id, "path": "/"},
+	)
+	await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
+		render,
+		session,
+		{"type": "channel_disconnect", "channel": channel.id},
+	)
+
+	assert events == ["__connect__", "__disconnect__"]
+	assert channel.connected is False
+	assert channel.closed is False
+
+
+@pytest.mark.asyncio
 async def test_channel_pending_cancelled_on_render_close():
 	app = ps.App()
 	render = DummyRender()
@@ -157,6 +420,7 @@ async def test_channel_pending_cancelled_on_render_close():
 		render=real_render,
 	):
 		channel = real_render.channels.create("close-channel")
+		connect_channel(real_render, channel)
 		pending = asyncio.create_task(channel.request("get", None))
 
 	real_render.close()

--- a/packages/pulse/python/tests/test_renderer.py
+++ b/packages/pulse/python/tests/test_renderer.py
@@ -1228,10 +1228,15 @@ async def test_ref_on_mount_uses_route_context():
 	app = ps.App([ps.Route("/", WithRef)])
 	render = ps.RenderSession("render-ref-route-context", app.routes)
 	session: Any = SimpleNamespace(sid="session-ref-route-context")
+	render.connect(lambda _: None)
 	with ps.PulseContext(app=app, session=session, render=render):
 		render.prerender(["/"])
+		render.attach("/", app.routes.find("/").default_route_info())
 
 	assert handle is not None
+	render.channels.handle_client_connect(
+		{"type": "channel_connect", "channel": handle.channel_id, "path": "/"}
+	)
 	render.channels.handle_client_event(
 		render=render,
 		session=session,


### PR DESCRIPTION
Summary:
- add explicit channel_connect/channel_disconnect client messages and server Channel.connected tracking
- reject unconnected, wrong-path, and stale-mount channel traffic while preserving route channels through dev StrictMode detach grace
- notify client bridges on denied connects, reject pending requests on transport/server disconnect, and coalesce stale queued lifecycle messages on reconnect

Validation:
- uv run pytest packages/pulse/python/tests/test_channels.py packages/pulse/python/tests/test_render_session.py -q
- bun test packages/pulse/js/src/channel.test.ts packages/pulse/js/src/client.test.ts
- make test
- make all
- uv run pulse run examples/main.py, agent-browser loaded http://localhost:8001, navigated to Counter, clicked Increment, confirmed rendered count changed