### PR TITLE
Add reconnect resume handshake

### DIFF
--- a/packages/pulse/js/src/client.test.ts
+++ b/packages/pulse/js/src/client.test.ts
@@ -44,13 +44,15 @@ const routeInfo = {
 	catchall: [],
 };
 
-const view = {
-	routeInfo,
-	onInit: vi.fn(),
-	onUpdate: vi.fn(),
-	onJsExec: vi.fn(),
-	onServerError: vi.fn(),
-};
+function makeView(pathRouteInfo = routeInfo) {
+	return {
+		routeInfo: pathRouteInfo,
+		onInit: vi.fn(),
+		onUpdate: vi.fn(),
+		onJsExec: vi.fn(),
+		onServerError: vi.fn(),
+	};
+}
 
 async function makeClient() {
 	const { PulseSocketIOClient } = await import("./client");
@@ -77,7 +79,7 @@ describe("PulseSocketIOClient attach ack", () => {
 	it("queues callbacks until the active attach is acknowledged", async () => {
 		const client = await makeClient();
 		const connected = client.connect();
-		client.attach("/", view);
+		client.attach("/", makeView());
 		socket.trigger("connect");
 		await connected;
 
@@ -106,7 +108,7 @@ describe("PulseSocketIOClient attach ack", () => {
 	it("drops queued callbacks when the path detaches before ack", async () => {
 		const client = await makeClient();
 		const connected = client.connect();
-		client.attach("/", view);
+		client.attach("/", makeView());
 		socket.trigger("connect");
 		await connected;
 
@@ -160,8 +162,153 @@ describe("PulseSocketIOClient attach ack", () => {
 		socket.trigger("connect");
 
 		expect(sentMessages()).toEqual([
-			{ type: "channel_connect", channel: "chan-1", path: "/view" },
+			{
+				type: "client_resume",
+				resumeId: expect.any(String),
+				views: [],
+				channels: [{ channel: "chan-1", path: "/view" }],
+			},
 		]);
+		const resume = sentMessages()[0]!;
+		socket.trigger(
+			"message",
+			serialize({
+				type: "server_resume",
+				resumeId: resume.resumeId,
+				status: "ok",
+				views: [],
+				channels: [{ channel: "chan-1", path: "/view" }],
+			}),
+		);
 		expect(() => bridge.emit("after-reconnect")).not.toThrow();
+	});
+
+	it("does not replay stale channel disconnect after offline release and reacquire", async () => {
+		const client = await makeClient();
+		const connected = client.connect();
+		socket.trigger("connect");
+		await connected;
+
+		client.acquireChannel("chan-1", "/view");
+		socket.trigger("disconnect");
+		client.releaseChannel("chan-1", "/view");
+		client.acquireChannel("chan-1", "/view");
+
+		socket.emitted = [];
+		socket.trigger("connect");
+
+		expect(sentMessages()).toEqual([
+			{
+				type: "client_resume",
+				resumeId: expect.any(String),
+				views: [],
+				channels: [{ channel: "chan-1", path: "/view" }],
+			},
+		]);
+		const resume = sentMessages()[0]!;
+		socket.trigger(
+			"message",
+			serialize({
+				type: "server_resume",
+				resumeId: resume.resumeId,
+				status: "ok",
+				views: [],
+				channels: [{ channel: "chan-1", path: "/view" }],
+			}),
+		);
+
+		expect(sentMessages()).toEqual([
+			{
+				type: "client_resume",
+				resumeId: resume.resumeId,
+				views: [],
+				channels: [{ channel: "chan-1", path: "/view" }],
+			},
+		]);
+	});
+
+	it("keeps queued callbacks behind resume acceptance", async () => {
+		const client = await makeClient();
+		const connected = client.connect();
+		client.attach("/", makeView());
+		socket.trigger("connect");
+		await connected;
+
+		const attach = sentMessages()[0]!;
+		socket.trigger(
+			"message",
+			serialize({
+				type: "attach_ack",
+				path: "/",
+				attachId: attach.attachId,
+			}),
+		);
+
+		socket.trigger("disconnect");
+		client.invokeCallback("/", "1.onClick", []);
+		socket.emitted = [];
+		socket.trigger("connect");
+
+		expect(sentMessages()).toEqual([
+			{
+				type: "client_resume",
+				resumeId: expect.any(String),
+				views: [{ path: "/", routeInfo, attachId: attach.attachId }],
+				channels: [],
+			},
+		]);
+
+		const resume = sentMessages()[0]!;
+		socket.trigger(
+			"message",
+			serialize({
+				type: "server_resume",
+				resumeId: resume.resumeId,
+				status: "ok",
+				views: [{ path: "/", attachId: attach.attachId }],
+				channels: [],
+			}),
+		);
+
+		expect(sentMessages()[1]).toMatchObject({
+			type: "callback",
+			path: "/",
+			callback: "1.onClick",
+		});
+	});
+
+	it("drops queued channel messages and closes bridge when channel is not resumed", async () => {
+		const client = await makeClient();
+		const connected = client.connect();
+		socket.trigger("connect");
+		await connected;
+
+		const bridge = client.acquireChannel("chan-1", "/view");
+		socket.trigger("disconnect");
+		bridge.emit("offline-event");
+		socket.emitted = [];
+		socket.trigger("connect");
+
+		const resume = sentMessages()[0]!;
+		socket.trigger(
+			"message",
+			serialize({
+				type: "server_resume",
+				resumeId: resume.resumeId,
+				status: "ok",
+				views: [],
+				channels: [],
+			}),
+		);
+
+		expect(sentMessages()).toEqual([
+			{
+				type: "client_resume",
+				resumeId: resume.resumeId,
+				views: [],
+				channels: [{ channel: "chan-1", path: "/view" }],
+			},
+		]);
+		expect(() => bridge.emit("after-refusal")).toThrow("Channel is closed");
 	});
 });

--- a/packages/pulse/js/src/client.tsx
+++ b/packages/pulse/js/src/client.tsx
@@ -7,11 +7,13 @@ import type {
 	ClientCallbackMessage,
 	ClientJsResultMessage,
 	ClientMessage,
+	ClientResumeMessage,
 	ServerApiCallMessage,
 	ServerChannelMessage,
 	ServerError,
 	ServerJsExecMessage,
 	ServerMessage,
+	ServerResumeMessage,
 } from "./messages";
 import type { PulsePrerenderView } from "./pulse";
 import { extractEvent } from "./serialize/events";
@@ -75,6 +77,8 @@ export class PulseSocketIOClient {
 	#errorTimeout: ReturnType<typeof setTimeout> | null = null;
 	#currentStatus: ConnectionStatus = "ok";
 	#nextAttachId = 0;
+	#resumePending = false;
+	#pendingResumeId: string | null = null;
 
 	constructor(
 		url: string,
@@ -163,6 +167,10 @@ export class PulseSocketIOClient {
 
 			socket.on("connect", () => {
 				console.log("[SocketIOTransport] Connected:", this.#socket?.id);
+				if (this.#hasConnectedOnce) {
+					this.#startResume(socket);
+					return;
+				}
 				// Send attach for all active views on connect/reconnect
 				for (const [path, route] of this.#activeViews) {
 					this.#sendAttach(path, route.routeInfo, socket);
@@ -236,7 +244,7 @@ export class PulseSocketIOClient {
 	}
 
 	public sendMessage(payload: ClientMessage) {
-		if (this.isConnected()) {
+		if (this.isConnected() && !this.#resumePending) {
 			// console.log("[SocketIOTransport] Sending:", payload);
 			this.#socket!.emit("message", serialize(payload as any));
 		} else {
@@ -294,6 +302,8 @@ export class PulseSocketIOClient {
 		this.#channels.clear();
 		this.#currentStatus = "ok";
 		this.#hasConnectedOnce = false;
+		this.#resumePending = false;
+		this.#pendingResumeId = null;
 	}
 
 	#handleServerMessage(message: ServerMessage) {
@@ -371,6 +381,10 @@ export class PulseSocketIOClient {
 			}
 			case "reload": {
 				window.location.reload();
+				break;
+			}
+			case "server_resume": {
+				this.#handleServerResume(message);
 				break;
 			}
 			case "attach_ack": {
@@ -515,9 +529,117 @@ export class PulseSocketIOClient {
 
 	#handleTransportDisconnect(): void {
 		this.#ackedAttachIds.clear();
+		this.#resumePending = false;
+		this.#pendingResumeId = null;
 		for (const entry of this.#channels.values()) {
 			entry.bridge.handleDisconnect(new PulseChannelResetError("Connection lost"));
 		}
+	}
+
+	#startResume(socket: Socket): void {
+		const resumeId = `${Date.now()}:${Math.random().toString(16).slice(2)}`;
+		this.#resumePending = true;
+		this.#pendingResumeId = resumeId;
+		const views: ClientResumeMessage["views"] = [];
+		for (const [path, view] of this.#activeViews) {
+			const attachId = this.#activeAttachIds.get(path);
+			views.push({
+				path,
+				routeInfo: view.routeInfo,
+				...(attachId ? { attachId } : {}),
+			});
+		}
+		const channels: ClientResumeMessage["channels"] = [];
+		for (const [channel, endpoint] of this.#channels) {
+			channels.push({ channel, path: endpoint.path });
+		}
+		socket.emit(
+			"message",
+			serialize({
+				type: "client_resume",
+				resumeId,
+				views,
+				channels,
+			} satisfies ClientResumeMessage),
+		);
+	}
+
+	#handleServerResume(message: ServerResumeMessage): void {
+		if (message.resumeId !== this.#pendingResumeId) return;
+		this.#pendingResumeId = null;
+		if (message.status === "reload") {
+			this.#resumePending = false;
+			this.#messageQueue = [];
+			this.#pendingCallbacks.clear();
+			for (const [channel, endpoint] of this.#channels) {
+				endpoint.bridge.dispose(new PulseChannelResetError("Resume rejected"));
+				this.#channels.delete(channel);
+			}
+			window.location.reload();
+			return;
+		}
+
+		const acceptedViews = new Set((message.views ?? []).map((view) => view.path));
+		const acceptedChannels = new Map(
+			(message.channels ?? []).map((channel) => [channel.channel, channel.path]),
+		);
+
+		for (const path of [...this.#pendingCallbacks.keys()]) {
+			if (!acceptedViews.has(path)) {
+				this.#pendingCallbacks.delete(path);
+			}
+		}
+		for (const view of message.views ?? []) {
+			const attachId = view.attachId ?? this.#activeAttachIds.get(view.path);
+			if (attachId && this.#activeAttachIds.get(view.path) === attachId) {
+				this.#ackedAttachIds.set(view.path, attachId);
+			}
+		}
+		for (const [channel, endpoint] of [...this.#channels]) {
+			if (acceptedChannels.get(channel) !== endpoint.path) {
+				endpoint.bridge.dispose(
+					new PulseChannelResetError("Channel was not resumed"),
+				);
+				this.#channels.delete(channel);
+			}
+		}
+
+		const queued = this.#messageQueue;
+		this.#messageQueue = [];
+		this.#resumePending = false;
+		for (const path of acceptedViews) {
+			this.#flushPendingCallbacks(path);
+		}
+		for (const payload of queued) {
+			if (this.#shouldReplayAfterResume(payload, acceptedViews, acceptedChannels)) {
+				this.sendMessage(payload);
+			}
+		}
+		this.#handleConnected();
+	}
+
+	#shouldReplayAfterResume(
+		payload: ClientMessage,
+		acceptedViews: Set<string>,
+		acceptedChannels: Map<string, string>,
+	): boolean {
+		if (
+			payload.type === "attach" ||
+			payload.type === "detach" ||
+			payload.type === "update" ||
+			payload.type === "channel_connect" ||
+			payload.type === "channel_disconnect" ||
+			payload.type === "client_resume"
+		) {
+			return false;
+		}
+		if (payload.type === "callback") {
+			return acceptedViews.has(payload.path);
+		}
+		if (payload.type === "channel_message") {
+			return acceptedChannels.has(payload.channel);
+		}
+		return true;
 	}
 
 	#sendAttach(path: string, routeInfo: RouteInfo, socket?: Socket): void {

--- a/packages/pulse/js/src/messages.ts
+++ b/packages/pulse/js/src/messages.ts
@@ -77,6 +77,24 @@ export interface ServerReloadMessage {
 	type: "reload";
 }
 
+export interface ServerResumeView {
+	path: string;
+	attachId?: string;
+}
+
+export interface ServerResumeChannel {
+	channel: string;
+	path: string;
+}
+
+export interface ServerResumeMessage {
+	type: "server_resume";
+	resumeId: string;
+	status: "ok" | "reload";
+	views?: ServerResumeView[];
+	channels?: ServerResumeChannel[];
+}
+
 export interface ServerAttachAckMessage {
 	type: "attach_ack";
 	path: string;
@@ -97,6 +115,7 @@ export type ServerMessage =
 	| ServerApiCallMessage
 	| ServerNavigateToMessage
 	| ServerReloadMessage
+	| ServerResumeMessage
 	| ServerAttachAckMessage
 	| ServerChannelRequestMessage
 	| ServerChannelResponseMessage
@@ -123,6 +142,24 @@ export interface ClientUpdateMessage {
 export interface ClientDetachMessage {
 	type: "detach";
 	path: string;
+}
+
+export interface ClientResumeView {
+	path: string;
+	routeInfo: RouteInfo;
+	attachId?: string;
+}
+
+export interface ClientResumeChannel {
+	channel: string;
+	path: string;
+}
+
+export interface ClientResumeMessage {
+	type: "client_resume";
+	resumeId: string;
+	views: ClientResumeView[];
+	channels: ClientResumeChannel[];
 }
 
 export interface ClientApiResultMessage {
@@ -179,6 +216,7 @@ export type ClientMessage =
 	| ClientCallbackMessage
 	| ClientUpdateMessage
 	| ClientDetachMessage
+	| ClientResumeMessage
 	| ClientApiResultMessage
 	| ClientChannelRequestMessage
 	| ClientChannelResponseMessage

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -949,6 +949,8 @@ class App:
 							"attachId": attach_id,
 						}
 					)
+			elif msg["type"] == "client_resume":
+				render.resume(msg["resumeId"], msg["views"], msg["channels"])
 			elif msg["type"] == "update":
 				render.update_route(msg["path"], msg["routeInfo"])
 			elif msg["type"] == "callback":

--- a/packages/pulse/python/src/pulse/channel.py
+++ b/packages/pulse/python/src/pulse/channel.py
@@ -174,6 +174,36 @@ class ChannelsManager:
 
 		channel.connected = True
 
+	def resume_client_channel(self, channel_id: str, path: str) -> bool:
+		channel = self._channels.get(channel_id)
+		if channel is None or channel.closed:
+			return False
+
+		path = ensure_absolute_path(path)
+		if channel.route_path is not None and path != channel.route_path:
+			logger.warning(
+				"Rejecting channel resume for wrong path: %s path=%s owner=%s",
+				channel_id,
+				path,
+				channel.route_path,
+			)
+			return False
+
+		if channel.route_path is not None:
+			mount = self._render_session.route_mounts.get(channel.route_path)
+			if (
+				mount is None
+				or mount.state != "active"
+				or mount.mount_id != channel.mount_id
+			):
+				logger.warning(
+					"Rejecting stale channel resume: %s path=%s", channel_id, path
+				)
+				return False
+
+		channel.connected = True
+		return True
+
 	def handle_client_disconnect(self, message: ClientChannelDisconnectMessage) -> None:
 		channel_id = str(message.get("channel"))
 		channel = self._channels.get(channel_id)

--- a/packages/pulse/python/src/pulse/messages.py
+++ b/packages/pulse/python/src/pulse/messages.py
@@ -55,6 +55,24 @@ class ServerReloadMessage(TypedDict):
 	type: Literal["reload"]
 
 
+class ServerResumeView(TypedDict):
+	path: str
+	attachId: NotRequired[str]
+
+
+class ServerResumeChannel(TypedDict):
+	channel: str
+	path: str
+
+
+class ServerResumeMessage(TypedDict):
+	type: Literal["server_resume"]
+	resumeId: str
+	status: Literal["ok", "reload"]
+	views: NotRequired[list[ServerResumeView]]
+	channels: NotRequired[list[ServerResumeChannel]]
+
+
 class ServerAttachAckMessage(TypedDict):
 	type: Literal["attach_ack"]
 	path: str
@@ -129,6 +147,24 @@ class ClientDetachMessage(TypedDict):
 	path: str
 
 
+class ClientResumeView(TypedDict):
+	path: str
+	routeInfo: RouteInfo
+	attachId: NotRequired[str]
+
+
+class ClientResumeChannel(TypedDict):
+	channel: str
+	path: str
+
+
+class ClientResumeMessage(TypedDict):
+	type: Literal["client_resume"]
+	resumeId: str
+	views: list[ClientResumeView]
+	channels: list[ClientResumeChannel]
+
+
 class ClientApiResultMessage(TypedDict):
 	type: Literal["api_result"]
 	id: str
@@ -184,6 +220,7 @@ ServerMessage = (
 	| ServerApiCallMessage
 	| ServerNavigateToMessage
 	| ServerReloadMessage
+	| ServerResumeMessage
 	| ServerAttachAckMessage
 	| ServerChannelMessage
 	| ServerJsExecMessage
@@ -195,6 +232,7 @@ ClientPulseMessage = (
 	| ClientAttachMessage
 	| ClientUpdateMessage
 	| ClientDetachMessage
+	| ClientResumeMessage
 	| ClientApiResultMessage
 	| ClientJsResultMessage
 )

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -10,12 +10,17 @@ from pulse.channel import Channel
 from pulse.context import PulseContext
 from pulse.hooks.runtime import NotFoundInterrupt, RedirectInterrupt
 from pulse.messages import (
+	ClientResumeChannel,
+	ClientResumeView,
 	ServerApiCallMessage,
 	ServerErrorPhase,
 	ServerInitMessage,
 	ServerJsExecMessage,
 	ServerMessage,
 	ServerNavigateToMessage,
+	ServerResumeChannel,
+	ServerResumeMessage,
+	ServerResumeView,
 	ServerUpdateMessage,
 )
 from pulse.queries.store import QueryStore
@@ -504,6 +509,65 @@ class RenderSession:
 		if mount.state == "pending" and self._send_message:
 			mount.activate(self._send_message)
 		return mount.state == "active"
+
+	def resume(
+		self,
+		resume_id: str,
+		views: list[ClientResumeView],
+		channels: list[ClientResumeChannel],
+	) -> bool:
+		accepted_views: list[ServerResumeView] = []
+		accepted_paths: set[str] = set()
+
+		for view in views:
+			path = ensure_absolute_path(view["path"])
+			mount = self.route_mounts.get(path)
+			if mount is None or mount.state in ("idle", "closed"):
+				self.send(
+					ServerResumeMessage(
+						type="server_resume",
+						resumeId=resume_id,
+						status="reload",
+					)
+				)
+				return False
+			mount.update_route(view["routeInfo"])
+			if mount.state == "pending" and self._send_message:
+				mount.activate(self._send_message)
+			if mount.state != "active":
+				self.send(
+					ServerResumeMessage(
+						type="server_resume",
+						resumeId=resume_id,
+						status="reload",
+					)
+				)
+				return False
+			accepted_paths.add(path)
+			resumed_view: ServerResumeView = {"path": path}
+			if attach_id := view.get("attachId"):
+				resumed_view["attachId"] = attach_id
+			accepted_views.append(resumed_view)
+
+		accepted_channels: list[ServerResumeChannel] = []
+		for channel in channels:
+			channel_id = str(channel.get("channel", ""))
+			path = ensure_absolute_path(str(channel.get("path", "")))
+			if path not in accepted_paths:
+				continue
+			if self.channels.resume_client_channel(channel_id, path):
+				accepted_channels.append({"channel": channel_id, "path": path})
+
+		self.send(
+			ServerResumeMessage(
+				type="server_resume",
+				resumeId=resume_id,
+				status="ok",
+				views=accepted_views,
+				channels=accepted_channels,
+			)
+		)
+		return True
 
 	def update_route(self, path: str, route_info: RouteInfo):
 		"""Update routing state (query params, etc.) for attached path."""

--- a/packages/pulse/python/tests/test_channels.py
+++ b/packages/pulse/python/tests/test_channels.py
@@ -169,6 +169,36 @@ def test_stale_connect_during_detach_grace_is_rejected():
 	assert channel.closed is False
 
 
+def test_resume_omits_closed_channel_from_acceptance():
+	app, render, session = make_route_render()
+	sent: list[dict[str, Any]] = []
+	render.send = sent.append  # pyright: ignore[reportAttributeAccessIssue]
+	channel = create_route_channel(app, render, session, "closed-resume-channel")
+	connect_channel(render, channel)
+	channel.close()
+
+	ok = render.resume(
+		"resume-1",
+		[
+			{
+				"path": "/",
+				"routeInfo": app.routes.find("/").default_route_info(),
+				"attachId": "attach-1",
+			}
+		],
+		[{"channel": channel.id, "path": "/"}],
+	)
+
+	assert ok is True
+	assert sent[-1] == {
+		"type": "server_resume",
+		"resumeId": "resume-1",
+		"status": "ok",
+		"views": [{"path": "/", "attachId": "attach-1"}],
+		"channels": [],
+	}
+
+
 @pytest.mark.asyncio
 async def test_channel_request_resolves_on_response():
 	app = ps.App()

--- a/packages/pulse/python/tests/test_render_session.py
+++ b/packages/pulse/python/tests/test_render_session.py
@@ -808,6 +808,81 @@ async def test_reconnect_flushes_queue_when_pending():
 	session.close()
 
 
+def test_resume_missing_mount_requests_reload():
+	routes = RouteTree([Route("a", simple_component)])
+	session = RenderSession("test-id", routes)
+	messages: list[ServerMessage] = []
+	session.connect(messages.append)
+
+	with ps.PulseContext.update(render=session):
+		ok = session.resume(
+			"resume-1",
+			[
+				{
+					"path": "/a",
+					"routeInfo": make_route_info("/a"),
+					"attachId": "attach-1",
+				}
+			],
+			[],
+		)
+
+	assert ok is False
+	assert messages == [
+		{"type": "server_resume", "resumeId": "resume-1", "status": "reload"}
+	]
+
+	session.close()
+
+
+def test_resume_accepts_pending_mount_and_flushes_queue_after_snapshot():
+	routes = RouteTree([Route("a", StatefulCounter)])
+	session = RenderSession("test-id", routes)
+	messages: list[ServerMessage] = []
+	session.connect(messages.append)
+
+	with ps.PulseContext.update(render=session):
+		session.prerender(["/a"], make_route_info("/a"))
+		session.attach("/a", make_route_info("/a"))
+
+	session.disconnect()
+	mount = session.route_mounts["/a"]
+	session.execute_callback("/a", first_callback_key(session, "/a"), [])
+	session.flush()
+	assert mount.queue is not None
+	assert len(mount.queue) == 1
+
+	resume_messages: list[ServerMessage] = []
+	session.connect(resume_messages.append)
+	with ps.PulseContext.update(render=session):
+		ok = session.resume(
+			"resume-1",
+			[
+				{
+					"path": "/a",
+					"routeInfo": make_route_info("/a"),
+					"attachId": "attach-1",
+				}
+			],
+			[],
+		)
+
+	assert ok is True
+	assert [message["type"] for message in resume_messages] == [
+		"vdom_update",
+		"server_resume",
+	]
+	assert resume_messages[1] == {
+		"type": "server_resume",
+		"resumeId": "resume-1",
+		"status": "ok",
+		"views": [{"path": "/a", "attachId": "attach-1"}],
+		"channels": [],
+	}
+
+	session.close()
+
+
 def test_prerender_of_active_path_queues_updates_until_route_sync():
 	routes = make_routes()
 	session = RenderSession("test-id", routes)


### PR DESCRIPTION
## Summary
- add client_resume/server_resume wire messages and gate client replay behind resume acceptance
- validate resumed route mounts and channels on the server, returning reload when the route state is no longer resumable
- drop lifecycle queue history on reconnect and filter queued callbacks/channel messages to accepted owners

## Validation
- bun test packages/pulse/js/src/client.test.ts
- uv run pytest packages/pulse/python/tests/test_render_session.py -k "resume or reconnect_flushes_queue_when_pending"
- uv run pytest packages/pulse/python/tests/test_channels.py -k "resume_omits_closed_channel or lifecycle or strict or stale_connect"
- make test
- make all
- uv run pulse run examples/main.py, verified with agent-browser: loaded app, navigated Home/Counter/About, clicked counter increment, checked stable console after reload