### PR TITLE
Docs, readmes, and skill updates for channel/renderable API changes

### DIFF
--- a/docs/content/docs/(core)/advanced/channels.mdx
+++ b/docs/content/docs/(core)/advanced/channels.mdx
@@ -93,7 +93,7 @@ The notification appears instantly for the user, without them clicking anything.
 
 ## Creating a channel
 
-Create a channel inside a component using `ps.channel()`. Each channel is automatically scoped to the current user session and route.
+Create a channel inside a component using `ps.channel()`. Each channel is tied to the current user session. Browser views subscribe to it when they render a client component that calls `usePulseChannel(channel.id)`.
 
 ```python
 import pulse as ps
@@ -106,7 +106,7 @@ def ChatRoom():
     # ... rest of component
 ```
 
-The string argument (`"chat"`) is an identifier that helps with debugging. If you don't provide one, Pulse generates a UUID automatically. The channel is cleaned up automatically when the component unmounts or the user navigates away.
+The string argument (`"chat"`) is an identifier that helps with debugging. If you don't provide one, Pulse generates a UUID automatically. The channel is cleaned up automatically when the owning route mount unmounts.
 
 ## Handling events from the client
 
@@ -163,6 +163,8 @@ from pulse.js.pulse import usePulseChannel
 @ps.javascript(jsx=True)
 def ChatClient(*, channelId: str):
     bridge = usePulseChannel(channelId)
+    if bridge is None:
+        return None
 
     # Listen for events from the server
     def on_new_message(payload):
@@ -188,11 +190,13 @@ The `usePulseChannel` hook returns a bridge object with three methods:
 - `emit(event, payload)` - Send events to the server (fire-and-forget)
 - `request(event, payload)` - Send a request and await the server's response
 
+Channel payloads can include Pulse renderable values. When a renderable value is sent through a route-owned channel, Pulse hydrates it with that route's client component registry.
+
 ## Channel lifecycle
 
-Channels are tied to the route where they're created. When the user navigates to a different route, the channel closes automatically and resources are cleaned up. This prevents memory leaks and stale connections.
+Channels are one-to-one. `ps.channel()` creates a server-owned channel for the view currently rendering, and `usePulseChannel(channel.id)` connects one browser endpoint for that same view. `channel.emit()` and `channel.request()` send to that endpoint only.
 
-If you need a channel that persists across route changes (like a global notification system), create it at a higher level in your component tree, such as in a layout component.
+When the owning view unmounts, Pulse closes every channel created by that route mount. A client release only detaches the browser endpoint; it does not own the server channel lifetime. If you need a channel that persists across route changes, create it from a layout that stays mounted.
 
 You can also close a channel manually when you're done with it:
 

--- a/docs/content/docs/(core)/advanced/index.mdx
+++ b/docs/content/docs/(core)/advanced/index.mdx
@@ -7,7 +7,7 @@ This section covers advanced topics for building more sophisticated Pulse applic
 
 ## Topics
 
-- **[Channels](/docs/advanced/channels)** - Real-time communication between server and client, broadcasting updates to multiple users
+- **[Channels](/docs/advanced/channels)** - Real-time communication between a server view and its browser endpoint
 - **[JS Interop](/docs/advanced/js-interop)** - Run JavaScript in the browser, integrate with third-party libraries
 - **[Custom Hooks](/docs/advanced/custom-hooks)** - Create reusable hooks with lifecycle control and automatic cleanup
 - **[Middleware](/docs/advanced/middleware)** - Intercept requests, add authentication, modify behavior globally

--- a/docs/content/docs/(core)/cookbook/advanced-patterns/chat-channels.mdx
+++ b/docs/content/docs/(core)/cookbook/advanced-patterns/chat-channels.mdx
@@ -37,7 +37,7 @@ class ChatState(ps.State):
         """Handle incoming message from client."""
         msg = Message(user=payload["user"], text=payload["text"])
         self.messages.append(msg)
-        # Broadcast to all connected clients
+        # Send to the connected client endpoint
         self.channel.emit("new_message", {"user": msg.user, "text": msg.text})
 
     def send_notification(self, text: str):
@@ -69,6 +69,9 @@ useEffect = ps.Import("useEffect", "react")
 @ps.javascript(jsx=True)
 def ChatClient(*, channelId: str):
     bridge = usePulseChannel(channelId)
+    if bridge is None:
+        return None
+
     messages, setMessages = useState([])
     inputText, setInputText = useState("")
 
@@ -108,11 +111,11 @@ def ChatClient(*, channelId: str):
 
 ## How it works
 
-- `ps.channel()` creates a bidirectional channel scoped to the current user session
+- `ps.channel()` creates a bidirectional channel owned by the current rendered view
 - `channel.on(event, handler)` registers a handler for client events
-- `channel.emit(event, payload)` sends fire-and-forget messages to the client
-- `usePulseChannel(id)` connects the client to the channel
-- Channels are automatically cleaned up when the component unmounts
+- `channel.emit(event, payload)` sends fire-and-forget messages to the connected client endpoint
+- `usePulseChannel(id)` connects the browser endpoint to the channel
+- Channels are automatically cleaned up when the owning route mount unmounts
 
 ## Request-response pattern
 

--- a/docs/content/docs/(core)/glossary.mdx
+++ b/docs/content/docs/(core)/glossary.mdx
@@ -205,8 +205,8 @@ Sending a message/event through a channel (fire-and-forget). The sender doesn't 
 **Subscribe / Listen**
 Registering to receive messages on a channel. When events arrive, your handler function runs.
 
-**Broadcast**
-Sending a message to all connected clients, not just one. Used for features like live notifications or collaborative editing.
+**Connected endpoint**
+The browser-side bridge connected to a server-owned channel. Channel messages are delivered to this endpoint.
 
 ## JavaScript Interop
 

--- a/docs/content/docs/(core)/tutorial/13-channels.mdx
+++ b/docs/content/docs/(core)/tutorial/13-channels.mdx
@@ -2,218 +2,114 @@
 title: "Channels"
 ---
 
-Sometimes your app needs to update in real-time. A chat application needs to show new messages instantly. A collaborative document editor needs to sync changes between users. A live dashboard needs to display fresh data as it arrives. Channels are Pulse's answer to these real-time communication needs.
+Channels let a server-rendered view and its browser endpoint exchange messages in real time. Use them when normal state updates are not enough, like client-side measurements, browser APIs, live progress, or server-initiated notifications.
 
-Channels let you send messages between the server and connected clients, and even between clients, all in real-time over WebSockets.
+## Create a channel
 
-## What Are Channels?
-
-A channel is like a chat room for your app. Clients can join a channel, send messages to it, and receive messages from it. You define what happens when messages arrive by writing handlers on the server.
-
-Think of it this way:
-- **State** is for data that belongs to one user's session
-- **Channels** are for data that needs to flow between multiple users or from server to clients in real-time
-
-## Creating a Channel
-
-Define a channel with `ps.channel()` and add handlers for different message types:
+Create the channel while rendering the view, then pass its ID to a client component.
 
 ```python
 import pulse as ps
+from pulse.js.pulse import usePulseChannel
 
-# Create a channel named "notifications"
-notifications = ps.channel("notifications")
-
-
-@notifications.on("subscribe")
-def on_subscribe(payload):
-    """Called when a client joins the channel."""
-    print(f"A user subscribed to notifications")
-
-
-@notifications.on("unsubscribe")
-def on_unsubscribe(payload):
-    """Called when a client leaves the channel."""
-    print(f"A user left the notifications channel")
-```
-
-The channel name ("notifications" here) is how clients will reference this channel.
-
-## Broadcasting Messages
-
-The real power of channels is broadcasting: sending a message to everyone subscribed to the channel.
-
-```python
-@notifications.on("new_alert")
-def on_new_alert(payload):
-    """When we receive an alert, broadcast it to all subscribers."""
-    # payload contains whatever the sender included
-    message = payload.get("message", "New notification!")
-
-    # Send to everyone in this channel
-    notifications.broadcast("alert", {"message": message, "time": "now"})
-```
-
-You can also broadcast from anywhere in your code, like from an event handler:
-
-```python
-class AdminState(ps.State):
-    def send_announcement(self, message: str):
-        # This reaches all users subscribed to the notifications channel
-        notifications.broadcast("announcement", {
-            "message": message,
-            "from": "Admin"
-        })
-```
-
-## Building a Simple Chat
-
-Let's put it together with a chat example. This shows how multiple users can communicate in real-time:
-
-```python
-import pulse as ps
-
-# Create the chat channel
-chat = ps.channel("chat")
-
-
-@chat.on("message")
-def on_chat_message(payload):
-    """When someone sends a message, broadcast it to everyone."""
-    username = payload.get("username", "Anonymous")
-    text = payload.get("text", "")
-
-    # Broadcast to all connected clients
-    chat.broadcast("new_message", {
-        "username": username,
-        "text": text,
-    })
+useEffect = ps.Import("useEffect", "react")
+useState = ps.Import("useState", "react")
 
 
 class ChatState(ps.State):
-    messages: list[dict] = []
-    username: str = ""
-    current_message: str = ""
+    messages: list[str]
+    channel: ps.Channel
 
-    def send_message(self):
-        if self.current_message.strip():
-            # Send to the channel (this triggers on_chat_message above)
-            chat.send("message", {
-                "username": self.username or "Anonymous",
-                "text": self.current_message,
-            })
-            self.current_message = ""
+    def __init__(self):
+        self.messages = []
+        self.channel = ps.channel()
+        self._cleanup = self.channel.on("client:message", self._on_message)
+
+    def _on_message(self, payload: dict):
+        text = payload["text"]
+        self.messages.append(text)
+        self.channel.emit("server:message", {"text": text})
+
+    def on_dispose(self):
+        self._cleanup()
+
+
+@ps.javascript(jsx=True)
+def ChatClient(*, channelId: str):
+    bridge = usePulseChannel(channelId)
+    if bridge is None:
+        return None
+
+    messages, setMessages = useState([])
+    draft, setDraft = useState("")
+
+    def subscribe():
+        def on_message(payload):
+            setMessages(lambda prev: [*prev, payload["text"]])
+
+        return bridge.on("server:message", on_message)
+
+    useEffect(subscribe, [bridge])
+
+    def send():
+        if draft.strip():
+            bridge.emit("client:message", {"text": draft})
+            setDraft("")
+
+    return ps.div()[
+        ps.ul([ps.li(message, key=i) for i, message in enumerate(messages)]),
+        ps.input(value=draft, onChange=lambda e: setDraft(e.target.value)),
+        ps.button("Send", onClick=send),
+    ]
 
 
 @ps.component
 def chat_room():
     with ps.init():
-        st = ChatState()
+        state = ChatState()
 
-    return ps.div(className="max-w-lg mx-auto p-4")[
-        ps.h1("Chat Room", className="text-2xl font-bold mb-4"),
-
-        # Username input
-        ps.input(
-            value=st.username,
-            onChange=lambda e: setattr(st, "username", e["target"]["value"]),
-            placeholder="Your name",
-            className="w-full border rounded px-3 py-2 mb-4",
-        ),
-
-        # Messages display
-        ps.div(className="border rounded p-4 h-64 overflow-y-auto mb-4")[
-            ps.For(
-                st.messages,
-                lambda msg: ps.div(className="mb-2")[
-                    ps.span(f"{msg['username']}: ", className="font-bold"),
-                    ps.span(msg['text']),
-                ],
-            ),
-        ],
-
-        # Message input
-        ps.div(className="flex gap-2")[
-            ps.input(
-                value=st.current_message,
-                onChange=lambda e: setattr(st, "current_message", e["target"]["value"]),
-                placeholder="Type a message...",
-                className="flex-1 border rounded px-3 py-2",
-            ),
-            ps.button(
-                "Send",
-                onClick=st.send_message,
-                className="bg-blue-500 text-white px-4 py-2 rounded",
-            ),
-        ],
+    return ps.div()[
+        ps.h1("Chat"),
+        ChatClient(channelId=state.channel.id),
     ]
 ```
 
-## Listening to Channel Messages on the Client
+You should now see messages appear as soon as the server echoes them back through the channel.
 
-To receive channel messages in your component, you need to subscribe to the channel from the JavaScript side. Pulse provides a `usePulseChannel` hook for this:
+## How it works
 
-```javascript
-// In your React/client code
-import { usePulseChannel } from "pulse-js";
+`ps.channel()` creates a server-owned channel for the view currently rendering. `usePulseChannel(channel.id)` connects one browser endpoint for that same view.
 
-function ChatMessages() {
-  const [messages, setMessages] = useState([]);
+The bridge has three methods:
 
-  usePulseChannel("chat", {
-    onMessage: (event, payload) => {
-      if (event === "new_message") {
-        setMessages(prev => [...prev, payload]);
-      }
-    }
-  });
+- `bridge.emit(event, payload)` sends an event to the server
+- `bridge.on(event, handler)` listens for events from the server
+- `bridge.request(event, payload)` sends an event and waits for a response
 
-  return (
-    <div>
-      {messages.map((msg, i) => (
-        <div key={i}>{msg.username}: {msg.text}</div>
-      ))}
-    </div>
-  );
-}
+Channels are one-to-one. If you need to fan messages out to multiple users, keep track of the per-user channels you want to notify and emit to each one.
+
+## Request-response
+
+Use `request()` when the server needs a browser value.
+
+```python
+async def read_viewport(channel: ps.Channel):
+    try:
+        return await channel.request("client:viewport", timeout=5.0)
+    except ps.ChannelTimeout:
+        return None
 ```
 
-If you're working purely in Python and want to handle incoming channel messages, you can use the `pulse.js.pulse` utilities or set up effects that respond to channel state.
+```python
+def subscribe():
+    def on_viewport(_payload):
+        return {"width": window.innerWidth, "height": window.innerHeight}
 
-## Channel Use Cases
-
-Channels are perfect for:
-
-- **Chat and messaging**: Real-time conversations between users
-- **Live notifications**: Alerts that appear instantly when something happens
-- **Collaborative editing**: Syncing changes between multiple users
-- **Live dashboards**: Pushing new data to all viewers simultaneously
-- **Gaming**: Real-time game state updates
-- **Presence**: Showing who's online or viewing a page
-
-## Broadcasting vs. Sending
-
-There's an important distinction:
-
-- **`channel.broadcast(event, payload)`**: Sends to ALL subscribed clients
-- **`channel.send(event, payload)`**: Sends to a specific client (the one that triggered the handler)
-
-Use broadcast when everyone should see something (a new chat message). Use send when only one user should see it (a private notification).
-
-## Tips for Working with Channels
-
-1. **Keep payloads small**: Channels are for real-time updates, not large data transfers.
-
-2. **Use meaningful event names**: `"new_message"` is clearer than `"msg"`.
-
-3. **Handle reconnections**: Users might disconnect and reconnect. Consider what state they need to catch up on.
-
-4. **Combine with state**: Channels deliver real-time updates, but your components still need state to store and display that data.
-
-5. **Think about scale**: Broadcasting to thousands of users is different from a small chat room. Design accordingly.
+    return bridge.on("client:viewport", on_viewport)
+```
 
 ## See also
 
 - [Advanced: Channels](/docs/advanced/channels)
 - [Reference: Channels](/docs/reference/pulse/channels)
-- [Reference: Pulse Client](/docs/reference/pulse-js/pulse-client)
+- [Reference: Pulse Client hooks](/docs/reference/pulse-client/hooks)

--- a/docs/content/docs/packages/pulse-js-client.mdx
+++ b/docs/content/docs/packages/pulse-js-client.mdx
@@ -90,6 +90,7 @@ import { usePulseChannel } from "pulse-client";
 
 function Chat() {
   const channel = usePulseChannel("chat");
+  if (!channel) return null;
 
   channel.on("new_message", (msg) => {
     // Handle incoming message
@@ -144,6 +145,7 @@ const data = deserialize(wire);
 **Hooks:**
 - `usePulseClient()` - Access the client instance
 - `usePulseChannel(name)` - Real-time messaging
+- `usePulseChannelManager()` - Advanced dynamic channel acquisition
 
 **Functions:**
 - `serialize` - Convert data for wire transfer

--- a/docs/content/docs/reference/pulse-client/classes.mdx
+++ b/docs/content/docs/reference/pulse-client/classes.mdx
@@ -11,7 +11,7 @@ Core classes for Pulse client functionality.
 
 ## ChannelBridge
 
-Manages bidirectional communication over a Pulse channel. You get a ChannelBridge instance from the `usePulseChannel` hook.
+Manages bidirectional communication over a Pulse channel. You get a ChannelBridge instance from the `usePulseChannel` hook after it connects, or from a `usePulseChannelManager()` lease.
 
 ```ts
 class ChannelBridge {
@@ -50,6 +50,7 @@ emit(event: string, payload?: any): void
 
 ```ts
 const channel = usePulseChannel("notifications");
+if (!channel) return;
 
 // Notify server of user activity (no response expected)
 channel.emit("user_active", { page: "/dashboard" });
@@ -79,6 +80,7 @@ request(event: string, payload?: any): Promise<any>
 
 ```ts
 const channel = usePulseChannel("api");
+if (!channel) return;
 
 // Fetch data from server
 const users = await channel.request("get_users", { limit: 10 });
@@ -114,6 +116,8 @@ const channel = usePulseChannel("notifications");
 
 // Subscribe to events
 useEffect(() => {
+  if (!channel) return;
+
   const unsubscribe = channel.on("notification", (data) => {
     showToast(data.message);
   });
@@ -123,6 +127,8 @@ useEffect(() => {
 
 // Handle server requests
 useEffect(() => {
+  if (!channel) return;
+
   return channel.on("confirm_action", async (data) => {
     const confirmed = await showConfirmDialog(data.message);
     return { confirmed };
@@ -147,6 +153,8 @@ function LiveAuction({ auctionId }: { auctionId: string }) {
 
   // Listen for bid updates
   useEffect(() => {
+    if (!channel) return;
+
     return channel.on("bid_update", (data) => {
       setCurrentBid(data.amount);
     });
@@ -154,6 +162,8 @@ function LiveAuction({ auctionId }: { auctionId: string }) {
 
   // Place a bid
   const placeBid = async (amount: number) => {
+    if (!channel) return;
+
     try {
       const result = await channel.request("place_bid", { amount });
       if (!result.success) {

--- a/docs/content/docs/reference/pulse-client/hooks.mdx
+++ b/docs/content/docs/reference/pulse-client/hooks.mdx
@@ -105,7 +105,7 @@ Hook to subscribe to a Pulse channel for bidirectional communication. Channels e
 ```ts
 import { usePulseChannel } from "pulse-ui-client";
 
-function usePulseChannel(channelId: string): ChannelBridge
+function usePulseChannel(channelId: string): ChannelBridge | null
 ```
 
 ### Parameters
@@ -116,22 +116,23 @@ function usePulseChannel(channelId: string): ChannelBridge
 
 ### Returns
 
-Returns a `ChannelBridge` instance for sending and receiving messages.
+Returns a `ChannelBridge` instance for sending and receiving messages, or `null` before the subscription effect has run.
 
 ### Throws
 
 - Throws if `channelId` is empty
 - Throws if used outside of a `PulseProvider`
+- Throws if used outside of a `PulseView`
 
 ### Lifecycle
 
 The hook manages channel subscription automatically:
 
-1. On mount: acquires a reference to the channel
-2. On unmount: releases the reference
-3. When all references are released: channel closes
+1. On mount: acquires the channel for the current `PulseView`
+2. Before the effect runs: returns `null`
+3. On unmount: releases the client endpoint
 
-Multiple components can subscribe to the same channel. The channel stays open as long as at least one component is subscribed.
+Channels are one-to-one. A channel ID can be acquired by one client endpoint at a time.
 
 ### Example: Chat Room
 
@@ -150,6 +151,8 @@ function ChatRoom({ roomId }: { roomId: string }) {
   const [messages, setMessages] = useState<Message[]>([]);
 
   useEffect(() => {
+    if (!channel) return;
+
     // Listen for new messages
     const unsubscribe = channel.on("message", (msg: Message) => {
       setMessages((prev) => [...prev, msg]);
@@ -159,6 +162,7 @@ function ChatRoom({ roomId }: { roomId: string }) {
   }, [channel]);
 
   const sendMessage = (text: string) => {
+    if (!channel) return;
     channel.emit("message", { text });
   };
 
@@ -192,6 +196,8 @@ function UserSearch() {
   const [loading, setLoading] = useState(false);
 
   const search = async (query: string) => {
+    if (!channel) return;
+
     setLoading(true);
     try {
       const users = await channel.request("search", { query });
@@ -214,6 +220,43 @@ function UserSearch() {
   );
 }
 ```
+
+---
+
+## usePulseChannelManager
+
+Hook to acquire channels dynamically while still using the current `PulseView` path and React cleanup lifecycle.
+
+```ts
+import { usePulseChannelManager } from "pulse-ui-client";
+
+function usePulseChannelManager(): PulseChannelManager
+```
+
+### Returns
+
+Returns a manager with:
+
+```ts
+type PulseChannelManager = {
+  acquire(channelId: string): {
+    bridge: ChannelBridge;
+    release(): void;
+  };
+  dispose(): void;
+};
+```
+
+Use this for advanced integrations that do not know every channel ID upfront. Normal components should prefer `usePulseChannel(channelId)`.
+
+### Throws
+
+- Throws if used outside of a `PulseProvider`
+- Throws if used outside of a `PulseView`
+
+### Lifecycle
+
+Each `acquire()` call returns a lease. Call `release()` when that lease is no longer needed. `release()` is safe to call more than once. Any leases that are still open are released automatically when the owning component unmounts.
 
 ---
 

--- a/docs/content/docs/reference/pulse/channels.mdx
+++ b/docs/content/docs/reference/pulse/channels.mdx
@@ -13,7 +13,7 @@ Bidirectional communication channels for real-time messaging between server and 
 def channel(identifier: str | None = None) -> Channel
 ```
 
-Create a channel bound to the current render session.
+Create a channel owned by the current rendered view. The browser view connects to that channel when client code calls `usePulseChannel(channel.id)`.
 
 **Parameters:**
 - `identifier` - Optional channel ID. Auto-generated UUID if not provided.
@@ -27,12 +27,12 @@ import pulse as ps
 
 @ps.component
 def ChatRoom():
-    ch = ps.channel("chat")
+    ch = ps.channel()
 
     @ch.on("message")
     def handle_message(payload):
         # Handle incoming message from client
-        ch.emit("broadcast", payload)
+        ch.emit("echo", payload)
 
     return ps.div("Chat room")
 ```
@@ -51,6 +51,8 @@ Bidirectional communication channel bound to a render session.
 | `render_id` | `str` | Associated render session ID |
 | `session_id` | `str` | Associated user session ID |
 | `route_path` | `str \| None` | Route path this channel is bound to |
+| `mount_id` | `str \| None` | Route mount generation that created the channel |
+| `connected` | `bool` | Whether the owning client endpoint is connected |
 | `closed` | `bool` | Whether the channel is closed |
 
 #### Methods
@@ -92,7 +94,7 @@ Send a fire-and-forget event to the client.
 - `event` - Event name.
 - `payload` - Data to send (optional).
 
-**Raises:** `ChannelClosed` if channel is closed.
+**Raises:** `ChannelClosed` if channel is closed or has no connected client endpoint.
 
 ```python
 ch.emit("notification", {"message": "Hello"})
@@ -120,7 +122,7 @@ Send a request to the client and await the response.
 **Returns:** Response payload from client.
 
 **Raises:**
-- `ChannelClosed` if channel is closed.
+- `ChannelClosed` if channel is closed or has no connected client endpoint.
 - `ChannelTimeout` if request times out.
 
 ```python

--- a/packages/pulse/js/README.md
+++ b/packages/pulse/js/README.md
@@ -106,6 +106,7 @@ import { usePulseChannel } from "pulse-client";
 
 function Chat() {
   const channel = usePulseChannel("chat");
+  if (!channel) return null;
   channel.on("new_message", (msg) => { /* handle */ });
   channel.emit("message", { text: "Hello" });
 }
@@ -115,7 +116,7 @@ function Chat() {
 
 **Components**: `PulseProvider`, `PulseView`, `PulseForm`, `RenderLazy`
 
-**Hooks**: `usePulseClient()`, `usePulseChannel(name)`
+**Hooks**: `usePulseClient()`, `usePulseChannel(name)`, `usePulseChannelManager()`
 
 **Functions**: `serialize`, `deserialize`, `extractServerRouteInfo`, `submitForm`
 

--- a/packages/pulse/python/README.md
+++ b/packages/pulse/python/README.md
@@ -161,7 +161,7 @@ ch = ps.channel("chat")
 
 @ch.on("message")
 def handle_message(data):
-    ch.broadcast("new_message", data)
+    ch.emit("new_message", data)
 ```
 
 ## Main Exports

--- a/skills/pulse/references/channels.md
+++ b/skills/pulse/references/channels.md
@@ -19,7 +19,7 @@ class ChatState(ps.State):
         self._cleanup()
 ```
 
-`ps.channel()` creates a unique channel ID. Pass `channel.id` to client components.
+`ps.channel()` creates a unique channel ID owned by the view currently rendering. Pass `channel.id` to one client component in that view. `usePulseChannel(channel.id)` connects that browser endpoint.
 
 ## Server → Client
 
@@ -28,6 +28,8 @@ class ChatState(ps.State):
 ```python
 self.channel.emit("server:notify", {"type": "update", "data": {...}})
 ```
+
+Channels are one-to-one. Pulse sends each channel message to the connected endpoint for the view that created the channel. Renderable payloads deserialize with that view's component registry.
 
 ### Request (with response)
 
@@ -82,6 +84,8 @@ from pulse.js.pulse import usePulseChannel
 @ps.javascript(jsx=True)
 def ChatClient(*, channelId: str):
     bridge = usePulseChannel(channelId)
+    if bridge is None:
+        return None
 
     # Send event to server
     def sendMessage(text: str):
@@ -135,7 +139,7 @@ class ChatRoom(ps.State):
     def _on_send(self, payload: dict):
         msg = {"user": "User", "text": payload["text"]}
         self.messages.append(msg)
-        # Broadcast to client
+        # Send to the connected client endpoint
         self.channel.emit("server:message", msg)
 
     def on_dispose(self):
@@ -146,6 +150,9 @@ class ChatRoom(ps.State):
 @ps.javascript(jsx=True)
 def ChatWidget(*, channelId: str):
     bridge = usePulseChannel(channelId)
+    if bridge is None:
+        return None
+
     messages, setMessages = useState([])
     draft, setDraft = useState("")
 
@@ -217,9 +224,9 @@ except ps.ChannelClosed:
 
 ## Channel Lifecycle
 
-1. **Created** — `ps.channel()` in State `__init__`
-2. **Active** — While component is mounted
-3. **Closed** — When component unmounts or user disconnects
+1. **Created** — `ps.channel()` during a route render
+2. **Connected** — One browser endpoint calls `usePulseChannel(channel.id)` for that route
+3. **Closed** — The owning route mount unmounts, the render session closes, or server code calls `channel.close()`
 
 Always clean up handlers in `on_dispose()`:
 
@@ -240,6 +247,7 @@ class MyState(ps.State):
 
 ```python
 channel.id      # str — unique channel identifier
+channel.connected  # bool — True if the client endpoint is connected
 channel.closed  # bool — True if channel is closed
 ```
 


### PR DESCRIPTION
## Summary
- Update channel docs, READMEs, and Pulse skill references for one-to-one server-owned channel lifecycle semantics.
- Document `usePulseChannel(): ChannelBridge | null` and `usePulseChannelManager()`.
- Add renderable channel payload notes and remove stale broadcast/multi-subscriber guidance from public docs.

## Verification
- `make format`
- `make sync` after initial Bun test dependency miss
- `make test`
- `bun run --cwd docs types:check`
- `git diff --check`

## Dependencies
Draft until the relevant split stack lands. Depends on #86 for renderable payload serialization, #87 for `usePulseChannelManager()` / nullable channel hook behavior, #89 for explicit channel lifecycle and connected endpoint semantics, #91 for payload cleanup context, and #92 for route-local hydration of renderable channel payloads.