### PR TITLE
Support renderable notification fields

### DIFF
--- a/packages/pulse-mantine/python/src/pulse_mantine/core/feedback/notifications.py
+++ b/packages/pulse-mantine/python/src/pulse_mantine/core/feedback/notifications.py
@@ -179,6 +179,7 @@ def NotificationsInternal(
 
 
 NOTIFICATIONS_CHANNEL_ID = uuid.uuid4().hex
+CLIENT_CALLBACK_KEYS = {"onClose", "onOpen"}
 
 
 class NotificationsStore(ps.State):
@@ -199,7 +200,7 @@ class NotificationsStore(ps.State):
 		existing = self.registry.get(ident)
 		merged = payload if not existing else existing | payload
 		self.registry[ident] = merged
-		self._channel.emit("show", serialize(merged))
+		self._channel.emit("show", client_notification_payload(merged))
 		return ident
 
 	def update(self, kwargs: NotificationData) -> str:
@@ -208,7 +209,7 @@ class NotificationsStore(ps.State):
 		existing = self.registry.get(ident)
 		merged = payload if not existing else existing | payload
 		self.registry[ident] = merged
-		self._channel.emit("update", serialize(merged))
+		self._channel.emit("update", client_notification_payload(merged))
 		return ident
 
 	def hide(self, id: str) -> str:
@@ -246,14 +247,14 @@ class NotificationsStore(ps.State):
 			result = update(current)
 		else:
 			result = update
-		new_notifications: list[NotificationData] = []
+		new_notifications: list[dict[str, Any]] = []
 		for item in result:
 			ident, item = ensure_id(item)
 			self.registry[ident] = item
-			new_notifications.append(item)
+			new_notifications.append(client_notification_payload(item))
 		self._channel.emit(
 			"updateState",
-			{"notifications": [serialize(x) for x in new_notifications]},
+			{"notifications": new_notifications},
 		)
 
 	def _on_state_sync(self, payload: Any) -> None:
@@ -324,8 +325,10 @@ def ensure_id(
 	return ident, cast(NotificationData, value)
 
 
-def serialize(value: NotificationData):
-	return {k: v for k, v in value.items() if k not in ("onClose", "onOpen")}
+def client_notification_payload(value: Mapping[str, Any]) -> dict[str, Any]:
+	return {
+		key: entry for key, entry in value.items() if key not in CLIENT_CALLBACK_KEYS
+	}
 
 
 notifications_state = ps.global_state(NotificationsStore)

--- a/packages/pulse-mantine/python/src/pulse_mantine/core/feedback/notifications.py
+++ b/packages/pulse-mantine/python/src/pulse_mantine/core/feedback/notifications.py
@@ -47,9 +47,9 @@ class NotificationProps(  # pyright: ignore[reportIncompatibleVariableOverride]
 	"""Controls notification line or icon color"""
 	radius: MantineRadius
 	"""Controls notification border radius"""
-	icon: ps.Element
+	icon: ps.Node
 	"""Notification icon, replaces color line"""
-	title: ps.Element  # pyright: ignore[reportIncompatibleVariableOverride]
+	title: ps.Node  # pyright: ignore[reportIncompatibleVariableOverride]
 	"""Notification title, displayed above the message body"""
 	loading: bool
 	"""If set, the Loader component is displayed instead of the icon"""
@@ -149,8 +149,8 @@ NotificationPosition = Literal[
 class NotificationDataWithoutId(NotificationProps, total=False):
 	id: str
 	"""Notification id, can be used to close or update notification"""
-	message: Required[str]
-	"""Main notification message. Real API also supports nodes, but we can't handle that yet."""
+	message: Required[ps.Node]
+	"""Main notification message"""
 	position: NotificationPosition
 	"""Notification position"""
 	autoClose: int | bool

--- a/packages/pulse-mantine/python/tests/test_notifications.py
+++ b/packages/pulse-mantine/python/tests/test_notifications.py
@@ -1,0 +1,108 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pulse as ps
+from pulse.user_session import UserSession
+from pulse_mantine.core.feedback.notifications import NotificationsStore
+
+
+class DummyRender:
+	id: str
+
+	def __init__(self, rid: str = "render-1") -> None:
+		self.id = rid
+		self.sent: list[dict[str, Any]] = []
+
+	def send(self, message: dict[str, Any]):
+		self.sent.append(message)
+
+
+def build_context():
+	app = ps.App()
+	render = DummyRender()
+	session = SimpleNamespace(sid="session-1")
+
+	real_render = ps.RenderSession(render.id, app.routes)
+	real_render.send = render.send  # pyright: ignore[reportAttributeAccessIssue]
+
+	app.render_sessions[render.id] = real_render
+	app._render_to_user[render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
+	app.user_sessions[session.sid] = session  # pyright: ignore[reportArgumentType]
+	return app, render, session, real_render
+
+
+def connect_channel(real_render: ps.RenderSession, channel_id: str) -> None:
+	real_render.channels.handle_client_connect(
+		{"type": "channel_connect", "channel": channel_id, "path": "/"}
+	)
+
+
+def test_notification_show_keeps_callback_server_side():
+	app, render, session, real_render = build_context()
+
+	def on_open(notification: dict[str, Any]) -> None:
+		notification["opened"] = True
+
+	with ps.PulseContext(
+		app=app,
+		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
+		render=real_render,
+	):
+		store = NotificationsStore()
+		connect_channel(real_render, store._channel.id)  # pyright: ignore[reportPrivateUsage]
+		ident = store.show({"message": "Saved", "onOpen": on_open})
+
+	assert store.registry[ident]["onOpen"] is on_open
+	assert render.sent[0]["event"] == "show"
+	assert render.sent[0]["payload"] == {"message": "Saved", "id": ident}
+
+
+def test_notification_update_keeps_callbacks_server_side():
+	app, render, session, real_render = build_context()
+
+	def on_close(notification: dict[str, Any]) -> None:
+		notification["closed"] = True
+
+	with ps.PulseContext(
+		app=app,
+		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
+		render=real_render,
+	):
+		store = NotificationsStore()
+		connect_channel(real_render, store._channel.id)  # pyright: ignore[reportPrivateUsage]
+		store.show({"id": "toast", "message": "Saving"})
+		store.update({"id": "toast", "message": "Saved", "onClose": on_close})
+
+	assert store.registry["toast"]["onClose"] is on_close
+	assert render.sent[1]["event"] == "update"
+	assert render.sent[1]["payload"] == {"id": "toast", "message": "Saved"}
+
+
+def test_notification_update_state_keeps_callbacks_server_side():
+	app, render, session, real_render = build_context()
+
+	def on_close(notification: dict[str, Any]) -> None:
+		notification["closed"] = True
+
+	with ps.PulseContext(
+		app=app,
+		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
+		render=real_render,
+	):
+		store = NotificationsStore()
+		connect_channel(real_render, store._channel.id)  # pyright: ignore[reportPrivateUsage]
+		store.updateState(
+			[
+				{
+					"id": "toast",
+					"message": "Synced",
+					"onClose": on_close,
+				}
+			]
+		)
+
+	assert store.registry["toast"]["onClose"] is on_close
+	assert render.sent[0]["event"] == "updateState"
+	assert render.sent[0]["payload"] == {
+		"notifications": [{"id": "toast", "message": "Synced"}]
+	}

--- a/packages/pulse-mantine/python/tests/test_notifications.py
+++ b/packages/pulse-mantine/python/tests/test_notifications.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 import pulse as ps
+from pulse.serializer import Serialized, serialize
 from pulse.user_session import UserSession
 from pulse_mantine.core.feedback.notifications import NotificationsStore
 
@@ -31,10 +32,36 @@ def build_context():
 	return app, render, session, real_render
 
 
-def connect_channel(real_render: ps.RenderSession, channel_id: str) -> None:
-	real_render.channels.handle_client_connect(
-		{"type": "channel_connect", "channel": channel_id, "path": "/"}
-	)
+def build_route_context():
+	@ps.component
+	def view():
+		return ps.div()
+
+	app = ps.App([ps.Route("/", view)])
+	render = DummyRender()
+	session = SimpleNamespace(sid="session-1")
+
+	real_render = ps.RenderSession(render.id, app.routes)
+	real_render.send = render.send  # pyright: ignore[reportAttributeAccessIssue]
+
+	app.render_sessions[render.id] = real_render
+	app._render_to_user[render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
+	app.user_sessions[session.sid] = session  # pyright: ignore[reportArgumentType]
+
+	with ps.PulseContext(
+		app=app,
+		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
+		render=real_render,
+	):
+		real_render.prerender(["/"])
+		real_render.attach("/", app.routes.find("/").default_route_info())
+	mount = real_render.get_route_mount("/")
+	return app, render, session, real_render, mount
+
+
+def serialize_message(message: dict[str, Any]) -> Serialized:
+	payload = serialize(message)
+	return (payload[0], payload[1])
 
 
 def test_notification_show_keeps_callback_server_side():
@@ -49,7 +76,6 @@ def test_notification_show_keeps_callback_server_side():
 		render=real_render,
 	):
 		store = NotificationsStore()
-		connect_channel(real_render, store._channel.id)  # pyright: ignore[reportPrivateUsage]
 		ident = store.show({"message": "Saved", "onOpen": on_open})
 
 	assert store.registry[ident]["onOpen"] is on_open
@@ -69,7 +95,6 @@ def test_notification_update_keeps_callbacks_server_side():
 		render=real_render,
 	):
 		store = NotificationsStore()
-		connect_channel(real_render, store._channel.id)  # pyright: ignore[reportPrivateUsage]
 		store.show({"id": "toast", "message": "Saving"})
 		store.update({"id": "toast", "message": "Saved", "onClose": on_close})
 
@@ -90,7 +115,6 @@ def test_notification_update_state_keeps_callbacks_server_side():
 		render=real_render,
 	):
 		store = NotificationsStore()
-		connect_channel(real_render, store._channel.id)  # pyright: ignore[reportPrivateUsage]
 		store.updateState(
 			[
 				{
@@ -105,4 +129,114 @@ def test_notification_update_state_keeps_callbacks_server_side():
 	assert render.sent[0]["event"] == "updateState"
 	assert render.sent[0]["payload"] == {
 		"notifications": [{"id": "toast", "message": "Synced"}]
+	}
+
+
+def test_notification_show_serializes_renderable_fields():
+	app, render, session, real_render, mount = build_route_context()
+
+	def on_open(notification: dict[str, Any]) -> None:
+		notification["opened"] = True
+
+	with ps.PulseContext(
+		app=app,
+		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
+		render=real_render,
+		route=mount.route,
+	):
+		store = NotificationsStore()
+		ident = store.show(
+			{
+				"title": ps.span("Upload"),
+				"message": ps.span("Complete"),
+				"icon": ps.span("!"),
+				"onOpen": on_open,
+			}
+		)
+
+	serialized = serialize_message(render.sent[0])
+	meta, payload = serialized
+	assert meta[4]
+	assert store.registry[ident]["onOpen"] is on_open
+	assert payload["path"] == "/"
+	assert payload["payload"] == {
+		"id": ident,
+		"title": {"tag": "span", "children": ["Upload"]},
+		"message": {"tag": "span", "children": ["Complete"]},
+		"icon": {"tag": "span", "children": ["!"]},
+	}
+
+
+def test_notification_update_serializes_renderable_fields():
+	app, render, session, real_render, mount = build_route_context()
+
+	def on_close(notification: dict[str, Any]) -> None:
+		notification["closed"] = True
+
+	with ps.PulseContext(
+		app=app,
+		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
+		render=real_render,
+		route=mount.route,
+	):
+		store = NotificationsStore()
+		store.show({"id": "toast", "message": "Saving"})
+		store.update(
+			{
+				"id": "toast",
+				"title": ps.span("Upload"),
+				"message": ps.span("Complete"),
+				"onClose": on_close,
+			}
+		)
+
+	serialized = serialize_message(render.sent[1])
+	meta, payload = serialized
+	assert meta[4]
+	assert store.registry["toast"]["onClose"] is on_close
+	assert payload["path"] == "/"
+	assert payload["payload"] == {
+		"id": "toast",
+		"title": {"tag": "span", "children": ["Upload"]},
+		"message": {"tag": "span", "children": ["Complete"]},
+	}
+
+
+def test_notification_update_state_serializes_renderable_fields():
+	app, render, session, real_render, mount = build_route_context()
+
+	def on_close(notification: dict[str, Any]) -> None:
+		notification["closed"] = True
+
+	with ps.PulseContext(
+		app=app,
+		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
+		render=real_render,
+		route=mount.route,
+	):
+		store = NotificationsStore()
+		store.updateState(
+			[
+				{
+					"id": "toast",
+					"title": ps.span("Upload"),
+					"message": ps.span("Complete"),
+					"onClose": on_close,
+				}
+			]
+		)
+
+	serialized = serialize_message(render.sent[0])
+	meta, payload = serialized
+	assert meta[4]
+	assert store.registry["toast"]["onClose"] is on_close
+	assert payload["path"] == "/"
+	assert payload["payload"] == {
+		"notifications": [
+			{
+				"id": "toast",
+				"title": {"tag": "span", "children": ["Upload"]},
+				"message": {"tag": "span", "children": ["Complete"]},
+			}
+		]
 	}


### PR DESCRIPTION
Stacked on #92 and includes the notification callback cleanup dependency from #91 as a narrow cherry-pick.\n\nSummary:\n- Allows Mantine notification fields such as title/message to carry Pulse renderable payloads through generic serialization and route-local hydration.\n- Keeps onOpen/onClose callback fields server-side and strips them from client payloads.\n- Adds focused notification tests.\n\nVerification:\n- uv run pytest packages/pulse-mantine/python/tests/test_notifications.py\n- make test\n- make all\n- Browser smoke: uv run pulse run examples/main.py --port 8104 --plain; agent-browser loaded / and navigated to Counter successfully.