### PR TITLE
Strip notification callbacks from client payloads

### DIFF
--- a/packages/pulse-mantine/python/src/pulse_mantine/core/feedback/notifications.py
+++ b/packages/pulse-mantine/python/src/pulse_mantine/core/feedback/notifications.py
@@ -179,6 +179,7 @@ def NotificationsInternal(
 
 
 NOTIFICATIONS_CHANNEL_ID = uuid.uuid4().hex
+CLIENT_CALLBACK_KEYS = {"onClose", "onOpen"}
 
 
 class NotificationsStore(ps.State):
@@ -199,7 +200,7 @@ class NotificationsStore(ps.State):
 		existing = self.registry.get(ident)
 		merged = payload if not existing else existing | payload
 		self.registry[ident] = merged
-		self._channel.emit("show", serialize(merged))
+		self._channel.emit("show", client_notification_payload(merged))
 		return ident
 
 	def update(self, kwargs: NotificationData) -> str:
@@ -208,7 +209,7 @@ class NotificationsStore(ps.State):
 		existing = self.registry.get(ident)
 		merged = payload if not existing else existing | payload
 		self.registry[ident] = merged
-		self._channel.emit("update", serialize(merged))
+		self._channel.emit("update", client_notification_payload(merged))
 		return ident
 
 	def hide(self, id: str) -> str:
@@ -246,14 +247,14 @@ class NotificationsStore(ps.State):
 			result = update(current)
 		else:
 			result = update
-		new_notifications: list[NotificationData] = []
+		new_notifications: list[dict[str, Any]] = []
 		for item in result:
 			ident, item = ensure_id(item)
 			self.registry[ident] = item
-			new_notifications.append(item)
+			new_notifications.append(client_notification_payload(item))
 		self._channel.emit(
 			"updateState",
-			{"notifications": [serialize(x) for x in new_notifications]},
+			{"notifications": new_notifications},
 		)
 
 	def _on_state_sync(self, payload: Any) -> None:
@@ -324,8 +325,10 @@ def ensure_id(
 	return ident, cast(NotificationData, value)
 
 
-def serialize(value: NotificationData):
-	return {k: v for k, v in value.items() if k not in ("onClose", "onOpen")}
+def client_notification_payload(value: Mapping[str, Any]) -> dict[str, Any]:
+	return {
+		key: entry for key, entry in value.items() if key not in CLIENT_CALLBACK_KEYS
+	}
 
 
 notifications_state = ps.global_state(NotificationsStore)

--- a/packages/pulse-mantine/python/tests/test_notifications.py
+++ b/packages/pulse-mantine/python/tests/test_notifications.py
@@ -1,0 +1,108 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pulse as ps
+from pulse.user_session import UserSession
+from pulse_mantine.core.feedback.notifications import NotificationsStore
+
+
+class DummyRender:
+	id: str
+
+	def __init__(self, rid: str = "render-1") -> None:
+		self.id = rid
+		self.sent: list[dict[str, Any]] = []
+
+	def send(self, message: dict[str, Any]):
+		self.sent.append(message)
+
+
+def build_context():
+	app = ps.App()
+	render = DummyRender()
+	session = SimpleNamespace(sid="session-1")
+
+	real_render = ps.RenderSession(render.id, app.routes)
+	real_render.send = render.send  # pyright: ignore[reportAttributeAccessIssue]
+
+	app.render_sessions[render.id] = real_render
+	app._render_to_user[render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
+	app.user_sessions[session.sid] = session  # pyright: ignore[reportArgumentType]
+	return app, render, session, real_render
+
+
+def connect_channel(real_render: ps.RenderSession, channel_id: str) -> None:
+	real_render.channels.handle_client_connect(
+		{"type": "channel_connect", "channel": channel_id, "path": "/"}
+	)
+
+
+def test_notification_show_keeps_callback_server_side():
+	app, render, session, real_render = build_context()
+
+	def on_open(notification: dict[str, Any]) -> None:
+		notification["opened"] = True
+
+	with ps.PulseContext(
+		app=app,
+		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
+		render=real_render,
+	):
+		store = NotificationsStore()
+		connect_channel(real_render, store._channel.id)  # pyright: ignore[reportPrivateUsage]
+		ident = store.show({"message": "Saved", "onOpen": on_open})
+
+	assert store.registry[ident]["onOpen"] is on_open
+	assert render.sent[0]["event"] == "show"
+	assert render.sent[0]["payload"] == {"message": "Saved", "id": ident}
+
+
+def test_notification_update_keeps_callbacks_server_side():
+	app, render, session, real_render = build_context()
+
+	def on_close(notification: dict[str, Any]) -> None:
+		notification["closed"] = True
+
+	with ps.PulseContext(
+		app=app,
+		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
+		render=real_render,
+	):
+		store = NotificationsStore()
+		connect_channel(real_render, store._channel.id)  # pyright: ignore[reportPrivateUsage]
+		store.show({"id": "toast", "message": "Saving"})
+		store.update({"id": "toast", "message": "Saved", "onClose": on_close})
+
+	assert store.registry["toast"]["onClose"] is on_close
+	assert render.sent[1]["event"] == "update"
+	assert render.sent[1]["payload"] == {"id": "toast", "message": "Saved"}
+
+
+def test_notification_update_state_keeps_callbacks_server_side():
+	app, render, session, real_render = build_context()
+
+	def on_close(notification: dict[str, Any]) -> None:
+		notification["closed"] = True
+
+	with ps.PulseContext(
+		app=app,
+		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
+		render=real_render,
+	):
+		store = NotificationsStore()
+		connect_channel(real_render, store._channel.id)  # pyright: ignore[reportPrivateUsage]
+		store.updateState(
+			[
+				{
+					"id": "toast",
+					"message": "Synced",
+					"onClose": on_close,
+				}
+			]
+		)
+
+	assert store.registry["toast"]["onClose"] is on_close
+	assert render.sent[0]["event"] == "updateState"
+	assert render.sent[0]["payload"] == {
+		"notifications": [{"id": "toast", "message": "Synced"}]
+	}


### PR DESCRIPTION
Stacked on #89.\n\nSummary:\n- Keeps Mantine notification onOpen/onClose callbacks in the server registry.\n- Strips those callback fields from payloads emitted to the browser.\n- Adds focused notification tests.\n\nVerification:\n- Worker pushed this branch but did not return a final verification report before stalling; verification should be confirmed during review.