### PR TITLE
Route-local message hydration

### DIFF
--- a/packages/pulse/js/src/client.test.ts
+++ b/packages/pulse/js/src/client.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, mock, vi } from "bun:test";
 import { deserialize, serialize } from "./serialize/serializer";
+import type { Serialized } from "./serialize/serializer";
 
 class FakeSocket {
 	connected = false;
@@ -50,6 +51,9 @@ const view = {
 	onUpdate: vi.fn(),
 	onJsExec: vi.fn(),
 	onServerError: vi.fn(),
+	deserializeMessage: vi.fn((data: Serialized) =>
+		deserialize(data, { coerceNullsToUndefined: true }),
+	),
 };
 
 async function makeClient() {
@@ -126,5 +130,136 @@ describe("PulseSocketIOClient attach ack", () => {
 			"attach",
 			"detach",
 		]);
+	});
+
+	it("deserializes js_exec with the owning view deserializer", async () => {
+		const renderNode = vi.fn(() => "route-a-node");
+		const client = await makeClient();
+		const connected = client.connect();
+		const viewA = {
+			...view,
+			onJsExec: vi.fn(),
+			deserializeMessage: vi.fn((data: Serialized) =>
+				deserialize(data, {
+					coerceNullsToUndefined: true,
+					renderer: { renderNode },
+				}),
+			),
+		};
+		const viewB = {
+			...view,
+			deserializeMessage: vi.fn(() => {
+				throw new Error("wrong view");
+			}),
+		};
+		client.attach("/a", viewA);
+		client.attach("/b", viewB);
+		socket.trigger("connect");
+		await connected;
+
+		socket.trigger("message", [
+			[[], [], [], [], [12]],
+			{
+				type: "js_exec",
+				path: "/a",
+				id: "exec-1",
+				expr: {
+					t: "call",
+					callee: { t: "ref", key: "fn" },
+					args: [
+						{
+							t: "lit",
+							value: {
+								tag: "$$RouteOnly",
+								props: { label: "A" },
+								children: [],
+							},
+						},
+					],
+				},
+			},
+		] satisfies Serialized);
+
+		expect(viewA.deserializeMessage).toHaveBeenCalledTimes(1);
+		expect(viewB.deserializeMessage).not.toHaveBeenCalled();
+		expect(viewA.onJsExec.mock.calls[0]![0].expr.args[0].value).toBe("route-a-node");
+		expect(renderNode).toHaveBeenCalledWith(
+			expect.objectContaining({ tag: "$$RouteOnly" }),
+		);
+	});
+
+	it("deserializes route-bound channel messages with the owning view deserializer", async () => {
+		const renderNode = vi.fn(() => "route-a-node");
+		const client = await makeClient();
+		const connected = client.connect();
+		const viewA = {
+			...view,
+			deserializeMessage: vi.fn((data: Serialized) =>
+				deserialize(data, {
+					coerceNullsToUndefined: true,
+					renderer: { renderNode },
+				}),
+			),
+		};
+		const viewB = {
+			...view,
+			deserializeMessage: vi.fn(() => {
+				throw new Error("wrong view");
+			}),
+		};
+		client.attach("/a", viewA);
+		client.attach("/b", viewB);
+		const bridge = client.acquireChannel("chan-1");
+		const handler = vi.fn();
+		bridge.on("ping", handler);
+		socket.trigger("connect");
+		await connected;
+
+		socket.trigger("message", [
+			[[], [], [], [], [6]],
+			{
+				type: "channel_message",
+				path: "/a",
+				channel: "chan-1",
+				event: "ping",
+				payload: {
+					content: {
+						tag: "$$RouteOnly",
+						props: { label: "A" },
+						children: [],
+					},
+				},
+			},
+		] satisfies Serialized);
+
+		expect(viewA.deserializeMessage).toHaveBeenCalledTimes(1);
+		expect(viewB.deserializeMessage).not.toHaveBeenCalled();
+		expect(handler).toHaveBeenCalledWith({ content: "route-a-node" });
+	});
+
+	it("drops unroutable channel messages with pulse nodes", async () => {
+		const client = await makeClient();
+		const connected = client.connect();
+		const bridge = client.acquireChannel("chan-1");
+		const handler = vi.fn();
+		bridge.on("ping", handler);
+		socket.trigger("connect");
+		await connected;
+
+		socket.trigger("message", [
+			[[], [], [], [], [5]],
+			{
+				type: "channel_message",
+				channel: "chan-1",
+				event: "ping",
+				payload: {
+					tag: "$$RouteOnly",
+					props: { label: "A" },
+					children: [],
+				},
+			},
+		] satisfies Serialized);
+
+		expect(handler).not.toHaveBeenCalled();
 	});
 });

--- a/packages/pulse/js/src/client.tsx
+++ b/packages/pulse/js/src/client.tsx
@@ -15,7 +15,7 @@ import type {
 } from "./messages";
 import type { PulsePrerenderView } from "./pulse";
 import { extractEvent } from "./serialize/events";
-import { deserialize, serialize } from "./serialize/serializer";
+import { deserialize, serialize, type Serialized } from "./serialize/serializer";
 import type { VDOMUpdate } from "./vdom";
 
 
@@ -35,6 +35,7 @@ export interface MountedView {
 	onUpdate: (ops: VDOMUpdate[]) => void;
 	onJsExec: (msg: ServerJsExecMessage) => void;
 	onServerError: (error: ServerError) => void;
+	deserializeMessage: (data: Serialized) => ServerMessage;
 }
 export type ConnectionStatus = "ok" | "connecting" | "reconnecting" | "error";
 export type ConnectionStatusListener = (status: ConnectionStatus) => void;
@@ -198,9 +199,7 @@ export class PulseSocketIOClient {
 			});
 
 			// Wrap in an arrow function to avoid losing the `this` reference
-			socket.on("message", (data) =>
-				this.#handleServerMessage(deserialize(data, { coerceNullsToUndefined: true })),
-			);
+			socket.on("message", (data) => this.#handleSerializedServerMessage(data));
 		});
 	}
 
@@ -515,6 +514,97 @@ export class PulseSocketIOClient {
 		}
 	}
 
+	#handleSerializedServerMessage(data: Serialized): void {
+		const raw = this.#serializedPayloadObject(data);
+		if (raw) {
+			const type = raw.type;
+			if (type === "js_exec") {
+				this.#handleSerializedJsExec(data, raw);
+				return;
+			}
+			if (type === "channel_message") {
+				if (this.#handleSerializedChannelMessage(data, raw)) {
+					return;
+				}
+			}
+		}
+		this.#handleServerMessage(deserialize(data, { coerceNullsToUndefined: true }));
+	}
+
+	#handleSerializedJsExec(data: Serialized, raw: Record<string, unknown>): void {
+		const path = raw.path;
+		if (typeof path !== "string") {
+			return;
+		}
+		const view = this.#activeViews.get(path);
+		if (!view) {
+			if (typeof raw.id === "string") this.#sendJsResult(raw.id, undefined, null);
+			return;
+		}
+		this.#handleServerMessage(this.#deserializeForView(data, view, "js_exec", path));
+	}
+
+	#handleSerializedChannelMessage(
+		data: Serialized,
+		raw: Record<string, unknown>,
+	): boolean {
+		const path = raw.path;
+		if (typeof path === "string") {
+			const view = this.#activeViews.get(path);
+			if (!view) {
+				if (typeof raw.channel === "string") {
+					this.#dropChannel(
+						raw.channel,
+						new PulseChannelResetError("Channel view is no longer active"),
+					);
+				}
+				return true;
+			}
+			this.#handleServerMessage(
+				this.#deserializeForView(data, view, "channel_message", path),
+			);
+			return true;
+		}
+		if (this.#hasPulseNodes(data)) {
+			if (typeof raw.channel === "string") {
+				this.#dropChannel(
+					raw.channel,
+					new PulseChannelResetError(
+						"Route-bound channel message is missing an active view path",
+					),
+				);
+			}
+			return true;
+		}
+		return false;
+	}
+
+	#deserializeForView(
+		data: Serialized,
+		view: MountedView,
+		type: string,
+		path: string,
+	): ServerMessage {
+		try {
+			return view.deserializeMessage(data);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new Error(`[Pulse] Failed to deserialize ${type} for path '${path}': ${message}`);
+		}
+	}
+
+	#serializedPayloadObject(data: Serialized): Record<string, unknown> | null {
+		const raw = data[1];
+		if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+			return null;
+		}
+		return raw as Record<string, unknown>;
+	}
+
+	#hasPulseNodes(data: Serialized): boolean {
+		return data[0][4].length > 0;
+	}
+
 	#sendAttach(path: string, routeInfo: RouteInfo, socket?: Socket): void {
 		const attachId = `${path}:${++this.#nextAttachId}`;
 		this.#activeAttachIds.set(path, attachId);
@@ -557,6 +647,13 @@ export class PulseSocketIOClient {
 		for (const message of queue) {
 			this.sendMessage(message);
 		}
+	}
+
+	#dropChannel(id: string, reason: PulseChannelResetError): void {
+		const entry = this.#channels.get(id);
+		if (!entry) return;
+		this.#channels.delete(id);
+		entry.bridge.dispose(reason);
 	}
 
 	_ensureChannelEntry(id: string): {

--- a/packages/pulse/js/src/messages.ts
+++ b/packages/pulse/js/src/messages.ts
@@ -43,6 +43,7 @@ export interface ServerApiCallMessage {
 
 export interface ServerChannelRequestMessage {
 	type: "channel_message";
+	path?: string;
 	channel: string;
 	event: string;
 	payload?: any;
@@ -53,6 +54,7 @@ export interface ServerChannelRequestMessage {
 
 export interface ServerChannelResponseMessage {
 	type: "channel_message";
+	path?: string;
 	channel: string;
 	event?: undefined;
 	responseTo: string;

--- a/packages/pulse/js/src/pulse.tsx
+++ b/packages/pulse/js/src/pulse.tsx
@@ -13,6 +13,7 @@ import { type ConnectionStatus, type Directives, PulseSocketIOClient } from "./c
 import type { RouteInfo } from "./helpers";
 import type { ServerError } from "./messages";
 import { VDOMRenderer } from "./renderer";
+import { deserialize } from "./serialize/serializer";
 import type { VDOM } from "./vdom";
 
 // =================================================================
@@ -221,6 +222,8 @@ export function PulseView({ path, registry }: PulseViewProps) {
 					client.sendJsResult(msg.id, result, error);
 				},
 				onServerError: setServerError,
+				deserializeMessage: (data) =>
+					deserialize(data, { coerceNullsToUndefined: true, renderer }),
 			});
 			return () => {
 				renderer.clearPendingCallbacks();

--- a/packages/pulse/python/src/pulse/channel.py
+++ b/packages/pulse/python/src/pulse/channel.py
@@ -344,6 +344,11 @@ class ChannelsManager:
 		channel: "Channel",
 		msg: ServerChannelMessage,
 	) -> None:
+		if channel.route_path is not None and "path" not in msg:
+			msg = cast(
+				ServerChannelMessage,
+				cast(object, {**msg, "path": channel.route_path}),
+			)
 		self._render_session.send(msg)
 
 

--- a/packages/pulse/python/src/pulse/messages.py
+++ b/packages/pulse/python/src/pulse/messages.py
@@ -76,6 +76,7 @@ class ServerApiCallMessage(TypedDict):
 
 class ServerChannelRequestMessage(TypedDict):
 	type: Literal["channel_message"]
+	path: NotRequired[str]
 	channel: str
 	event: str
 	payload: Any
@@ -85,6 +86,7 @@ class ServerChannelRequestMessage(TypedDict):
 
 class ServerChannelResponseMessage(TypedDict):
 	type: Literal["channel_message"]
+	path: NotRequired[str]
 	channel: str
 	event: None
 	responseTo: str

--- a/packages/pulse/python/tests/test_channels.py
+++ b/packages/pulse/python/tests/test_channels.py
@@ -49,6 +49,39 @@ async def test_channel_emit_sends_message():
 	assert message["payload"] == {"values": {"a": 1}}
 
 
+def test_route_bound_channel_emit_includes_path():
+	@ps.component
+	def view():
+		return ps.div()
+
+	app = ps.App([ps.Route("/", view)])
+	render = DummyRender()
+	session = SimpleNamespace(sid="session-route")
+
+	real_render = ps.RenderSession(render.id, app.routes)
+	real_render.send = render.send  # pyright: ignore[reportAttributeAccessIssue]
+
+	with ps.PulseContext(
+		app=app,
+		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
+		render=real_render,
+	):
+		real_render.prerender(["/"])
+		real_render.attach("/", app.routes.find("/").default_route_info())
+		mount = real_render.get_route_mount("/")
+		with ps.PulseContext.update(route=mount.route):
+			channel = real_render.channels.create("route-channel")
+			channel.emit("setValues", {"values": {"a": 1}})
+
+	assert len(render.sent) == 1
+	message = render.sent[0]
+	assert message["type"] == "channel_message"
+	assert message["path"] == "/"
+	assert message["channel"] == "route-channel"
+	assert message["event"] == "setValues"
+	assert message["payload"] == {"values": {"a": 1}}
+
+
 @pytest.mark.asyncio
 async def test_channel_request_resolves_on_response():
 	app = ps.App()


### PR DESCRIPTION
Stacked on #86.\n\nSummary:\n- Deserializes route-bound js_exec/channel_message payloads with the owning PulseView renderer/registry.\n- Adds optional path metadata for route-bound channel messages.\n- Adds client/channel tests for route-local hydration behavior.\n\nVerification:\n- Worker pushed this branch but did not return a final verification report before stalling; verification should be confirmed during review.