### PR TITLE
Channel & serialization cleanup (splits 02–09)

### DIFF
--- a/docs/content/docs/reference/pulse-client/hooks.mdx
+++ b/docs/content/docs/reference/pulse-client/hooks.mdx
@@ -105,7 +105,7 @@ Hook to subscribe to a Pulse channel for bidirectional communication. Channels e
 ```ts
 import { usePulseChannel } from "pulse-ui-client";
 
-function usePulseChannel(channelId: string): ChannelBridge
+function usePulseChannel(channelId: string): ChannelBridge | null
 ```
 
 ### Parameters
@@ -116,22 +116,21 @@ function usePulseChannel(channelId: string): ChannelBridge
 
 ### Returns
 
-Returns a `ChannelBridge` instance for sending and receiving messages.
+Returns `null` during the first render, then a `ChannelBridge` instance after the channel is acquired.
 
 ### Throws
 
 - Throws if `channelId` is empty
 - Throws if used outside of a `PulseProvider`
+- Throws if used outside of a `PulseView`
 
 ### Lifecycle
 
 The hook manages channel subscription automatically:
 
-1. On mount: acquires a reference to the channel
-2. On unmount: releases the reference
-3. When all references are released: channel closes
-
-Multiple components can subscribe to the same channel. The channel stays open as long as at least one component is subscribed.
+1. On mount: acquires the channel for the current `PulseView` path
+2. On unmount: releases the channel lease
+3. When the lease is released: the client bridge closes
 
 ### Example: Chat Room
 
@@ -150,6 +149,8 @@ function ChatRoom({ roomId }: { roomId: string }) {
   const [messages, setMessages] = useState<Message[]>([]);
 
   useEffect(() => {
+    if (!channel) return;
+
     // Listen for new messages
     const unsubscribe = channel.on("message", (msg: Message) => {
       setMessages((prev) => [...prev, msg]);
@@ -159,6 +160,7 @@ function ChatRoom({ roomId }: { roomId: string }) {
   }, [channel]);
 
   const sendMessage = (text: string) => {
+    if (!channel) return;
     channel.emit("message", { text });
   };
 
@@ -192,6 +194,8 @@ function UserSearch() {
   const [loading, setLoading] = useState(false);
 
   const search = async (query: string) => {
+    if (!channel) return;
+
     setLoading(true);
     try {
       const users = await channel.request("search", { query });

--- a/docs/content/docs/reference/pulse-client/serialization.mdx
+++ b/docs/content/docs/reference/pulse-client/serialization.mdx
@@ -5,7 +5,7 @@ description: "Wire format for Pulse client-server communication"
 
 # Serialization
 
-Pulse uses a custom serialization format for WebSocket messages. This format handles JavaScript types that JSON doesn't support natively, like `Date`, `Set`, `Map`, and object references.
+Pulse uses a custom serialization format for WebSocket messages. This format handles JavaScript types that JSON doesn't support natively, like `Date`, `Set`, `Map`, object references, and server-rendered Pulse node payloads.
 
 ---
 
@@ -28,8 +28,8 @@ function serialize(data: Serializable): Serialized
 ### Returns
 
 ```ts
-type Serialized = [[number[], number[], number[], number[]], PlainJSON];
-//                  ^refs     ^dates    ^sets     ^maps     ^payload
+type Serialized = [[number[], number[], number[], number[], number[]], PlainJSON];
+//                  ^refs     ^dates    ^sets     ^maps     ^pulseNodes ^payload
 ```
 
 A tuple containing:
@@ -43,7 +43,7 @@ A tuple containing:
 | `null`, `undefined` | Passed through |
 | `boolean`, `string` | Passed through |
 | `number` | Passed through (NaN becomes null, Infinity throws) |
-| `Date` | Converted to timestamp |
+| `Date` | Converted to an ISO 8601 string |
 | `Array` | Recursively processed |
 | `Set` | Converted to array |
 | `Map` | Converted to object (string keys only) |
@@ -63,7 +63,7 @@ const data = {
 };
 
 const serialized = serialize(data);
-// [[[], [0], [1], [2]], { name: "Alice", createdAt: 1705276800000, tags: ["admin", "active"], metadata: { version: 1 } }]
+// [[[], [2], [3], [6], []], { name: "Alice", createdAt: "2024-01-15T00:00:00.000Z", tags: ["admin", "active"], metadata: { version: 1 } }]
 ```
 
 ### Circular References
@@ -87,7 +87,7 @@ serialize({ value: Infinity });
 
 // NaN is converted to null (with no error)
 serialize({ value: NaN });
-// [[[], [], [], []], { value: null }]
+// [[[], [], [], [], []], { value: null }]
 ```
 
 ---
@@ -114,12 +114,16 @@ function deserialize<T>(payload: Serialized, options?: DeserializationOptions): 
 ```ts
 interface DeserializationOptions {
   coerceNullsToUndefined?: boolean;
+  registry?: ComponentRegistry;
+  renderer?: Pick<VDOMRenderer, "renderNode">;
 }
 ```
 
 | Option | Default | Description |
 |--------|---------|-------------|
 | `coerceNullsToUndefined` | `false` | Convert `null` values to `undefined` |
+| `registry` | `undefined` | Component registry used to render serialized Pulse nodes |
+| `renderer` | `undefined` | Renderer used to render serialized Pulse nodes |
 
 ### Returns
 
@@ -131,10 +135,10 @@ The reconstructed JavaScript value with proper types restored.
 import { deserialize } from "pulse-ui-client";
 
 const serialized: Serialized = [
-  [[], [0], [1], [2]],
+  [[], [2], [3], [6], []],
   {
     name: "Alice",
-    createdAt: 1705276800000,
+    createdAt: "2024-01-15T00:00:00.000Z",
     tags: ["admin", "active"],
     metadata: { version: 1 },
   },
@@ -148,6 +152,16 @@ const data = deserialize(serialized);
 //   metadata: Map([["version", 1]]) // Map restored
 // }
 ```
+
+### Pulse node payloads
+
+Python can serialize Pulse `Element`, `PulseNode`, and VDOM expression payloads inside ordinary data. Those entries are marked in the `pulseNodes` metadata slot. During deserialization, pass either a route registry or renderer so the client can turn the VDOM into React nodes:
+
+```ts
+const data = deserialize(payload, { registry });
+```
+
+If the payload contains Pulse node metadata and you do not pass `registry` or `renderer`, `deserialize()` throws.
 
 ### Null Coercion
 
@@ -173,6 +187,7 @@ type Serialized = [
     number[],  // dates: indices of Date objects
     number[],  // sets: indices of Set objects
     number[],  // maps: indices of Map objects
+    number[],  // pulseNodes: indices of VDOM payloads
   ],
   PlainJSON    // The actual data as JSON
 ];
@@ -180,7 +195,7 @@ type Serialized = [
 
 ### Index Tracking
 
-During serialization, a global counter increments for each visited node. The metadata arrays record which indices are special types:
+During serialization, a global counter increments for each visited payload slot. The metadata arrays record which indices are special types:
 
 ```ts
 // Example: { date: new Date(), items: new Set([1, 2]) }
@@ -190,8 +205,8 @@ During serialization, a global counter increments for each visited node. The met
 
 // Serialized:
 [
-  [[], [1], [2], []],  // dates=[1], sets=[2]
-  { date: 1705276800000, items: [1, 2] }
+  [[], [1], [2], [], []],  // dates=[1], sets=[2]
+  { date: "2024-01-15T00:00:00.000Z", items: [1, 2] }
 ]
 ```
 
@@ -204,7 +219,7 @@ a.ref = b;  // circular
 
 // Serialized:
 [
-  [[3], [], [], []],  // refs=[3] (index 3 is a back-reference)
+  [[4], [], [], [], []],  // refs=[4] (index 4 is a back-reference)
   { name: "a", ref: { name: "b", ref: 0 } }
   //                              ^ references index 0
 ]

--- a/docs/content/docs/reference/pulse-client/types.mdx
+++ b/docs/content/docs/reference/pulse-client/types.mdx
@@ -656,7 +656,7 @@ type MessageListener = (message: ServerMessage) => void;
 Wire format for serialized data.
 
 ```ts
-type Serialized = [[number[], number[], number[], number[]], PlainJSON];
+type Serialized = [[number[], number[], number[], number[], number[]], PlainJSON];
 ```
 
 ### PlainJSON
@@ -676,6 +676,8 @@ Options for deserialization.
 ```ts
 interface DeserializationOptions {
   coerceNullsToUndefined?: boolean;
+  registry?: ComponentRegistry;
+  renderer?: Pick<VDOMRenderer, "renderNode">;
 }
 ```
 

--- a/docs/content/docs/reference/pulse/serializer.mdx
+++ b/docs/content/docs/reference/pulse/serializer.mdx
@@ -3,7 +3,7 @@ title: "Serializer"
 description: "Wire serialization helpers"
 ---
 
-Serialization utilities for converting Python objects to/from wire format. Handles shared references, cycles, dates, sets, and maps.
+Serialization utilities for converting Python objects to/from wire format. Handles shared references, cycles, dates, sets, maps, and Pulse renderable payloads.
 
 ## Functions
 
@@ -25,7 +25,9 @@ Serialize a Python value to wire format.
 **Supported types:**
 - Primitives: `None`, `bool`, `int`, `float`, `str`
 - Collections: `list`, `tuple`, `dict`, `set`
-- `datetime.datetime` (converted to milliseconds since Unix epoch)
+- `datetime.datetime` (converted to UTC ISO 8601 strings)
+- `datetime.date` (converted to ISO date strings)
+- Pulse renderables: `Element`, `PulseNode`, and VDOM `Expr`
 - Dataclasses (serialized as dict of fields)
 - Objects with `__dict__` (public attributes only)
 
@@ -33,6 +35,7 @@ Serialize a Python value to wire format.
 - `NaN` floats serialize as `None`
 - `Infinity` raises `ValueError`
 - Dict keys must be strings
+- Pulse renderables are snapshot-rendered; callbacks and refs are stripped
 - Private attributes (starting with `_`) are excluded from object serialization
 - Shared references and cycles are preserved
 
@@ -65,6 +68,7 @@ Deserialize wire format back to Python values.
 
 **Notes:**
 - `datetime` values are reconstructed as UTC-aware
+- `date` values are reconstructed as `datetime.date`
 - `set` values are reconstructed as Python sets
 - Shared references and cycles are restored
 
@@ -79,11 +83,11 @@ restored = ps.deserialize(serialized)
 ### Serialized
 
 ```python
-Serialized = tuple[tuple[list[int], list[int], list[int], list[int]], PlainJSON]
+Serialized = tuple[tuple[list[int], list[int], list[int], list[int], list[int]], PlainJSON]
 ```
 
 Serialized payload structure:
-- First element: metadata tuple of `(refs, dates, sets, maps)` - lists of indices
+- First element: metadata tuple of `(refs, dates, sets, maps, pulse_nodes)` - lists of indices
 - Second element: JSON-compatible payload
 
 ### PlainJSON
@@ -99,15 +103,16 @@ JSON-compatible type alias.
 The serialized format is a tuple:
 
 ```
-((refs, dates, sets, maps), payload)
+((refs, dates, sets, maps, pulse_nodes), payload)
 ```
 
 - `refs` - Indices where the value is a reference to a previously visited node
-- `dates` - Indices that are `datetime` objects (stored as millisecond timestamps)
+- `dates` - Indices that are `datetime` or `date` objects
 - `sets` - Indices that are `set` objects (stored as arrays)
 - `maps` - Indices that are `Map` objects (for JS interop)
+- `pulse_nodes` - Indices that are VDOM payloads and should render on the JS client
 
 This format preserves:
 - Shared references (same object referenced multiple times)
 - Circular references
-- Type information for dates and sets
+- Type information for dates, sets, maps, and Pulse nodes

--- a/packages/pulse-mantine/js/src/combobox.tsx
+++ b/packages/pulse-mantine/js/src/combobox.tsx
@@ -1,5 +1,5 @@
 import { Combobox as MantineCombobox, useCombobox } from "@mantine/core";
-import { usePulseClient, type ChannelBridge } from "pulse-ui-client";
+import { usePulseChannel, type ChannelBridge } from "pulse-ui-client";
 import { type ComponentPropsWithoutRef, useEffect, useRef } from "react";
 
 type DropdownEventSource = "keyboard" | "mouse" | "unknown";
@@ -38,7 +38,7 @@ export function Combobox({
 	scrollBehavior,
 	...rest
 }: PulseComboboxProps) {
-	const client = usePulseClient();
+	const channel = usePulseChannel(channelId);
 	const channelRef = useRef<ChannelBridge | null>(null);
 
 	const combobox = useCombobox({
@@ -61,7 +61,7 @@ export function Combobox({
 	});
 
 	useEffect(() => {
-		const channel = client.acquireChannel(channelId);
+		if (!channel) return;
 		channelRef.current = channel;
 		const cleanups = [
 			channel.on("openDropdown", (payload: OptionalEventSourcePayload) => {
@@ -111,9 +111,8 @@ export function Combobox({
 			if (channelRef.current === channel) {
 				channelRef.current = null;
 			}
-			client.releaseChannel(channelId);
 		};
-	}, [client, channelId, combobox]);
+	}, [channel, combobox]);
 
 	return <MantineCombobox {...(rest as any)} store={combobox} />;
 }

--- a/packages/pulse-mantine/js/src/form/form.tsx
+++ b/packages/pulse-mantine/js/src/form/form.tsx
@@ -3,7 +3,7 @@ import { useForm } from "@mantine/form";
 import {
 	serialize,
 	submitForm,
-	usePulseClient,
+	usePulseChannel,
 	type ChannelBridge,
 } from "pulse-ui-client";
 import {
@@ -63,7 +63,7 @@ export function Form<TValues extends Record<string, any> = Record<string, any>>(
 	cascadeUpdates,
 	...formProps
 }: MantineFormProps<TValues>) {
-	const client = usePulseClient();
+	const channel = usePulseChannel(channelId);
 	const channelRef = useRef<ChannelBridge | null>(null);
 	const formRef = useRef<UseFormReturnType<TValues> | null>(null);
 	// Timers for server-validation per path
@@ -291,78 +291,91 @@ export function Form<TValues extends Record<string, any> = Record<string, any>>(
 	}, []);
 
 	useEffect(() => {
-		const channel = client.acquireChannel(channelId);
+		if (!channel) return;
 		channelRef.current = channel;
 		const cleanups = [
 			channel.on("setValues", (payload: { values: TValues }) => {
-				if (payload?.values !== undefined) {
-					form.setValues(payload.values);
-					// Always sync back after programmatic value updates
-					sendSync("change");
-				}
+				const currentForm = formRef.current;
+				if (payload?.values === undefined || !currentForm) return;
+				currentForm.setValues(payload.values);
+				// Always sync back after programmatic value updates
+				sendSync("change");
 			}),
 			channel.on("setFieldValue", (payload: { path: string; value: any }) => {
-				if (!payload) return;
-				form.setFieldValue(payload.path, payload.value);
+				const currentForm = formRef.current;
+				if (!payload || !currentForm) return;
+				currentForm.setFieldValue(payload.path, payload.value);
 				sendSync("change", payload.path);
 			}),
 			channel.on("insertListItem", (payload: { path: string; item: any; index?: number }) => {
-				if (!payload) return;
-				form.insertListItem(payload.path, payload.item, payload.index);
+				const currentForm = formRef.current;
+				if (!payload || !currentForm) return;
+				currentForm.insertListItem(payload.path, payload.item, payload.index);
 				sendSync("change", payload.path);
 			}),
 			channel.on("removeListItem", (payload: { path: string; index: number }) => {
-				if (!payload) return;
-				form.removeListItem(payload.path, payload.index);
+				const currentForm = formRef.current;
+				if (!payload || !currentForm) return;
+				currentForm.removeListItem(payload.path, payload.index);
 				sendSync("change", payload.path);
 			}),
 			channel.on("reorderListItem", (payload: { path: string; from: number; to: number }) => {
-				if (!payload) return;
-				form.reorderListItem(payload.path, {
+				const currentForm = formRef.current;
+				if (!payload || !currentForm) return;
+				currentForm.reorderListItem(payload.path, {
 					from: payload.from,
 					to: payload.to,
 				});
 				sendSync("change", payload.path);
 			}),
 			channel.on("setErrors", (payload: { errors: Record<string, any> }) => {
-				if (!payload) return;
-				form.setErrors(payload.errors);
+				const currentForm = formRef.current;
+				if (!payload || !currentForm) return;
+				currentForm.setErrors(payload.errors);
 			}),
 			channel.on("setFieldError", (payload: { path: string; error: any }) => {
-				if (!payload) return;
-				form.setFieldError(payload.path, payload.error);
+				const currentForm = formRef.current;
+				if (!payload || !currentForm) return;
+				currentForm.setFieldError(payload.path, payload.error);
 			}),
 			channel.on("clearErrors", (payload?: { paths?: string[] }) => {
+				const currentForm = formRef.current;
+				if (!currentForm) return;
 				const paths = payload?.paths;
 				if (Array.isArray(paths) && paths.length > 0) {
 					paths.forEach((p) => {
-						form.clearFieldError(p);
+						currentForm.clearFieldError(p);
 					});
 				} else {
-					form.clearErrors();
+					currentForm.clearErrors();
 				}
 			}),
 			channel.on("setTouched", (payload: { touched: Record<string, boolean> }) => {
-				if (!payload) return;
-				form.setTouched(payload.touched);
+				const currentForm = formRef.current;
+				if (!payload || !currentForm) return;
+				currentForm.setTouched(payload.touched);
 			}),
 			channel.on("validate", () => {
+				const currentForm = formRef.current;
+				if (!currentForm) return;
 				// Client-side validation of all fields. Server-side validation is triggered on Python side.
-				form.validate();
+				currentForm.validate();
 			}),
 			channel.on("reset", (payload?: { initialValues?: TValues }) => {
+				const currentForm = formRef.current;
+				if (!currentForm) return;
 				if (payload?.initialValues) {
 					// Same behavior as form.reset(), except we allow modifying the initialValues
-					form.resetTouched();
-					form.resetDirty();
-					form.setValues(payload.initialValues);
+					currentForm.resetTouched();
+					currentForm.resetDirty();
+					currentForm.setValues(payload.initialValues);
 					sendSync("change");
 				} else {
-					form.reset();
+					currentForm.reset();
 					sendSync("change");
 				}
 			}),
-			channel.on("getFormValues", () => form.getValues()),
+			channel.on("getFormValues", () => formRef.current?.getValues()),
 		];
 
 		return () => {
@@ -370,9 +383,8 @@ export function Form<TValues extends Record<string, any> = Record<string, any>>(
 			if (channelRef.current === channel) {
 				channelRef.current = null;
 			}
-			client.releaseChannel(channelId);
 		};
-	}, [client, channelId, form, sendSync]);
+	}, [channel, sendSync]);
 
 	const submitHandler = useMemo(
 		() =>

--- a/packages/pulse-mantine/js/src/notifications.tsx
+++ b/packages/pulse-mantine/js/src/notifications.tsx
@@ -5,7 +5,7 @@ import {
 	type NotificationsProps,
 	notifications as notificationsApi,
 } from "@mantine/notifications";
-import { usePulseClient, type ChannelBridge } from "pulse-ui-client";
+import { usePulseChannel, type ChannelBridge } from "pulse-ui-client";
 import { useEffect, useRef } from "react";
 
 type NotificationUpdatePayload = Parameters<typeof notificationsApi.update>[0];
@@ -38,13 +38,12 @@ export function Notifications({ channelId, ...props }: PulseNotificationsProps) 
 
 function ConnectedNotifications({ channelId, ...props }: ConnectedNotificationsProps) {
 	const { store = defaultStore, ...rest } = props;
-	const client = usePulseClient();
+	const channel = usePulseChannel(channelId);
 	const channelRef = useRef<ChannelBridge | null>(null);
 
 	useEffect(() => {
-		if (!channelId) return;
+		if (!channel) return;
 
-		const channel = client.acquireChannel(channelId);
 		channelRef.current = channel;
 		const cleanups = [
 			channel.on("show", (payload: unknown) => {
@@ -97,9 +96,8 @@ function ConnectedNotifications({ channelId, ...props }: ConnectedNotificationsP
 			if (channelRef.current === channel) {
 				channelRef.current = null;
 			}
-			client.releaseChannel(channelId);
 		};
-	}, [client, channelId, store]);
+	}, [channel, store]);
 
 	return <MantineNotifications {...rest} store={store} />;
 }

--- a/packages/pulse-mantine/js/src/tree.tsx
+++ b/packages/pulse-mantine/js/src/tree.tsx
@@ -1,5 +1,5 @@
 import { Tree as MantineTree, useTree } from "@mantine/core";
-import { usePulseClient, type ChannelBridge } from "pulse-ui-client";
+import { usePulseChannel, type ChannelBridge } from "pulse-ui-client";
 import { type ComponentPropsWithoutRef, useEffect, useRef } from "react";
 
 type ExpandedState = Record<string, boolean>;
@@ -59,7 +59,7 @@ function ConnectedTree({
 	autoSync = true,
 	...rest
 }: ConnectedTreeProps) {
-	const client = usePulseClient();
+	const channel = usePulseChannel(channelId);
 	const channelRef = useRef<ChannelBridge | null>(null);
 
 	// Create controller with initial state and wire auto-sync callbacks
@@ -80,8 +80,7 @@ function ConnectedTree({
 
 	// Server -> client imperative API
 	useEffect(() => {
-		if (!channelId) return;
-		const channel = client.acquireChannel(channelId);
+		if (!channel) return;
 		channelRef.current = channel;
 		const cleanups = [
 			channel.on("toggleExpanded", (payload: { value: string }) => {
@@ -163,9 +162,8 @@ function ConnectedTree({
 			if (channelRef.current === channel) {
 				channelRef.current = null;
 			}
-			client.releaseChannel(channelId);
 		};
-	}, [client, channelId, tree]);
+	}, [channel, tree]);
 
 	return <MantineTree {...(rest as any)} tree={tree as any} />;
 }

--- a/packages/pulse-mantine/python/src/pulse_mantine/core/feedback/notifications.py
+++ b/packages/pulse-mantine/python/src/pulse_mantine/core/feedback/notifications.py
@@ -179,6 +179,7 @@ def NotificationsInternal(
 
 
 NOTIFICATIONS_CHANNEL_ID = uuid.uuid4().hex
+CLIENT_CALLBACK_KEYS = {"onClose", "onOpen"}
 
 
 class NotificationsStore(ps.State):
@@ -199,7 +200,7 @@ class NotificationsStore(ps.State):
 		existing = self.registry.get(ident)
 		merged = payload if not existing else existing | payload
 		self.registry[ident] = merged
-		self._channel.emit("show", serialize(merged))
+		self._channel.emit("show", client_notification_payload(merged))
 		return ident
 
 	def update(self, kwargs: NotificationData) -> str:
@@ -208,7 +209,7 @@ class NotificationsStore(ps.State):
 		existing = self.registry.get(ident)
 		merged = payload if not existing else existing | payload
 		self.registry[ident] = merged
-		self._channel.emit("update", serialize(merged))
+		self._channel.emit("update", client_notification_payload(merged))
 		return ident
 
 	def hide(self, id: str) -> str:
@@ -246,14 +247,14 @@ class NotificationsStore(ps.State):
 			result = update(current)
 		else:
 			result = update
-		new_notifications: list[NotificationData] = []
+		new_notifications: list[dict[str, Any]] = []
 		for item in result:
 			ident, item = ensure_id(item)
 			self.registry[ident] = item
-			new_notifications.append(item)
+			new_notifications.append(client_notification_payload(item))
 		self._channel.emit(
 			"updateState",
-			{"notifications": [serialize(x) for x in new_notifications]},
+			{"notifications": new_notifications},
 		)
 
 	def _on_state_sync(self, payload: Any) -> None:
@@ -324,8 +325,10 @@ def ensure_id(
 	return ident, cast(NotificationData, value)
 
 
-def serialize(value: NotificationData):
-	return {k: v for k, v in value.items() if k not in ("onClose", "onOpen")}
+def client_notification_payload(value: Mapping[str, Any]) -> dict[str, Any]:
+	return {
+		key: entry for key, entry in value.items() if key not in CLIENT_CALLBACK_KEYS
+	}
 
 
 notifications_state = ps.global_state(NotificationsStore)

--- a/packages/pulse-mantine/python/src/pulse_mantine/core/feedback/notifications.py
+++ b/packages/pulse-mantine/python/src/pulse_mantine/core/feedback/notifications.py
@@ -47,9 +47,9 @@ class NotificationProps(  # pyright: ignore[reportIncompatibleVariableOverride]
 	"""Controls notification line or icon color"""
 	radius: MantineRadius
 	"""Controls notification border radius"""
-	icon: ps.Element
+	icon: ps.Node
 	"""Notification icon, replaces color line"""
-	title: ps.Element  # pyright: ignore[reportIncompatibleVariableOverride]
+	title: ps.Node  # pyright: ignore[reportIncompatibleVariableOverride]
 	"""Notification title, displayed above the message body"""
 	loading: bool
 	"""If set, the Loader component is displayed instead of the icon"""
@@ -149,8 +149,8 @@ NotificationPosition = Literal[
 class NotificationDataWithoutId(NotificationProps, total=False):
 	id: str
 	"""Notification id, can be used to close or update notification"""
-	message: Required[str]
-	"""Main notification message. Real API also supports nodes, but we can't handle that yet."""
+	message: Required[ps.Node]
+	"""Main notification message"""
 	position: NotificationPosition
 	"""Notification position"""
 	autoClose: int | bool

--- a/packages/pulse-mantine/python/tests/test_combobox_store.py
+++ b/packages/pulse-mantine/python/tests/test_combobox_store.py
@@ -34,6 +34,12 @@ def build_context():
 	return app, render, session, real_render
 
 
+def connect_channel(real_render: ps.RenderSession, channel_id: str) -> None:
+	real_render.channels.handle_client_connect(
+		{"type": "channel_connect", "channel": channel_id, "path": "/"}
+	)
+
+
 @pytest.mark.asyncio
 async def test_combobox_store_emits_actions():
 	app, render, session, real_render = build_context()
@@ -44,6 +50,7 @@ async def test_combobox_store_emits_actions():
 		render=real_render,
 	):
 		store = ComboboxStore()
+		connect_channel(real_render, store._channel.id)
 		store.open_dropdown("keyboard")
 		store.select_option(3)
 
@@ -67,6 +74,7 @@ async def test_combobox_store_optional_payloads():
 		render=real_render,
 	):
 		store = ComboboxStore()
+		connect_channel(real_render, store._channel.id)
 		store.open_dropdown()
 		store.update_selected_option_index()
 
@@ -90,6 +98,7 @@ async def test_combobox_store_request_roundtrip():
 		render=real_render,
 	):
 		store = ComboboxStore()
+		connect_channel(real_render, store._channel.id)
 		pending = asyncio.create_task(store.get_dropdown_opened())
 
 	await asyncio.sleep(0)
@@ -134,6 +143,7 @@ async def test_combobox_store_callbacks():
 			onDropdownOpen=lambda source: opened_sources.append(source),
 			onDropdownClose=lambda source: closed_sources.append(source),
 		)
+		connect_channel(real_render, store._channel.id)
 
 	with ps.PulseContext(
 		app=app,

--- a/packages/pulse-mantine/python/tests/test_form.py
+++ b/packages/pulse-mantine/python/tests/test_form.py
@@ -33,6 +33,7 @@ def build_context():
 
 	real_render = ps.RenderSession(render.id, routes, server_address="http://localhost")
 	real_render.send = render.send  # pyright: ignore[reportAttributeAccessIssue]
+	real_render.connect(render.send)
 	with ps.PulseContext(app=app):
 		real_render.prerender(
 			["/"],
@@ -48,12 +49,19 @@ def build_context():
 				},
 			),
 		)
+		real_render.attach("/", route.default_route_info())
 	route_ctx = real_render.route_mounts["/"].route
 
 	app.render_sessions[render.id] = real_render
 	app._render_to_user[render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
 	app.user_sessions[session.sid] = session  # pyright: ignore[reportArgumentType]
 	return app, render, session, real_render, route_ctx
+
+
+def connect_channel(real_render: ps.RenderSession, channel_id: str) -> None:
+	real_render.channels.handle_client_connect(
+		{"type": "channel_connect", "channel": channel_id, "path": "/"}
+	)
 
 
 def test_form_recreates_channel_after_client_release():
@@ -81,6 +89,8 @@ def test_form_recreates_channel_after_client_release():
 		render=real_render,
 		route=route_ctx,
 	):
+		form.render()
+		connect_channel(real_render, form._channel.id)
 		form.reset()
 
 	assert not form._channel.closed
@@ -110,6 +120,7 @@ async def test_form_sync_handler_survives_channel_recreation():
 		route=route_ctx,
 	):
 		form.render()
+		connect_channel(real_render, form._channel.id)
 		real_render.channels.handle_client_event(
 			render=real_render,
 			session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]

--- a/packages/pulse-mantine/python/tests/test_notifications.py
+++ b/packages/pulse-mantine/python/tests/test_notifications.py
@@ -1,0 +1,108 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pulse as ps
+from pulse.user_session import UserSession
+from pulse_mantine.core.feedback.notifications import NotificationsStore
+
+
+class DummyRender:
+	id: str
+
+	def __init__(self, rid: str = "render-1") -> None:
+		self.id = rid
+		self.sent: list[dict[str, Any]] = []
+
+	def send(self, message: dict[str, Any]):
+		self.sent.append(message)
+
+
+def build_context():
+	app = ps.App()
+	render = DummyRender()
+	session = SimpleNamespace(sid="session-1")
+
+	real_render = ps.RenderSession(render.id, app.routes)
+	real_render.send = render.send  # pyright: ignore[reportAttributeAccessIssue]
+
+	app.render_sessions[render.id] = real_render
+	app._render_to_user[render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
+	app.user_sessions[session.sid] = session  # pyright: ignore[reportArgumentType]
+	return app, render, session, real_render
+
+
+def connect_channel(real_render: ps.RenderSession, channel_id: str) -> None:
+	real_render.channels.handle_client_connect(
+		{"type": "channel_connect", "channel": channel_id, "path": "/"}
+	)
+
+
+def test_notification_show_keeps_callback_server_side():
+	app, render, session, real_render = build_context()
+
+	def on_open(notification: dict[str, Any]) -> None:
+		notification["opened"] = True
+
+	with ps.PulseContext(
+		app=app,
+		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
+		render=real_render,
+	):
+		store = NotificationsStore()
+		connect_channel(real_render, store._channel.id)  # pyright: ignore[reportPrivateUsage]
+		ident = store.show({"message": "Saved", "onOpen": on_open})
+
+	assert store.registry[ident]["onOpen"] is on_open
+	assert render.sent[0]["event"] == "show"
+	assert render.sent[0]["payload"] == {"message": "Saved", "id": ident}
+
+
+def test_notification_update_keeps_callbacks_server_side():
+	app, render, session, real_render = build_context()
+
+	def on_close(notification: dict[str, Any]) -> None:
+		notification["closed"] = True
+
+	with ps.PulseContext(
+		app=app,
+		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
+		render=real_render,
+	):
+		store = NotificationsStore()
+		connect_channel(real_render, store._channel.id)  # pyright: ignore[reportPrivateUsage]
+		store.show({"id": "toast", "message": "Saving"})
+		store.update({"id": "toast", "message": "Saved", "onClose": on_close})
+
+	assert store.registry["toast"]["onClose"] is on_close
+	assert render.sent[1]["event"] == "update"
+	assert render.sent[1]["payload"] == {"id": "toast", "message": "Saved"}
+
+
+def test_notification_update_state_keeps_callbacks_server_side():
+	app, render, session, real_render = build_context()
+
+	def on_close(notification: dict[str, Any]) -> None:
+		notification["closed"] = True
+
+	with ps.PulseContext(
+		app=app,
+		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
+		render=real_render,
+	):
+		store = NotificationsStore()
+		connect_channel(real_render, store._channel.id)  # pyright: ignore[reportPrivateUsage]
+		store.updateState(
+			[
+				{
+					"id": "toast",
+					"message": "Synced",
+					"onClose": on_close,
+				}
+			]
+		)
+
+	assert store.registry["toast"]["onClose"] is on_close
+	assert render.sent[0]["event"] == "updateState"
+	assert render.sent[0]["payload"] == {
+		"notifications": [{"id": "toast", "message": "Synced"}]
+	}

--- a/packages/pulse-mantine/python/tests/test_notifications.py
+++ b/packages/pulse-mantine/python/tests/test_notifications.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 import pulse as ps
+from pulse.serializer import Serialized, serialize
 from pulse.user_session import UserSession
 from pulse_mantine.core.feedback.notifications import NotificationsStore
 
@@ -31,10 +32,36 @@ def build_context():
 	return app, render, session, real_render
 
 
-def connect_channel(real_render: ps.RenderSession, channel_id: str) -> None:
-	real_render.channels.handle_client_connect(
-		{"type": "channel_connect", "channel": channel_id, "path": "/"}
-	)
+def build_route_context():
+	@ps.component
+	def view():
+		return ps.div()
+
+	app = ps.App([ps.Route("/", view)])
+	render = DummyRender()
+	session = SimpleNamespace(sid="session-1")
+
+	real_render = ps.RenderSession(render.id, app.routes)
+	real_render.send = render.send  # pyright: ignore[reportAttributeAccessIssue]
+
+	app.render_sessions[render.id] = real_render
+	app._render_to_user[render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
+	app.user_sessions[session.sid] = session  # pyright: ignore[reportArgumentType]
+
+	with ps.PulseContext(
+		app=app,
+		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
+		render=real_render,
+	):
+		real_render.prerender(["/"])
+		real_render.attach("/", app.routes.find("/").default_route_info())
+	mount = real_render.get_route_mount("/")
+	return app, render, session, real_render, mount
+
+
+def serialize_message(message: dict[str, Any]) -> Serialized:
+	payload = serialize(message)
+	return (payload[0], payload[1])
 
 
 def test_notification_show_keeps_callback_server_side():
@@ -49,7 +76,6 @@ def test_notification_show_keeps_callback_server_side():
 		render=real_render,
 	):
 		store = NotificationsStore()
-		connect_channel(real_render, store._channel.id)  # pyright: ignore[reportPrivateUsage]
 		ident = store.show({"message": "Saved", "onOpen": on_open})
 
 	assert store.registry[ident]["onOpen"] is on_open
@@ -69,7 +95,6 @@ def test_notification_update_keeps_callbacks_server_side():
 		render=real_render,
 	):
 		store = NotificationsStore()
-		connect_channel(real_render, store._channel.id)  # pyright: ignore[reportPrivateUsage]
 		store.show({"id": "toast", "message": "Saving"})
 		store.update({"id": "toast", "message": "Saved", "onClose": on_close})
 
@@ -90,7 +115,6 @@ def test_notification_update_state_keeps_callbacks_server_side():
 		render=real_render,
 	):
 		store = NotificationsStore()
-		connect_channel(real_render, store._channel.id)  # pyright: ignore[reportPrivateUsage]
 		store.updateState(
 			[
 				{
@@ -105,4 +129,114 @@ def test_notification_update_state_keeps_callbacks_server_side():
 	assert render.sent[0]["event"] == "updateState"
 	assert render.sent[0]["payload"] == {
 		"notifications": [{"id": "toast", "message": "Synced"}]
+	}
+
+
+def test_notification_show_serializes_renderable_fields():
+	app, render, session, real_render, mount = build_route_context()
+
+	def on_open(notification: dict[str, Any]) -> None:
+		notification["opened"] = True
+
+	with ps.PulseContext(
+		app=app,
+		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
+		render=real_render,
+		route=mount.route,
+	):
+		store = NotificationsStore()
+		ident = store.show(
+			{
+				"title": ps.span("Upload"),
+				"message": ps.span("Complete"),
+				"icon": ps.span("!"),
+				"onOpen": on_open,
+			}
+		)
+
+	serialized = serialize_message(render.sent[0])
+	meta, payload = serialized
+	assert meta[4]
+	assert store.registry[ident]["onOpen"] is on_open
+	assert payload["path"] == "/"
+	assert payload["payload"] == {
+		"id": ident,
+		"title": {"tag": "span", "children": ["Upload"]},
+		"message": {"tag": "span", "children": ["Complete"]},
+		"icon": {"tag": "span", "children": ["!"]},
+	}
+
+
+def test_notification_update_serializes_renderable_fields():
+	app, render, session, real_render, mount = build_route_context()
+
+	def on_close(notification: dict[str, Any]) -> None:
+		notification["closed"] = True
+
+	with ps.PulseContext(
+		app=app,
+		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
+		render=real_render,
+		route=mount.route,
+	):
+		store = NotificationsStore()
+		store.show({"id": "toast", "message": "Saving"})
+		store.update(
+			{
+				"id": "toast",
+				"title": ps.span("Upload"),
+				"message": ps.span("Complete"),
+				"onClose": on_close,
+			}
+		)
+
+	serialized = serialize_message(render.sent[1])
+	meta, payload = serialized
+	assert meta[4]
+	assert store.registry["toast"]["onClose"] is on_close
+	assert payload["path"] == "/"
+	assert payload["payload"] == {
+		"id": "toast",
+		"title": {"tag": "span", "children": ["Upload"]},
+		"message": {"tag": "span", "children": ["Complete"]},
+	}
+
+
+def test_notification_update_state_serializes_renderable_fields():
+	app, render, session, real_render, mount = build_route_context()
+
+	def on_close(notification: dict[str, Any]) -> None:
+		notification["closed"] = True
+
+	with ps.PulseContext(
+		app=app,
+		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
+		render=real_render,
+		route=mount.route,
+	):
+		store = NotificationsStore()
+		store.updateState(
+			[
+				{
+					"id": "toast",
+					"title": ps.span("Upload"),
+					"message": ps.span("Complete"),
+					"onClose": on_close,
+				}
+			]
+		)
+
+	serialized = serialize_message(render.sent[0])
+	meta, payload = serialized
+	assert meta[4]
+	assert store.registry["toast"]["onClose"] is on_close
+	assert payload["path"] == "/"
+	assert payload["payload"] == {
+		"notifications": [
+			{
+				"id": "toast",
+				"title": {"tag": "span", "children": ["Upload"]},
+				"message": {"tag": "span", "children": ["Complete"]},
+			}
+		]
 	}

--- a/packages/pulse/js/README.md
+++ b/packages/pulse/js/README.md
@@ -41,7 +41,6 @@ src/
 ├── form.tsx            # PulseForm component
 ├── helpers.ts          # Route info extraction utilities
 ├── vdom.ts             # VDOM types (VDOMNode, VDOMElement)
-├── usePulseChannel.ts  # React hook for channels
 │
 └── serialize/          # Data serialization
     ├── serializer.ts   # Main serialize/deserialize
@@ -106,16 +105,20 @@ import { usePulseChannel } from "pulse-client";
 
 function Chat() {
   const channel = usePulseChannel("chat");
+  if (!channel) return null;
+
   channel.on("new_message", (msg) => { /* handle */ });
   channel.emit("message", { text: "Hello" });
 }
 ```
 
+`usePulseChannel` must run under a `PulseView`. It returns `null` before the channel is acquired.
+
 ## Main Exports
 
 **Components**: `PulseProvider`, `PulseView`, `PulseForm`, `RenderLazy`
 
-**Hooks**: `usePulseClient()`, `usePulseChannel(name)`
+**Hooks**: `usePulseClient()`, `usePulseViewPath()`, `usePulseChannelManager()`, `usePulseChannelManagerForPath(path)`, `usePulseChannel(name)`
 
 **Functions**: `serialize`, `deserialize`, `extractServerRouteInfo`, `submitForm`
 

--- a/packages/pulse/js/src/channel.test.ts
+++ b/packages/pulse/js/src/channel.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from "bun:test";
-import { ChannelBridge, PulseChannelResetError } from "./channel";
+import {
+	ChannelBridge,
+	createPulseChannelManager,
+	PulseChannelResetError,
+} from "./channel";
 import { PulseSocketIOClient } from "./client";
-import type { ClientChannelMessage } from "./messages";
+import type { ClientChannelMessage, ClientMessage } from "./messages";
 
 function makeClient() {
 	const sent: ClientChannelMessage[] = [];
@@ -84,13 +88,119 @@ describe("ChannelBridge", () => {
 			},
 		);
 
-		const first = client.acquireChannel("chan-1");
-		client.releaseChannel("chan-1");
+		const first = client.acquireChannel("chan-1", "/view");
+		client.releaseChannel("chan-1", "/view");
 
 		expect(() => first.on("event", vi.fn())).toThrow(PulseChannelResetError);
 
-		const second = client.acquireChannel("chan-1");
+		const second = client.acquireChannel("chan-1", "/view");
 		expect(second).not.toBe(first);
 		expect(() => second.on("event", vi.fn())).not.toThrow();
+	});
+
+	it("rejects duplicate client channel acquisitions", () => {
+		const client = new PulseSocketIOClient(
+			"http://pulse.test",
+			{},
+			vi.fn() as any,
+			{
+				initialConnectingDelay: 0,
+				initialErrorDelay: 0,
+				reconnectErrorDelay: 0,
+			},
+		);
+
+		client.acquireChannel("chan-1", "/a");
+
+		expect(() => client.acquireChannel("chan-1", "/b")).toThrow(
+			"Pulse channel 'chan-1' is already acquired",
+		);
+	});
+
+	it("channel manager acquires with its view path and releases idempotently", () => {
+		const client = new PulseSocketIOClient(
+			"http://pulse.test",
+			{},
+			vi.fn() as any,
+			{
+				initialConnectingDelay: 0,
+				initialErrorDelay: 0,
+				reconnectErrorDelay: 0,
+			},
+		);
+		const sent: ClientMessage[] = [];
+		vi.spyOn(client, "sendMessage").mockImplementation((message: any) => {
+			sent.push(message);
+		});
+
+		const manager = createPulseChannelManager(client, "/view");
+		const lease = manager.acquire("chan-1");
+		lease.release();
+		lease.release();
+
+		expect(sent).toEqual([
+			expect.objectContaining({
+				type: "channel_message",
+				channel: "chan-1",
+				event: "__close__",
+			}),
+		]);
+		expect(sent as any[]).not.toContainEqual(
+			expect.objectContaining({ type: "channel_connect" }),
+		);
+		expect(sent as any[]).not.toContainEqual(
+			expect.objectContaining({ type: "channel_disconnect" }),
+		);
+	});
+
+	it("channel manager rejects duplicate acquires", () => {
+		const client = new PulseSocketIOClient(
+			"http://pulse.test",
+			{},
+			vi.fn() as any,
+			{
+				initialConnectingDelay: 0,
+				initialErrorDelay: 0,
+				reconnectErrorDelay: 0,
+			},
+		);
+
+		const manager = createPulseChannelManager(client, "/view");
+		manager.acquire("chan-1");
+
+		expect(() => manager.acquire("chan-1")).toThrow(
+			"PulseChannelManager already acquired channel 'chan-1'",
+		);
+	});
+
+	it("channel manager disposes outstanding leases", () => {
+		const client = new PulseSocketIOClient(
+			"http://pulse.test",
+			{},
+			vi.fn() as any,
+			{
+				initialConnectingDelay: 0,
+				initialErrorDelay: 0,
+				reconnectErrorDelay: 0,
+			},
+		);
+		const sent: ClientMessage[] = [];
+		vi.spyOn(client, "sendMessage").mockImplementation((message: any) => {
+			sent.push(message);
+		});
+
+		const manager = createPulseChannelManager(client, "/view");
+		manager.acquire("chan-a");
+		const released = manager.acquire("chan-b");
+		released.release();
+		manager.dispose();
+		manager.dispose();
+
+		expect(
+			sent
+				.filter((message) => message.type === "channel_message")
+				.map((message) => message.channel),
+		).toEqual(["chan-b", "chan-a"]);
+		expect(() => manager.acquire("chan-c")).toThrow("PulseChannelManager is disposed");
 	});
 });

--- a/packages/pulse/js/src/channel.test.ts
+++ b/packages/pulse/js/src/channel.test.ts
@@ -5,15 +5,15 @@ import {
 	PulseChannelResetError,
 } from "./channel";
 import { PulseSocketIOClient } from "./client";
-import type { ClientChannelMessage, ClientMessage } from "./messages";
+import type { ClientMessage } from "./messages";
 
 function makeClient() {
-	const sent: ClientChannelMessage[] = [];
-	const sendMessage = vi.fn(async (message: ClientChannelMessage) => {
+	const sent: ClientMessage[] = [];
+	const sendMessage = vi.fn(async (message: ClientMessage) => {
 		sent.push(message);
 	});
 	const client = { sendMessage } as any;
-	const bridge = new ChannelBridge(client, "chan-1");
+	const bridge = new ChannelBridge(client, "chan-1", "/view");
 	return { bridge, sent, sendMessage };
 }
 
@@ -22,7 +22,15 @@ describe("ChannelBridge", () => {
 		const { bridge, sent } = makeClient();
 		const pending = bridge.request("echo", { foo: 1 });
 		expect(sent).toHaveLength(1);
-		const requestId = sent[0]!.requestId!;
+		expect(sent[0]).toEqual(
+			expect.objectContaining({
+				type: "channel_message",
+				channel: "chan-1",
+				event: "echo",
+			}),
+		);
+		expect(sent[0]).not.toHaveProperty("path");
+		const requestId = (sent[0] as any).requestId!;
 		bridge.handleServerMessage({
 			type: "channel_message",
 			channel: "chan-1",
@@ -76,6 +84,24 @@ describe("ChannelBridge", () => {
 		await expect(pending).rejects.toBeInstanceOf(PulseChannelResetError);
 	});
 
+	it("rejects pending requests on transport disconnect without closing", async () => {
+		const { bridge, sent } = makeClient();
+		const pending = bridge.request("during-disconnect");
+		bridge.handleDisconnect(new PulseChannelResetError("Connection lost"));
+
+		await expect(pending).rejects.toBeInstanceOf(PulseChannelResetError);
+		expect(() => bridge.on("event", vi.fn())).not.toThrow();
+
+		bridge.emit("after-reconnect", { ok: true });
+		expect(sent.at(-1)).toEqual(
+			expect.objectContaining({
+				type: "channel_message",
+				channel: "chan-1",
+				event: "after-reconnect",
+			}),
+		);
+	});
+
 	it("reacquires a fresh bridge after release closes a channel", () => {
 		const client = new PulseSocketIOClient(
 			"http://pulse.test",
@@ -98,7 +124,7 @@ describe("ChannelBridge", () => {
 		expect(() => second.on("event", vi.fn())).not.toThrow();
 	});
 
-	it("rejects duplicate client channel acquisitions", () => {
+	it("connects once per channel id and rejects duplicate endpoints", () => {
 		const client = new PulseSocketIOClient(
 			"http://pulse.test",
 			{},
@@ -109,12 +135,26 @@ describe("ChannelBridge", () => {
 				reconnectErrorDelay: 0,
 			},
 		);
+		const sent: ClientMessage[] = [];
+		vi.spyOn(client, "sendMessage").mockImplementation((message: any) => {
+			sent.push(message);
+		});
 
-		client.acquireChannel("chan-1", "/a");
+		const first = client.acquireChannel("chan-1", "/a");
 
 		expect(() => client.acquireChannel("chan-1", "/b")).toThrow(
 			"Pulse channel 'chan-1' is already acquired",
 		);
+		expect(() => first.on("event", vi.fn())).not.toThrow();
+		expect(sent).toEqual([
+			expect.objectContaining({ type: "channel_connect", channel: "chan-1", path: "/a" }),
+		]);
+
+		client.releaseChannel("chan-1", "/a");
+		expect(sent.at(-1)).toEqual({
+			type: "channel_disconnect",
+			channel: "chan-1",
+		});
 	});
 
 	it("channel manager acquires with its view path and releases idempotently", () => {
@@ -139,18 +179,9 @@ describe("ChannelBridge", () => {
 		lease.release();
 
 		expect(sent).toEqual([
-			expect.objectContaining({
-				type: "channel_message",
-				channel: "chan-1",
-				event: "__close__",
-			}),
+			expect.objectContaining({ type: "channel_connect", path: "/view" }),
+			expect.objectContaining({ type: "channel_disconnect", channel: "chan-1" }),
 		]);
-		expect(sent as any[]).not.toContainEqual(
-			expect.objectContaining({ type: "channel_connect" }),
-		);
-		expect(sent as any[]).not.toContainEqual(
-			expect.objectContaining({ type: "channel_disconnect" }),
-		);
 	});
 
 	it("channel manager rejects duplicate acquires", () => {
@@ -164,6 +195,7 @@ describe("ChannelBridge", () => {
 				reconnectErrorDelay: 0,
 			},
 		);
+		vi.spyOn(client, "sendMessage").mockImplementation(() => {});
 
 		const manager = createPulseChannelManager(client, "/view");
 		manager.acquire("chan-1");
@@ -198,7 +230,7 @@ describe("ChannelBridge", () => {
 
 		expect(
 			sent
-				.filter((message) => message.type === "channel_message")
+				.filter((message) => message.type === "channel_disconnect")
 				.map((message) => message.channel),
 		).toEqual(["chan-b", "chan-a"]);
 		expect(() => manager.acquire("chan-c")).toThrow("PulseChannelManager is disposed");

--- a/packages/pulse/js/src/channel.ts
+++ b/packages/pulse/js/src/channel.ts
@@ -1,11 +1,9 @@
-import { useEffect, useState } from "react";
 import type { PulseSocketIOClient } from "./client";
 import type {
 	ServerChannelMessage,
 	ServerChannelRequestMessage,
 	ServerChannelResponseMessage,
 } from "./messages";
-import { usePulseClient } from "./pulse";
 
 export class PulseChannelResetError extends Error {
 	constructor(message: string) {
@@ -15,6 +13,16 @@ export class PulseChannelResetError extends Error {
 }
 
 export type ChannelEventHandler = (payload: any) => any | Promise<any>;
+
+export type PulseChannelLease = {
+	bridge: ChannelBridge;
+	release: () => void;
+};
+
+export interface PulseChannelManager {
+	acquire(channelId: string): PulseChannelLease;
+	dispose(): void;
+}
 
 interface PendingRequest {
 	resolve: (value: any) => void;
@@ -237,32 +245,73 @@ export class ChannelBridge {
 			return;
 		}
 		this.closed = true;
-		for (const request of this.pending.values()) {
-			request.reject(reason);
-		}
-		this.pending.clear();
+		this.rejectPending(reason);
 		this.handlers.clear();
 		this.backlog = [];
 		// No-op: owning client manages registry lifecycle.
 	}
+
+	private rejectPending(reason: PulseChannelResetError): void {
+		for (const request of this.pending.values()) {
+			request.reject(reason);
+		}
+		this.pending.clear();
+	}
 }
 
-export function usePulseChannel(channelId: string): ChannelBridge | null {
-	const client = usePulseClient();
+class ClientPulseChannelManager implements PulseChannelManager {
+	#client: PulseSocketIOClient;
+	#path: string;
+	#leases = new Map<string, { channelId: string; released: boolean }>();
+	#disposed = false;
 
-	const [bridge, setBridge] = useState<ChannelBridge | null>(null);
+	constructor(client: PulseSocketIOClient, path: string) {
+		this.#client = client;
+		this.#path = path;
+	}
 
-	useEffect(() => {
+	acquire(channelId: string): PulseChannelLease {
 		if (!channelId) {
-			throw new Error("usePulseChannel requires a non-empty channelId");
+			throw new Error("PulseChannelManager.acquire requires a non-empty channelId");
 		}
-		const acquired = client.acquireChannel(channelId);
-		setBridge(acquired);
-		return () => {
-			setBridge((current) => (current === acquired ? null : current));
-			client.releaseChannel(channelId);
+		if (this.#disposed) {
+			throw new Error("PulseChannelManager is disposed");
+		}
+		if (this.#leases.has(channelId)) {
+			throw new Error(`PulseChannelManager already acquired channel '${channelId}'`);
+		}
+		const bridge = this.#client.acquireChannel(channelId, this.#path);
+		const lease = { channelId, released: false };
+		this.#leases.set(channelId, lease);
+		return {
+			bridge,
+			release: () => {
+				this.#release(lease);
+			},
 		};
-	}, [client, channelId]);
+	}
 
-	return bridge;
+	dispose(): void {
+		if (this.#disposed) return;
+		this.#disposed = true;
+		const leases = [...this.#leases.values()];
+		this.#leases.clear();
+		for (const lease of leases) {
+			this.#release(lease);
+		}
+	}
+
+	#release(lease: { channelId: string; released: boolean }): void {
+		if (lease.released) return;
+		lease.released = true;
+		this.#leases.delete(lease.channelId);
+		this.#client.releaseChannel(lease.channelId, this.#path);
+	}
+}
+
+export function createPulseChannelManager(
+	client: PulseSocketIOClient,
+	path: string,
+): PulseChannelManager {
+	return new ClientPulseChannelManager(client, path);
 }

--- a/packages/pulse/js/src/channel.ts
+++ b/packages/pulse/js/src/channel.ts
@@ -67,6 +67,7 @@ export class ChannelBridge {
 	constructor(
 		private client: PulseSocketIOClient,
 		public readonly id: string,
+		public readonly path: string,
 	) {}
 
 	emit(event: string, payload?: any): void {
@@ -142,7 +143,7 @@ export class ChannelBridge {
 	}
 
 	handleDisconnect(reason: PulseChannelResetError): void {
-		this.close(reason);
+		this.rejectPending(reason);
 	}
 
 	dispose(reason: PulseChannelResetError): void {

--- a/packages/pulse/js/src/client.test.ts
+++ b/packages/pulse/js/src/client.test.ts
@@ -44,13 +44,15 @@ const routeInfo = {
 	catchall: [],
 };
 
-const view = {
-	routeInfo,
-	onInit: vi.fn(),
-	onUpdate: vi.fn(),
-	onJsExec: vi.fn(),
-	onServerError: vi.fn(),
-};
+function makeView(pathRouteInfo = routeInfo) {
+	return {
+		routeInfo: pathRouteInfo,
+		onInit: vi.fn(),
+		onUpdate: vi.fn(),
+		onJsExec: vi.fn(),
+		onServerError: vi.fn(),
+	};
+}
 
 async function makeClient() {
 	const { PulseSocketIOClient } = await import("./client");
@@ -77,7 +79,7 @@ describe("PulseSocketIOClient attach ack", () => {
 	it("queues callbacks until the active attach is acknowledged", async () => {
 		const client = await makeClient();
 		const connected = client.connect();
-		client.attach("/", view);
+		client.attach("/", makeView());
 		socket.trigger("connect");
 		await connected;
 
@@ -106,7 +108,7 @@ describe("PulseSocketIOClient attach ack", () => {
 	it("drops queued callbacks when the path detaches before ack", async () => {
 		const client = await makeClient();
 		const connected = client.connect();
-		client.attach("/", view);
+		client.attach("/", makeView());
 		socket.trigger("connect");
 		await connected;
 
@@ -160,8 +162,153 @@ describe("PulseSocketIOClient attach ack", () => {
 		socket.trigger("connect");
 
 		expect(sentMessages()).toEqual([
-			{ type: "channel_connect", channel: "chan-1", path: "/view" },
+			{
+				type: "client_resume",
+				resumeId: expect.any(String),
+				views: [],
+				channels: [{ channel: "chan-1", path: "/view" }],
+			},
 		]);
+		const resume = sentMessages()[0]!;
+		socket.trigger(
+			"message",
+			serialize({
+				type: "server_resume",
+				resumeId: resume.resumeId,
+				status: "ok",
+				views: [],
+				channels: [{ channel: "chan-1", path: "/view" }],
+			}),
+		);
 		expect(() => bridge.emit("after-reconnect")).not.toThrow();
+	});
+
+	it("does not replay stale channel disconnect after offline release and reacquire", async () => {
+		const client = await makeClient();
+		const connected = client.connect();
+		socket.trigger("connect");
+		await connected;
+
+		client.acquireChannel("chan-1", "/view");
+		socket.trigger("disconnect");
+		client.releaseChannel("chan-1", "/view");
+		client.acquireChannel("chan-1", "/view");
+
+		socket.emitted = [];
+		socket.trigger("connect");
+
+		expect(sentMessages()).toEqual([
+			{
+				type: "client_resume",
+				resumeId: expect.any(String),
+				views: [],
+				channels: [{ channel: "chan-1", path: "/view" }],
+			},
+		]);
+		const resume = sentMessages()[0]!;
+		socket.trigger(
+			"message",
+			serialize({
+				type: "server_resume",
+				resumeId: resume.resumeId,
+				status: "ok",
+				views: [],
+				channels: [{ channel: "chan-1", path: "/view" }],
+			}),
+		);
+
+		expect(sentMessages()).toEqual([
+			{
+				type: "client_resume",
+				resumeId: resume.resumeId,
+				views: [],
+				channels: [{ channel: "chan-1", path: "/view" }],
+			},
+		]);
+	});
+
+	it("keeps queued callbacks behind resume acceptance", async () => {
+		const client = await makeClient();
+		const connected = client.connect();
+		client.attach("/", makeView());
+		socket.trigger("connect");
+		await connected;
+
+		const attach = sentMessages()[0]!;
+		socket.trigger(
+			"message",
+			serialize({
+				type: "attach_ack",
+				path: "/",
+				attachId: attach.attachId,
+			}),
+		);
+
+		socket.trigger("disconnect");
+		client.invokeCallback("/", "1.onClick", []);
+		socket.emitted = [];
+		socket.trigger("connect");
+
+		expect(sentMessages()).toEqual([
+			{
+				type: "client_resume",
+				resumeId: expect.any(String),
+				views: [{ path: "/", routeInfo, attachId: attach.attachId }],
+				channels: [],
+			},
+		]);
+
+		const resume = sentMessages()[0]!;
+		socket.trigger(
+			"message",
+			serialize({
+				type: "server_resume",
+				resumeId: resume.resumeId,
+				status: "ok",
+				views: [{ path: "/", attachId: attach.attachId }],
+				channels: [],
+			}),
+		);
+
+		expect(sentMessages()[1]).toMatchObject({
+			type: "callback",
+			path: "/",
+			callback: "1.onClick",
+		});
+	});
+
+	it("drops queued channel messages and closes bridge when channel is not resumed", async () => {
+		const client = await makeClient();
+		const connected = client.connect();
+		socket.trigger("connect");
+		await connected;
+
+		const bridge = client.acquireChannel("chan-1", "/view");
+		socket.trigger("disconnect");
+		bridge.emit("offline-event");
+		socket.emitted = [];
+		socket.trigger("connect");
+
+		const resume = sentMessages()[0]!;
+		socket.trigger(
+			"message",
+			serialize({
+				type: "server_resume",
+				resumeId: resume.resumeId,
+				status: "ok",
+				views: [],
+				channels: [],
+			}),
+		);
+
+		expect(sentMessages()).toEqual([
+			{
+				type: "client_resume",
+				resumeId: resume.resumeId,
+				views: [],
+				channels: [{ channel: "chan-1", path: "/view" }],
+			},
+		]);
+		expect(() => bridge.emit("after-refusal")).toThrow("Channel is closed");
 	});
 });

--- a/packages/pulse/js/src/client.test.ts
+++ b/packages/pulse/js/src/client.test.ts
@@ -127,4 +127,41 @@ describe("PulseSocketIOClient attach ack", () => {
 			"detach",
 		]);
 	});
+
+	it("coalesces queued channel lifecycle messages on initial connect", async () => {
+		const client = await makeClient();
+		const connected = client.connect();
+
+		client.acquireChannel("chan-1", "/view");
+		client.releaseChannel("chan-1", "/view");
+		client.acquireChannel("chan-1", "/view");
+
+		socket.trigger("connect");
+		await connected;
+
+		expect(sentMessages()).toEqual([
+			{ type: "channel_connect", channel: "chan-1", path: "/view" },
+		]);
+	});
+
+	it("rejects channel requests on transport disconnect and reconnects endpoint", async () => {
+		const client = await makeClient();
+		const connected = client.connect();
+		socket.trigger("connect");
+		await connected;
+
+		const bridge = client.acquireChannel("chan-1", "/view");
+		const pending = bridge.request("needs-response");
+
+		socket.trigger("disconnect");
+		await expect(pending).rejects.toThrow("Connection lost");
+
+		socket.emitted = [];
+		socket.trigger("connect");
+
+		expect(sentMessages()).toEqual([
+			{ type: "channel_connect", channel: "chan-1", path: "/view" },
+		]);
+		expect(() => bridge.emit("after-reconnect")).not.toThrow();
+	});
 });

--- a/packages/pulse/js/src/client.test.ts
+++ b/packages/pulse/js/src/client.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, mock, vi } from "bun:test";
 import { deserialize, serialize } from "./serialize/serializer";
+import type { Serialized } from "./serialize/serializer";
 
 class FakeSocket {
 	connected = false;
@@ -50,6 +51,9 @@ const view = {
 	onUpdate: vi.fn(),
 	onJsExec: vi.fn(),
 	onServerError: vi.fn(),
+	deserializeMessage: vi.fn((data: Serialized) =>
+		deserialize(data, { coerceNullsToUndefined: true }),
+	),
 };
 
 async function makeClient() {
@@ -126,5 +130,136 @@ describe("PulseSocketIOClient attach ack", () => {
 			"attach",
 			"detach",
 		]);
+	});
+
+	it("deserializes js_exec with the owning view deserializer", async () => {
+		const renderNode = vi.fn(() => "route-a-node");
+		const client = await makeClient();
+		const connected = client.connect();
+		const viewA = {
+			...view,
+			onJsExec: vi.fn(),
+			deserializeMessage: vi.fn((data: Serialized) =>
+				deserialize(data, {
+					coerceNullsToUndefined: true,
+					renderer: { renderNode },
+				}),
+			),
+		};
+		const viewB = {
+			...view,
+			deserializeMessage: vi.fn(() => {
+				throw new Error("wrong view");
+			}),
+		};
+		client.attach("/a", viewA);
+		client.attach("/b", viewB);
+		socket.trigger("connect");
+		await connected;
+
+		socket.trigger("message", [
+			[[], [], [], [], [12]],
+			{
+				type: "js_exec",
+				path: "/a",
+				id: "exec-1",
+				expr: {
+					t: "call",
+					callee: { t: "ref", key: "fn" },
+					args: [
+						{
+							t: "lit",
+							value: {
+								tag: "$$RouteOnly",
+								props: { label: "A" },
+								children: [],
+							},
+						},
+					],
+				},
+			},
+		] satisfies Serialized);
+
+		expect(viewA.deserializeMessage).toHaveBeenCalledTimes(1);
+		expect(viewB.deserializeMessage).not.toHaveBeenCalled();
+		expect(viewA.onJsExec.mock.calls[0]![0].expr.args[0].value).toBe("route-a-node");
+		expect(renderNode).toHaveBeenCalledWith(
+			expect.objectContaining({ tag: "$$RouteOnly" }),
+		);
+	});
+
+	it("deserializes route-bound channel messages with the owning view deserializer", async () => {
+		const renderNode = vi.fn(() => "route-a-node");
+		const client = await makeClient();
+		const connected = client.connect();
+		const viewA = {
+			...view,
+			deserializeMessage: vi.fn((data: Serialized) =>
+				deserialize(data, {
+					coerceNullsToUndefined: true,
+					renderer: { renderNode },
+				}),
+			),
+		};
+		const viewB = {
+			...view,
+			deserializeMessage: vi.fn(() => {
+				throw new Error("wrong view");
+			}),
+		};
+		client.attach("/a", viewA);
+		client.attach("/b", viewB);
+		const bridge = client.acquireChannel("chan-1");
+		const handler = vi.fn();
+		bridge.on("ping", handler);
+		socket.trigger("connect");
+		await connected;
+
+		socket.trigger("message", [
+			[[], [], [], [], [6]],
+			{
+				type: "channel_message",
+				path: "/a",
+				channel: "chan-1",
+				event: "ping",
+				payload: {
+					content: {
+						tag: "$$RouteOnly",
+						props: { label: "A" },
+						children: [],
+					},
+				},
+			},
+		] satisfies Serialized);
+
+		expect(viewA.deserializeMessage).toHaveBeenCalledTimes(1);
+		expect(viewB.deserializeMessage).not.toHaveBeenCalled();
+		expect(handler).toHaveBeenCalledWith({ content: "route-a-node" });
+	});
+
+	it("drops unroutable channel messages with pulse nodes", async () => {
+		const client = await makeClient();
+		const connected = client.connect();
+		const bridge = client.acquireChannel("chan-1");
+		const handler = vi.fn();
+		bridge.on("ping", handler);
+		socket.trigger("connect");
+		await connected;
+
+		socket.trigger("message", [
+			[[], [], [], [], [5]],
+			{
+				type: "channel_message",
+				channel: "chan-1",
+				event: "ping",
+				payload: {
+					tag: "$$RouteOnly",
+					props: { label: "A" },
+					children: [],
+				},
+			},
+		] satisfies Serialized);
+
+		expect(handler).not.toHaveBeenCalled();
 	});
 });

--- a/packages/pulse/js/src/client.tsx
+++ b/packages/pulse/js/src/client.tsx
@@ -167,10 +167,26 @@ export class PulseSocketIOClient {
 				for (const [path, route] of this.#activeViews) {
 					this.#sendAttach(path, route.routeInfo, socket);
 				}
+				for (const [channel, endpoint] of this.#channels) {
+					socket.emit(
+						"message",
+						serialize({
+							type: "channel_connect",
+							channel,
+							path: endpoint.path,
+						}),
+					);
+				}
 
 				for (const payload of this.#messageQueue) {
 					// Already sent above
 					if (payload.type === "attach" && this.#activeViews.has(payload.path)) {
+						continue;
+					}
+					if (
+						payload.type === "channel_connect" ||
+						payload.type === "channel_disconnect"
+					) {
 						continue;
 					}
 					// We're reattaching all the routes, so no need to send update
@@ -470,8 +486,13 @@ export class PulseSocketIOClient {
 		if (this.#channels.has(id)) {
 			throw new Error(`Pulse channel '${id}' is already acquired`);
 		}
-		const bridge = new ChannelBridge(this, id);
+		const bridge = new ChannelBridge(this, id, path);
 		this.#channels.set(id, { path, bridge });
+		this.sendMessage({
+			type: "channel_connect",
+			channel: id,
+			path,
+		});
 		return bridge;
 	}
 
@@ -550,10 +571,8 @@ export class PulseSocketIOClient {
 		this.#channels.delete(id);
 		endpoint.bridge.dispose(new PulseChannelResetError("Channel released"));
 		this.sendMessage({
-			type: "channel_message",
+			type: "channel_disconnect",
 			channel: id,
-			event: "__close__",
-			payload: { reason: "refcount_zero" },
 		});
 	}
 }

--- a/packages/pulse/js/src/client.tsx
+++ b/packages/pulse/js/src/client.tsx
@@ -61,7 +61,7 @@ export class PulseSocketIOClient {
 	#socket: Socket | null = null;
 	#messageQueue: ClientMessage[];
 	#connectionListeners: Set<ConnectionStatusListener> = new Set();
-	#channels: Map<string, { bridge: ChannelBridge; refCount: number }> = new Map();
+	#channels: Map<string, { path: string; bridge: ChannelBridge }> = new Map();
 	#url: string;
 	#frameworkNavigate: NavigateFunction;
 	#directives: Directives;
@@ -254,6 +254,11 @@ export class PulseSocketIOClient {
 		this.#activeAttachIds.delete(path);
 		this.#ackedAttachIds.delete(path);
 		this.#pendingCallbacks.delete(path);
+		for (const [channel, endpoint] of [...this.#channels]) {
+			if (endpoint.path === path) {
+				this.#releaseChannel(channel, endpoint);
+			}
+		}
 		void this.sendMessage({ type: "detach", path });
 	}
 
@@ -461,49 +466,28 @@ export class PulseSocketIOClient {
 		this.sendMessage(msg);
 	}
 
-	public acquireChannel(id: string): ChannelBridge {
-		const entry = this.#ensureChannelEntry(id);
-		entry.refCount += 1;
-		return entry.bridge;
+	public acquireChannel(id: string, path = ""): ChannelBridge {
+		if (this.#channels.has(id)) {
+			throw new Error(`Pulse channel '${id}' is already acquired`);
+		}
+		const bridge = new ChannelBridge(this, id);
+		this.#channels.set(id, { path, bridge });
+		return bridge;
 	}
 
-	public releaseChannel(id: string): void {
-		const entry = this.#channels.get(id);
-		if (!entry) {
+	public releaseChannel(id: string, path = ""): void {
+		const endpoint = this.#channels.get(id);
+		if (!endpoint || endpoint.path !== path) {
 			return;
 		}
-		entry.refCount = Math.max(0, entry.refCount - 1);
-		if (entry.refCount === 0) {
-			entry.bridge.dispose(new PulseChannelResetError("Channel released"));
-			this.sendMessage({
-				type: "channel_message",
-				channel: id,
-				event: "__close__",
-				payload: { reason: "refcount_zero" },
-			});
-			this.#channels.delete(id);
-		}
-	}
-
-	#ensureChannelEntry(id: string): {
-		bridge: ChannelBridge;
-		refCount: number;
-	} {
-		let entry = this.#channels.get(id);
-		if (!entry) {
-			entry = {
-				bridge: new ChannelBridge(this, id),
-				refCount: 0,
-			};
-			this.#channels.set(id, entry);
-		}
-		return entry;
+		this.#releaseChannel(id, endpoint);
 	}
 
 	#routeChannelMessage(message: ServerChannelMessage): void {
-		const entry = this.#ensureChannelEntry(message.channel);
-		const closed = entry.bridge.handleServerMessage(message);
-		if (closed && entry.refCount === 0) {
+		const endpoint = this.#channels.get(message.channel);
+		if (!endpoint) return;
+		const closed = endpoint.bridge.handleServerMessage(message);
+		if (closed) {
 			this.#channels.delete(message.channel);
 		}
 	}
@@ -559,10 +543,17 @@ export class PulseSocketIOClient {
 		}
 	}
 
-	_ensureChannelEntry(id: string): {
-		bridge: ChannelBridge;
-		refCount: number;
-	} {
-		return this.#ensureChannelEntry(id);
+	#releaseChannel(
+		id: string,
+		endpoint: { path: string; bridge: ChannelBridge },
+	): void {
+		this.#channels.delete(id);
+		endpoint.bridge.dispose(new PulseChannelResetError("Channel released"));
+		this.sendMessage({
+			type: "channel_message",
+			channel: id,
+			event: "__close__",
+			payload: { reason: "refcount_zero" },
+		});
 	}
 }

--- a/packages/pulse/js/src/client.tsx
+++ b/packages/pulse/js/src/client.tsx
@@ -15,7 +15,7 @@ import type {
 } from "./messages";
 import type { PulsePrerenderView } from "./pulse";
 import { extractEvent } from "./serialize/events";
-import { deserialize, serialize } from "./serialize/serializer";
+import { deserialize, serialize, type Serialized } from "./serialize/serializer";
 import type { VDOMUpdate } from "./vdom";
 
 
@@ -35,6 +35,7 @@ export interface MountedView {
 	onUpdate: (ops: VDOMUpdate[]) => void;
 	onJsExec: (msg: ServerJsExecMessage) => void;
 	onServerError: (error: ServerError) => void;
+	deserializeMessage: (data: Serialized) => ServerMessage;
 }
 export type ConnectionStatus = "ok" | "connecting" | "reconnecting" | "error";
 export type ConnectionStatusListener = (status: ConnectionStatus) => void;
@@ -198,9 +199,7 @@ export class PulseSocketIOClient {
 			});
 
 			// Wrap in an arrow function to avoid losing the `this` reference
-			socket.on("message", (data) =>
-				this.#handleServerMessage(deserialize(data, { coerceNullsToUndefined: true })),
-			);
+			socket.on("message", (data) => this.#handleSerializedServerMessage(data));
 		});
 	}
 
@@ -515,6 +514,97 @@ export class PulseSocketIOClient {
 		}
 	}
 
+	#handleSerializedServerMessage(data: Serialized): void {
+		const raw = this.#serializedPayloadObject(data);
+		if (raw) {
+			const type = raw.type;
+			if (type === "js_exec") {
+				this.#handleSerializedJsExec(data, raw);
+				return;
+			}
+			if (type === "channel_message") {
+				if (this.#handleSerializedChannelMessage(data, raw)) {
+					return;
+				}
+			}
+		}
+		this.#handleServerMessage(deserialize(data, { coerceNullsToUndefined: true }));
+	}
+
+	#handleSerializedJsExec(data: Serialized, raw: Record<string, unknown>): void {
+		const path = raw.path;
+		if (typeof path !== "string") {
+			return;
+		}
+		const view = this.#activeViews.get(path);
+		if (!view) {
+			if (typeof raw.id === "string") this.#sendJsResult(raw.id, undefined, null);
+			return;
+		}
+		this.#handleServerMessage(this.#deserializeForView(data, view, "js_exec", path));
+	}
+
+	#handleSerializedChannelMessage(
+		data: Serialized,
+		raw: Record<string, unknown>,
+	): boolean {
+		const path = raw.path;
+		if (typeof path === "string") {
+			const view = this.#activeViews.get(path);
+			if (!view) {
+				if (typeof raw.channel === "string") {
+					this.#dropChannel(
+						raw.channel,
+						new PulseChannelResetError("Channel view is no longer active"),
+					);
+				}
+				return true;
+			}
+			this.#handleServerMessage(
+				this.#deserializeForView(data, view, "channel_message", path),
+			);
+			return true;
+		}
+		if (this.#hasPulseNodes(data)) {
+			if (typeof raw.channel === "string") {
+				this.#dropChannel(
+					raw.channel,
+					new PulseChannelResetError(
+						"Route-bound channel message is missing an active view path",
+					),
+				);
+			}
+			return true;
+		}
+		return false;
+	}
+
+	#deserializeForView(
+		data: Serialized,
+		view: MountedView,
+		type: string,
+		path: string,
+	): ServerMessage {
+		try {
+			return view.deserializeMessage(data);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new Error(`[Pulse] Failed to deserialize ${type} for path '${path}': ${message}`);
+		}
+	}
+
+	#serializedPayloadObject(data: Serialized): Record<string, unknown> | null {
+		const raw = data[1];
+		if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+			return null;
+		}
+		return raw as Record<string, unknown>;
+	}
+
+	#hasPulseNodes(data: Serialized): boolean {
+		return data[0][4].length > 0;
+	}
+
 	#sendAttach(path: string, routeInfo: RouteInfo, socket?: Socket): void {
 		const attachId = `${path}:${++this.#nextAttachId}`;
 		this.#activeAttachIds.set(path, attachId);
@@ -557,6 +647,13 @@ export class PulseSocketIOClient {
 		for (const message of queue) {
 			this.sendMessage(message);
 		}
+	}
+
+	#dropChannel(id: string, reason: PulseChannelResetError): void {
+		const entry = this.#channels.get(id);
+		if (!entry) return;
+		this.#channels.delete(id);
+		entry.bridge.dispose(reason);
 	}
 
 	_ensureChannelEntry(id: string): {

--- a/packages/pulse/js/src/client.tsx
+++ b/packages/pulse/js/src/client.tsx
@@ -7,11 +7,13 @@ import type {
 	ClientCallbackMessage,
 	ClientJsResultMessage,
 	ClientMessage,
+	ClientResumeMessage,
 	ServerApiCallMessage,
 	ServerChannelMessage,
 	ServerError,
 	ServerJsExecMessage,
 	ServerMessage,
+	ServerResumeMessage,
 } from "./messages";
 import type { PulsePrerenderView } from "./pulse";
 import { extractEvent } from "./serialize/events";
@@ -75,6 +77,8 @@ export class PulseSocketIOClient {
 	#errorTimeout: ReturnType<typeof setTimeout> | null = null;
 	#currentStatus: ConnectionStatus = "ok";
 	#nextAttachId = 0;
+	#resumePending = false;
+	#pendingResumeId: string | null = null;
 
 	constructor(
 		url: string,
@@ -163,6 +167,10 @@ export class PulseSocketIOClient {
 
 			socket.on("connect", () => {
 				console.log("[SocketIOTransport] Connected:", this.#socket?.id);
+				if (this.#hasConnectedOnce) {
+					this.#startResume(socket);
+					return;
+				}
 				// Send attach for all active views on connect/reconnect
 				for (const [path, route] of this.#activeViews) {
 					this.#sendAttach(path, route.routeInfo, socket);
@@ -236,7 +244,7 @@ export class PulseSocketIOClient {
 	}
 
 	public sendMessage(payload: ClientMessage) {
-		if (this.isConnected()) {
+		if (this.isConnected() && !this.#resumePending) {
 			// console.log("[SocketIOTransport] Sending:", payload);
 			this.#socket!.emit("message", serialize(payload as any));
 		} else {
@@ -294,6 +302,8 @@ export class PulseSocketIOClient {
 		this.#channels.clear();
 		this.#currentStatus = "ok";
 		this.#hasConnectedOnce = false;
+		this.#resumePending = false;
+		this.#pendingResumeId = null;
 	}
 
 	#handleServerMessage(message: ServerMessage) {
@@ -371,6 +381,10 @@ export class PulseSocketIOClient {
 			}
 			case "reload": {
 				window.location.reload();
+				break;
+			}
+			case "server_resume": {
+				this.#handleServerResume(message);
 				break;
 			}
 			case "attach_ack": {
@@ -515,9 +529,117 @@ export class PulseSocketIOClient {
 
 	#handleTransportDisconnect(): void {
 		this.#ackedAttachIds.clear();
+		this.#resumePending = false;
+		this.#pendingResumeId = null;
 		for (const entry of this.#channels.values()) {
 			entry.bridge.handleDisconnect(new PulseChannelResetError("Connection lost"));
 		}
+	}
+
+	#startResume(socket: Socket): void {
+		const resumeId = `${Date.now()}:${Math.random().toString(16).slice(2)}`;
+		this.#resumePending = true;
+		this.#pendingResumeId = resumeId;
+		const views: ClientResumeMessage["views"] = [];
+		for (const [path, view] of this.#activeViews) {
+			const attachId = this.#activeAttachIds.get(path);
+			views.push({
+				path,
+				routeInfo: view.routeInfo,
+				...(attachId ? { attachId } : {}),
+			});
+		}
+		const channels: ClientResumeMessage["channels"] = [];
+		for (const [channel, endpoint] of this.#channels) {
+			channels.push({ channel, path: endpoint.path });
+		}
+		socket.emit(
+			"message",
+			serialize({
+				type: "client_resume",
+				resumeId,
+				views,
+				channels,
+			} satisfies ClientResumeMessage),
+		);
+	}
+
+	#handleServerResume(message: ServerResumeMessage): void {
+		if (message.resumeId !== this.#pendingResumeId) return;
+		this.#pendingResumeId = null;
+		if (message.status === "reload") {
+			this.#resumePending = false;
+			this.#messageQueue = [];
+			this.#pendingCallbacks.clear();
+			for (const [channel, endpoint] of this.#channels) {
+				endpoint.bridge.dispose(new PulseChannelResetError("Resume rejected"));
+				this.#channels.delete(channel);
+			}
+			window.location.reload();
+			return;
+		}
+
+		const acceptedViews = new Set((message.views ?? []).map((view) => view.path));
+		const acceptedChannels = new Map(
+			(message.channels ?? []).map((channel) => [channel.channel, channel.path]),
+		);
+
+		for (const path of [...this.#pendingCallbacks.keys()]) {
+			if (!acceptedViews.has(path)) {
+				this.#pendingCallbacks.delete(path);
+			}
+		}
+		for (const view of message.views ?? []) {
+			const attachId = view.attachId ?? this.#activeAttachIds.get(view.path);
+			if (attachId && this.#activeAttachIds.get(view.path) === attachId) {
+				this.#ackedAttachIds.set(view.path, attachId);
+			}
+		}
+		for (const [channel, endpoint] of [...this.#channels]) {
+			if (acceptedChannels.get(channel) !== endpoint.path) {
+				endpoint.bridge.dispose(
+					new PulseChannelResetError("Channel was not resumed"),
+				);
+				this.#channels.delete(channel);
+			}
+		}
+
+		const queued = this.#messageQueue;
+		this.#messageQueue = [];
+		this.#resumePending = false;
+		for (const path of acceptedViews) {
+			this.#flushPendingCallbacks(path);
+		}
+		for (const payload of queued) {
+			if (this.#shouldReplayAfterResume(payload, acceptedViews, acceptedChannels)) {
+				this.sendMessage(payload);
+			}
+		}
+		this.#handleConnected();
+	}
+
+	#shouldReplayAfterResume(
+		payload: ClientMessage,
+		acceptedViews: Set<string>,
+		acceptedChannels: Map<string, string>,
+	): boolean {
+		if (
+			payload.type === "attach" ||
+			payload.type === "detach" ||
+			payload.type === "update" ||
+			payload.type === "channel_connect" ||
+			payload.type === "channel_disconnect" ||
+			payload.type === "client_resume"
+		) {
+			return false;
+		}
+		if (payload.type === "callback") {
+			return acceptedViews.has(payload.path);
+		}
+		if (payload.type === "channel_message") {
+			return acceptedChannels.has(payload.channel);
+		}
+		return true;
 	}
 
 	#sendAttach(path: string, routeInfo: RouteInfo, socket?: Socket): void {

--- a/packages/pulse/js/src/index.ts
+++ b/packages/pulse/js/src/index.ts
@@ -1,7 +1,7 @@
 // Public API surface for pulse-client
 
-export type { ChannelBridge } from "./channel";
-export { PulseChannelResetError, usePulseChannel } from "./channel";
+export type { ChannelBridge, PulseChannelLease, PulseChannelManager } from "./channel";
+export { PulseChannelResetError } from "./channel";
 // Client implementation (types only - implementation is internal)
 export type {
 	ConnectionStatusListener,
@@ -38,7 +38,16 @@ export type {
 } from "./messages";
 export type { PulseConfig, PulsePrerender, PulseProviderProps } from "./pulse";
 // Core React bindings
-export { PulseProvider, PulseView, usePulseClient } from "./pulse";
+export {
+	PulseViewPathContext,
+	PulseProvider,
+	PulseView,
+	usePulseChannel,
+	usePulseChannelManager,
+	usePulseChannelManagerForPath,
+	usePulseClient,
+	usePulseViewPath,
+} from "./pulse";
 // Renderer helpers
 // Renderer (structural expressions + eval-keyed props)
 export { VDOMRenderer } from "./renderer";

--- a/packages/pulse/js/src/messages.ts
+++ b/packages/pulse/js/src/messages.ts
@@ -43,6 +43,7 @@ export interface ServerApiCallMessage {
 
 export interface ServerChannelRequestMessage {
 	type: "channel_message";
+	path?: string;
 	channel: string;
 	event: string;
 	payload?: any;
@@ -53,6 +54,7 @@ export interface ServerChannelRequestMessage {
 
 export interface ServerChannelResponseMessage {
 	type: "channel_message";
+	path?: string;
 	channel: string;
 	event?: undefined;
 	responseTo: string;

--- a/packages/pulse/js/src/messages.ts
+++ b/packages/pulse/js/src/messages.ts
@@ -77,6 +77,24 @@ export interface ServerReloadMessage {
 	type: "reload";
 }
 
+export interface ServerResumeView {
+	path: string;
+	attachId?: string;
+}
+
+export interface ServerResumeChannel {
+	channel: string;
+	path: string;
+}
+
+export interface ServerResumeMessage {
+	type: "server_resume";
+	resumeId: string;
+	status: "ok" | "reload";
+	views?: ServerResumeView[];
+	channels?: ServerResumeChannel[];
+}
+
 export interface ServerAttachAckMessage {
 	type: "attach_ack";
 	path: string;
@@ -97,6 +115,7 @@ export type ServerMessage =
 	| ServerApiCallMessage
 	| ServerNavigateToMessage
 	| ServerReloadMessage
+	| ServerResumeMessage
 	| ServerAttachAckMessage
 	| ServerChannelRequestMessage
 	| ServerChannelResponseMessage
@@ -123,6 +142,24 @@ export interface ClientUpdateMessage {
 export interface ClientDetachMessage {
 	type: "detach";
 	path: string;
+}
+
+export interface ClientResumeView {
+	path: string;
+	routeInfo: RouteInfo;
+	attachId?: string;
+}
+
+export interface ClientResumeChannel {
+	channel: string;
+	path: string;
+}
+
+export interface ClientResumeMessage {
+	type: "client_resume";
+	resumeId: string;
+	views: ClientResumeView[];
+	channels: ClientResumeChannel[];
 }
 
 export interface ClientApiResultMessage {
@@ -179,6 +216,7 @@ export type ClientMessage =
 	| ClientCallbackMessage
 	| ClientUpdateMessage
 	| ClientDetachMessage
+	| ClientResumeMessage
 	| ClientApiResultMessage
 	| ClientChannelRequestMessage
 	| ClientChannelResponseMessage

--- a/packages/pulse/js/src/messages.ts
+++ b/packages/pulse/js/src/messages.ts
@@ -156,6 +156,17 @@ export interface ClientChannelResponseMessage {
 
 export type ClientChannelMessage = ClientChannelRequestMessage | ClientChannelResponseMessage;
 
+export interface ClientChannelConnectMessage {
+	type: "channel_connect";
+	channel: string;
+	path: string;
+}
+
+export interface ClientChannelDisconnectMessage {
+	type: "channel_disconnect";
+	channel: string;
+}
+
 export interface ClientJsResultMessage {
 	type: "js_result";
 	id: string;
@@ -171,4 +182,6 @@ export type ClientMessage =
 	| ClientApiResultMessage
 	| ClientChannelRequestMessage
 	| ClientChannelResponseMessage
+	| ClientChannelConnectMessage
+	| ClientChannelDisconnectMessage
 	| ClientJsResultMessage;

--- a/packages/pulse/js/src/pulse.test.tsx
+++ b/packages/pulse/js/src/pulse.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "bun:test";
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router";
+import { PulseProvider, PulseView, usePulseChannel, usePulseViewPath } from "./pulse";
+
+vi.mock("socket.io-client", () => ({
+	io: () => ({
+		connected: false,
+		disconnect: vi.fn(),
+		emit: vi.fn(),
+		on: vi.fn(),
+	}),
+}));
+
+describe("PulseView channel hooks", () => {
+	it("provides view path context and returns null before channel effect runs", async () => {
+		const states: Array<{ path: string; channel: string | null }> = [];
+
+		function Probe() {
+			const path = usePulseViewPath();
+			const channel = usePulseChannel("chan-1");
+			states.push({ path, channel: channel?.id ?? null });
+			return <div data-testid="channel">{channel?.id ?? "null"}</div>;
+		}
+
+		render(
+			<MemoryRouter initialEntries={["/test"]}>
+				<PulseProvider
+					config={{
+						serverAddress: "http://pulse.test",
+						apiPrefix: "/api",
+						connectionStatus: {
+							initialConnectingDelay: 100000,
+							initialErrorDelay: 100000,
+							reconnectErrorDelay: 100000,
+						},
+					}}
+					prerender={{
+						directives: {},
+						views: {
+							"/test": {
+								vdom: { tag: "$$Probe" },
+							},
+						},
+					}}
+				>
+					<PulseView path="/test" registry={{ Probe }} />
+				</PulseProvider>
+			</MemoryRouter>,
+		);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("channel")).toHaveTextContent("chan-1");
+		});
+		expect(states[0]).toEqual({ path: "/test", channel: null });
+		expect(states.at(-1)).toEqual({ path: "/test", channel: "chan-1" });
+	});
+});

--- a/packages/pulse/js/src/pulse.tsx
+++ b/packages/pulse/js/src/pulse.tsx
@@ -9,6 +9,11 @@ import {
 	useState,
 } from "react";
 import { useLocation, useNavigate, useParams } from "react-router";
+import {
+	createPulseChannelManager,
+	type ChannelBridge,
+	type PulseChannelManager,
+} from "./channel";
 import { type ConnectionStatus, type Directives, PulseSocketIOClient } from "./client";
 import type { RouteInfo } from "./helpers";
 import type { ServerError } from "./messages";
@@ -46,6 +51,7 @@ export type PulsePrerender = {
 // Context for the client, provided by PulseProvider
 const PulseClientContext = createContext<PulseSocketIOClient | null>(null);
 const PulsePrerenderContext = createContext<PulsePrerender | null>(null);
+export const PulseViewPathContext = createContext<string | null>(null);
 
 export const usePulseClient = () => {
 	const client = useContext(PulseClientContext);
@@ -66,6 +72,63 @@ export const usePulsePrerender = (path: string) => {
 	}
 	return view;
 };
+
+export const usePulseViewPath = () => {
+	const path = useContext(PulseViewPathContext);
+	if (!path) {
+		throw new Error("usePulseViewPath must be used within a PulseView");
+	}
+	return path;
+};
+
+export function usePulseChannelManager(): PulseChannelManager {
+	const path = usePulseViewPath();
+	return usePulseChannelManagerForPath(path);
+}
+
+export function usePulseChannelManagerForPath(path: string): PulseChannelManager {
+	const client = usePulseClient();
+	const manager = useMemo(() => createPulseChannelManager(client, path), [client, path]);
+	const pendingDispose = useRef<{
+		manager: PulseChannelManager;
+		timer: ReturnType<typeof setTimeout>;
+	} | null>(null);
+	useEffect(() => {
+		if (pendingDispose.current?.manager === manager) {
+			clearTimeout(pendingDispose.current.timer);
+			pendingDispose.current = null;
+		}
+		return () => {
+			const timer = setTimeout(() => {
+				manager.dispose();
+				if (pendingDispose.current?.manager === manager) {
+					pendingDispose.current = null;
+				}
+			}, 0);
+			pendingDispose.current = { manager, timer };
+		};
+	}, [manager]);
+	return manager;
+}
+
+export function usePulseChannel(channelId: string): ChannelBridge | null {
+	const manager = usePulseChannelManager();
+	const [bridge, setBridge] = useState<ChannelBridge | null>(null);
+
+	useEffect(() => {
+		if (!channelId) {
+			throw new Error("usePulseChannel requires a non-empty channelId");
+		}
+		const lease = manager.acquire(channelId);
+		setBridge(lease.bridge);
+		return () => {
+			setBridge((current) => (current === lease.bridge ? null : current));
+			lease.release();
+		};
+	}, [manager, channelId]);
+
+	return bridge;
+}
 
 // =================================================================
 // Provider
@@ -166,10 +229,11 @@ export interface PulseViewProps {
 
 export function PulseView({ path, registry }: PulseViewProps) {
 	const client = usePulseClient();
+	const channels = usePulseChannelManagerForPath(path);
 	const initialView = usePulsePrerender(path);
 	const renderer = useMemo(
-		() => new VDOMRenderer(client, path, registry),
-		[client, path, registry],
+		() => new VDOMRenderer(client, channels, path, registry),
+		[client, channels, path, registry],
 	);
 	const [tree, setTree] = useState<ReactNode>(() => renderer.init(initialView));
 	const [serverError, setServerError] = useState<ServerError | null>(null);
@@ -256,7 +320,7 @@ export function PulseView({ path, registry }: PulseViewProps) {
 		return <ServerErrorPopup error={serverError} />;
 	}
 
-	return tree;
+	return <PulseViewPathContext.Provider value={path}>{tree}</PulseViewPathContext.Provider>;
 }
 
 function ServerErrorPopup({ error }: { error: ServerError }) {

--- a/packages/pulse/js/src/pulse.tsx
+++ b/packages/pulse/js/src/pulse.tsx
@@ -13,6 +13,7 @@ import { type ConnectionStatus, type Directives, PulseSocketIOClient } from "./c
 import type { RouteInfo } from "./helpers";
 import type { ServerError } from "./messages";
 import { VDOMRenderer } from "./renderer";
+import { deserialize } from "./serialize/serializer";
 import type { VDOM } from "./vdom";
 
 // =================================================================
@@ -221,6 +222,8 @@ export function PulseView({ path, registry }: PulseViewProps) {
 					client.sendJsResult(msg.id, result, error);
 				},
 				onServerError: setServerError,
+				deserializeMessage: (data) =>
+					deserialize(data, { coerceNullsToUndefined: true, renderer }),
 			});
 			return () => {
 				renderer.clearPendingCallbacks();

--- a/packages/pulse/js/src/ref.test.ts
+++ b/packages/pulse/js/src/ref.test.ts
@@ -39,10 +39,24 @@ class FakeBridge {
 	}
 }
 
+function makeRegistry(bridge: FakeBridge, acquire = vi.fn(), release = vi.fn()) {
+	return {
+		registry: new RefRegistry({
+			acquire: (channelId: string) => {
+				acquire(channelId);
+				return { bridge, release } as any;
+			},
+			dispose() {},
+		}),
+		acquire,
+		release,
+	};
+}
+
 describe("RefRegistry", () => {
 	it("emits mount and unmount", () => {
 		const bridge = new FakeBridge();
-		const registry = new RefRegistry(() => bridge as any);
+		const { registry } = makeRegistry(bridge);
 		const cb = registry.getCallback("chan-1", "ref-1");
 
 		cb({});
@@ -56,7 +70,7 @@ describe("RefRegistry", () => {
 
 	it("handles request ops", () => {
 		const bridge = new FakeBridge();
-		const registry = new RefRegistry(() => bridge as any);
+		const { registry } = makeRegistry(bridge);
 		const cb = registry.getCallback("chan-1", "ref-1");
 
 		const element = {
@@ -75,7 +89,7 @@ describe("RefRegistry", () => {
 
 	it("handles call ops", () => {
 		const bridge = new FakeBridge();
-		const registry = new RefRegistry(() => bridge as any);
+		const { registry } = makeRegistry(bridge);
 		const cb = registry.getCallback("chan-1", "ref-1");
 
 		const focus = vi.fn();
@@ -92,12 +106,25 @@ describe("RefRegistry", () => {
 
 	it("locks to a single channel until disposed", () => {
 		const bridge = new FakeBridge();
-		const registry = new RefRegistry(() => bridge as any);
-		registry.getCallback("chan-1", "ref-1");
-		expect(() => registry.getCallback("chan-2", "ref-2")).toThrow(
+		const { registry } = makeRegistry(bridge);
+		registry.getCallback("chan-1", "ref-1")({});
+		expect(() => registry.getCallback("chan-2", "ref-2")({})).toThrow(
 			"[Pulse] Ref channel changed unexpectedly",
 		);
 		registry.dispose();
-		expect(() => registry.getCallback("chan-2", "ref-2")).not.toThrow();
+		expect(() => registry.getCallback("chan-2", "ref-2")({})).not.toThrow();
+	});
+
+	it("acquires lazily when the ref mounts and releases on dispose", () => {
+		const bridge = new FakeBridge();
+		const { registry, acquire, release } = makeRegistry(bridge);
+		const cb = registry.getCallback("chan-1", "ref-1");
+
+		expect(acquire).not.toHaveBeenCalled();
+		cb({});
+		expect(acquire).toHaveBeenCalledWith("chan-1");
+
+		registry.dispose();
+		expect(release).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/pulse/js/src/ref.tsx
+++ b/packages/pulse/js/src/ref.tsx
@@ -1,4 +1,4 @@
-import type { ChannelBridge } from "./channel";
+import type { ChannelBridge, PulseChannelLease, PulseChannelManager } from "./channel";
 import type { PulseRefSpec } from "./vdom";
 
 type RefPayload = {
@@ -10,11 +10,10 @@ type RefPayload = {
 type RefOpResult = any;
 
 type RefEntry = {
+	channelId: string;
 	node: any;
 	callback: (node: any) => void;
 };
-
-type ChannelBridgeProvider = (channelId: string) => ChannelBridge;
 
 const ATTR_ALIASES: Record<string, string> = {
 	className: "class",
@@ -180,24 +179,30 @@ export function isPulseRefSpec(v: unknown): v is PulseRefSpec {
 }
 
 export class RefRegistry {
-	#getBridge: ChannelBridgeProvider;
+	#channels: PulseChannelManager;
 	#bridge: ChannelBridge | null = null;
+	#releaseBridge: (() => void) | null = null;
 	#channelId: string | null = null;
 	#entries: Map<string, RefEntry> = new Map();
 	#cleanup: Array<() => void> = [];
 
-	constructor(getBridge: ChannelBridgeProvider) {
-		this.#getBridge = getBridge;
+	constructor(channels: PulseChannelManager) {
+		this.#channels = channels;
 	}
 
 	getCallback(channelId: string, refId: string): (node: any) => void {
-		this.#ensureChannel(channelId);
 		let entry = this.#entries.get(refId);
+		if (entry && entry.channelId !== channelId) {
+			throw new Error("[Pulse] Ref channel changed unexpectedly");
+		}
 		if (!entry) {
 			const callback = (node: any) => {
+				if (node) {
+					this.#ensureChannel(channelId);
+				}
 				this.#setNode(refId, node ?? null);
 			};
-			entry = { node: null, callback };
+			entry = { channelId, node: null, callback };
 			this.#entries.set(refId, entry);
 		}
 		return entry.callback;
@@ -214,14 +219,15 @@ export class RefRegistry {
 			}
 			return;
 		}
-		const bridge = this.#getBridge(channelId);
-		this.#bridge = bridge;
+		const lease: PulseChannelLease = this.#channels.acquire(channelId);
+		this.#bridge = lease.bridge;
+		this.#releaseBridge = lease.release;
 		this.#channelId = channelId;
 		this.#cleanup.push(
-			bridge.on("ref:call", (payload) => {
+			lease.bridge.on("ref:call", (payload) => {
 				this.#handleCall(payload);
 			}),
-			bridge.on("ref:request", (payload) => {
+			lease.bridge.on("ref:request", (payload) => {
 				return this.#handleRequest(payload);
 			}),
 		);
@@ -230,6 +236,8 @@ export class RefRegistry {
 	#teardown(): void {
 		for (const fn of this.#cleanup) fn();
 		this.#cleanup = [];
+		this.#releaseBridge?.();
+		this.#releaseBridge = null;
 		this.#entries.clear();
 		this.#bridge = null;
 		this.#channelId = null;

--- a/packages/pulse/js/src/renderer.test.tsx
+++ b/packages/pulse/js/src/renderer.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "bun:test";
 import React from "react";
-import { ChannelBridge } from "./channel";
+import { ChannelBridge, createPulseChannelManager } from "./channel";
 import { VDOMRenderer } from "./renderer";
 
 import type { VDOMNode, VDOMUpdate } from "./vdom";
@@ -20,21 +20,24 @@ describe("VDOMRenderer", () => {
 		const client: any = {
 			sendMessage,
 			invokeCallback,
-			_ensureChannelEntry: (id: string) => {
-				let bridge = bridges.get(id);
+			acquireChannel: (id: string, path: string) => {
+				const key = `${path}:${id}`;
+				let bridge = bridges.get(key);
 				if (!bridge) {
 					bridge = new ChannelBridge(client, id);
-					bridges.set(id, bridge);
+					bridges.set(key, bridge);
 				}
-				return { bridge, refCount: 0 };
+				return bridge;
 			},
+			releaseChannel: vi.fn(),
 		};
 		return { client, invokeCallback, sent };
 	}
 
 	function makeRenderer(registry: Record<string, unknown> = {}) {
 		const { client, invokeCallback, sent } = makeClient();
-		const renderer = new VDOMRenderer(client, "/test", registry);
+		const channels = createPulseChannelManager(client, "/test");
+		const renderer = new VDOMRenderer(client, channels, "/test", registry);
 		return { renderer, invokeCallback, sent };
 	}
 
@@ -149,8 +152,18 @@ describe("VDOMRenderer", () => {
 
 	it("handles multiple ref channels across renderers", () => {
 		const shared = makeClient();
-		const rendererA = new VDOMRenderer(shared.client, "/a", {});
-		const rendererB = new VDOMRenderer(shared.client, "/b", {});
+		const rendererA = new VDOMRenderer(
+			shared.client,
+			createPulseChannelManager(shared.client, "/a"),
+			"/a",
+			{},
+		);
+		const rendererB = new VDOMRenderer(
+			shared.client,
+			createPulseChannelManager(shared.client, "/b"),
+			"/b",
+			{},
+		);
 
 		const treeA = rendererA.renderNode({
 			tag: "input",

--- a/packages/pulse/js/src/renderer.test.tsx
+++ b/packages/pulse/js/src/renderer.test.tsx
@@ -24,7 +24,7 @@ describe("VDOMRenderer", () => {
 				const key = `${path}:${id}`;
 				let bridge = bridges.get(key);
 				if (!bridge) {
-					bridge = new ChannelBridge(client, id);
+					bridge = new ChannelBridge(client, id, path);
 					bridges.set(key, bridge);
 				}
 				return bridge;

--- a/packages/pulse/js/src/renderer.tsx
+++ b/packages/pulse/js/src/renderer.tsx
@@ -76,6 +76,16 @@ export class VDOMRenderer {
 		});
 	}
 
+	static snapshot(registry: ComponentRegistry = {}): VDOMRenderer {
+		const client = {
+			invokeCallback() {},
+			_ensureChannelEntry(channelId: string) {
+				throw new Error(`[Pulse] Snapshot VDOM cannot bind ref channel '${channelId}'`);
+			},
+		} as unknown as PulseSocketIOClient;
+		return new VDOMRenderer(client, "", registry);
+	}
+
 	getObject(key: string): unknown {
 		const obj = (this.#registry as any)[key];
 		if (obj === undefined) {

--- a/packages/pulse/js/src/renderer.tsx
+++ b/packages/pulse/js/src/renderer.tsx
@@ -7,6 +7,7 @@ import {
 	type ReactElement,
 	type ReactNode,
 } from "react";
+import type { PulseChannelManager } from "./channel";
 import type { PulseSocketIOClient } from "./client";
 import type { PulsePrerenderView } from "./pulse";
 import { isPulseRefSpec, RefRegistry } from "./ref";
@@ -65,15 +66,31 @@ export class VDOMRenderer {
 	// Track eval keys + callback entries per ReactElement (not real props).
 	#metaMap: WeakMap<ReactElement, ElementMeta>;
 
-	constructor(client: PulseSocketIOClient, path: string, registry: ComponentRegistry = {}) {
+	constructor(
+		client: PulseSocketIOClient,
+		channels: PulseChannelManager,
+		path: string,
+		registry: ComponentRegistry = {},
+	) {
 		this.#client = client;
 		this.#path = path;
 		this.#registry = registry;
 		this.#callbackEntries = new Set();
 		this.#metaMap = new WeakMap();
-		this.#refRegistry = new RefRegistry((channelId) => {
-			return this.#client._ensureChannelEntry(channelId).bridge;
-		});
+		this.#refRegistry = new RefRegistry(channels);
+	}
+
+	static snapshot(registry: ComponentRegistry = {}): VDOMRenderer {
+		const client = {
+			invokeCallback() {},
+		} as unknown as PulseSocketIOClient;
+		const channels: PulseChannelManager = {
+			acquire(channelId: string) {
+				throw new Error(`[Pulse] Snapshot VDOM cannot bind ref channel '${channelId}'`);
+			},
+			dispose() {},
+		};
+		return new VDOMRenderer(client, channels, "", registry);
 	}
 
 	getObject(key: string): unknown {

--- a/packages/pulse/js/src/serialize/serializer.test.ts
+++ b/packages/pulse/js/src/serialize/serializer.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import React from "react";
 import { deserialize, serialize, type Serialized } from "./serializer";
 
 describe("v4 serialization", () => {
@@ -141,13 +142,20 @@ describe("v4 serialization", () => {
 		expect(parsed.when).toBe(parsed.same);
 	});
 	it("decodes date literals as UTC midnight dates", () => {
-		const ser: Serialized = [[[], [0], [], []], "2024-01-02"];
+		const ser: Serialized = [[[], [0], [], [], []], "2024-01-02"];
 		const parsed = deserialize(ser) as Date;
 		expect(parsed).toBeInstanceOf(Date);
 		expect(parsed.toISOString()).toBe("2024-01-02T00:00:00.000Z");
 	});
+	it("decodes dates after primitive siblings", () => {
+		const ser = serialize(["x", new Date(Date.UTC(2024, 0, 2))]);
+		const parsed = deserialize(ser) as [string, Date];
+		expect(parsed[0]).toBe("x");
+		expect(parsed[1]).toBeInstanceOf(Date);
+		expect(parsed[1].toISOString()).toBe("2024-01-02T00:00:00.000Z");
+	});
 	it("throws on invalid date literals", () => {
-		const ser: Serialized = [[[], [0], [], []], "2024-02-30"];
+		const ser: Serialized = [[[], [0], [], [], []], "2024-02-30"];
 		expect(() => deserialize(ser)).toThrow("Invalid date literal: 2024-02-30");
 	});
 
@@ -200,5 +208,85 @@ describe("v4 serialization", () => {
 		const ser = serialize(data);
 		const parsed = deserialize(ser);
 		expect(parsed).toEqual(data);
+	});
+
+	it("leaves user VDOM-looking dictionaries alone without metadata", () => {
+		const payload: Serialized = [[[], [], [], [], []], { __pulse_vdom__: { tag: "span" } }];
+		expect(deserialize<any>(payload)).toEqual({ __pulse_vdom__: { tag: "span" } });
+	});
+
+	it("throws when pulse node metadata is present without a renderer or registry", () => {
+		const payload: Serialized = [
+			[[], [], [], [], [1]],
+			{ title: { tag: "span", children: ["Feedback"] } },
+		];
+		expect(() => deserialize(payload)).toThrow(
+			"Payload contains VDOM nodes but no renderer or registry was provided",
+		);
+	});
+
+	it("renders pulse node metadata with a one-shot renderer from a registry", () => {
+		const Badge = (props: { label: string }) => React.createElement("strong", props.label);
+		const payload: Serialized = [
+			[[], [], [], [], [1]],
+			{ title: { tag: "$$Badge", props: { label: "Feedback" } } },
+		];
+		const parsed = deserialize(payload, { registry: { Badge } }) as any;
+		expect(React.isValidElement(parsed.title)).toBe(true);
+		expect(parsed.title.type).toBe(Badge);
+		expect(parsed.title.props.label).toBe("Feedback");
+	});
+
+	it("reconstructs pulse node props before rendering VDOM", () => {
+		const Badge = (_props: { when: Date; tags: Set<string> }) => null;
+		const payload: Serialized = [
+			[[], [4], [5], [], [1]],
+			{
+				title: {
+					tag: "$$Badge",
+					props: {
+						when: "2024-04-05T06:07:08.000Z",
+						tags: ["saved"],
+					},
+				},
+			},
+		];
+		const parsed = deserialize(payload, { registry: { Badge } }) as any;
+		expect(parsed.title.type).toBe(Badge);
+		expect(parsed.title.props.when).toBeInstanceOf(Date);
+		expect(parsed.title.props.when.toISOString()).toBe("2024-04-05T06:07:08.000Z");
+		expect(parsed.title.props.tags).toBeInstanceOf(Set);
+		expect(Array.from(parsed.title.props.tags)).toEqual(["saved"]);
+	});
+
+	it("renders pulse nodes without consuming primitive children as traversal nodes", () => {
+		const payload: Serialized = [
+			[[], [5], [], [], [1]],
+			[{ tag: "span", children: ["x"] }, "2024-01-02"],
+		];
+		const parsed = deserialize(payload, { registry: {} }) as any;
+		expect(React.isValidElement(parsed[0])).toBe(true);
+		expect(parsed[0].props.children).toBe("x");
+		expect(parsed[1]).toBeInstanceOf(Date);
+		expect(parsed[1].toISOString()).toBe("2024-01-02T00:00:00.000Z");
+	});
+
+	it("preserves repeated pulse node references", () => {
+		const payload: Serialized = [
+			[[5], [], [], [], [1]],
+			[{ tag: "span", children: ["x"] }, 1],
+		];
+		const parsed = deserialize(payload, { registry: {} }) as any;
+		expect(React.isValidElement(parsed[0])).toBe(true);
+		expect(parsed[0].props.children).toBe("x");
+		expect(parsed[1]).toBe(parsed[0]);
+	});
+
+	it("requires the route-local registry for imported component pulse nodes", () => {
+		const payload: Serialized = [
+			[[], [], [], [], [1]],
+			{ title: { tag: "$$RouteOnly", props: { value: 1 } } },
+		];
+		expect(() => deserialize(payload, { registry: {} })).toThrow("Missing component 'RouteOnly'");
 	});
 });

--- a/packages/pulse/js/src/serialize/serializer.ts
+++ b/packages/pulse/js/src/serialize/serializer.ts
@@ -1,9 +1,13 @@
+import type { ReactNode } from "react";
+import { VDOMRenderer } from "../renderer";
+import type { ComponentRegistry, VDOMNode } from "../vdom";
+
 export type Primitive = number | string | boolean | null | undefined;
 export type JSON<T> = T | Array<JSON<T>> | { [K: string]: JSON<T> };
 export type PlainJSON = JSON<Primitive>;
 export type Serializable = any;
 
-export type Serialized = [[number[], number[], number[], number[]], PlainJSON];
+export type Serialized = [[number[], number[], number[], number[], number[]], PlainJSON];
 
 export function serialize(data: Serializable): Serialized {
 	const seen = new Map<any, number>();
@@ -11,11 +15,13 @@ export function serialize(data: Serializable): Serialized {
 	const dates: number[] = [];
 	const sets: number[] = [];
 	const maps: number[] = [];
+	const pulseNodes: number[] = [];
 
-	// Single global counter - increments once per node visit
+	// Single global counter - increments once per payload slot visit
 	let globalIndex = 0;
 
 	function process(value: Serializable, context?: string): PlainJSON {
+		const idx = globalIndex++;
 		if (value == null || typeof value === "string" || typeof value === "boolean") {
 			return value;
 		}
@@ -34,7 +40,6 @@ export function serialize(data: Serializable): Serialized {
 			return value;
 		}
 
-		const idx = globalIndex++;
 		const prevRef = seen.get(value);
 		if (prevRef !== undefined) {
 			// Make sure to push the current index, but use the ref's index as the value!
@@ -93,33 +98,60 @@ export function serialize(data: Serializable): Serialized {
 	}
 
 	const payload = process(data);
-	return [[refs, dates, sets, maps], payload];
+	return [[refs, dates, sets, maps, pulseNodes], payload];
 }
 
 export interface DeserializationOptions {
 	coerceNullsToUndefined?: boolean;
+	registry?: ComponentRegistry;
+	renderer?: Pick<VDOMRenderer, "renderNode">;
 }
 
 export function deserialize<Data extends Serializable = Serializable>(
 	payload: Serialized,
 	options?: DeserializationOptions,
 ): Data {
-	const [[refsA, datesA, setsA, mapsA], data] = payload;
+	const [metadata, data] = payload;
+	const [refsA, datesA, setsA, mapsA, pulseNodesA] = metadata;
 
 	const refs = new Set(refsA);
 	const dates = new Set(datesA);
 	const sets = new Set(setsA);
 	const maps = new Set(mapsA);
+	const pulseNodes = new Set(pulseNodesA);
+	const pulseRenderer = options?.renderer
+		? options.renderer
+		: options?.registry
+			? VDOMRenderer.snapshot(options.registry)
+			: undefined;
+	if (pulseNodes.size > 0 && !pulseRenderer) {
+		throw new Error("[Pulse] Payload contains VDOM nodes but no renderer or registry was provided");
+	}
 
 	const objects: Array<any> = [];
+	let globalIndex = 0;
 
 	function reconstruct(value: PlainJSON): any {
-		const idx = objects.length;
+		const idx = globalIndex++;
+		const shouldRenderPulseNode = pulseNodes.has(idx);
 		if (refs.has(idx)) {
-			// We increment the counter on refs during serialization. We're never
-			// going to use this entry, so we can just push null.
-			objects.push(null);
-			return objects[value as number];
+			if (typeof value !== "number") {
+				throw new Error("Reference payload must be a numeric index");
+			}
+			objects[idx] = null;
+			if (!(value in objects)) {
+				throw new Error(`Dangling reference to index ${value}`);
+			}
+			return objects[value];
+		}
+
+		function finish(result: any) {
+			if (!shouldRenderPulseNode) {
+				return result;
+			}
+			const node = pulseRenderer!.renderNode(result as VDOMNode) as ReactNode;
+			objects[idx] = node;
+			return node;
 		}
 
 		if (dates.has(idx)) {
@@ -130,23 +162,21 @@ export function deserialize<Data extends Serializable = Serializable>(
 			if (literal) {
 				const [y, m, d] = literal;
 				const dt = new Date(Date.UTC(y, m - 1, d));
-				objects.push(dt);
+				objects[idx] = dt;
 				return dt;
 			}
 			if (isDateLiteral(value)) {
 				throw new Error(`Invalid date literal: ${value}`);
 			}
 			const dt = new Date(value);
-			objects.push(dt);
+			objects[idx] = dt;
 			return dt;
 		}
 
-		if (
-			value == null ||
-			typeof value === "number" ||
-			typeof value === "string" ||
-			typeof value === "boolean"
-		) {
+		if (isPrimitive(value)) {
+			if (shouldRenderPulseNode) {
+				throw new Error("Pulse node payload must be a VDOM node");
+			}
 			if (options?.coerceNullsToUndefined) {
 				return value ?? undefined;
 			}
@@ -156,48 +186,57 @@ export function deserialize<Data extends Serializable = Serializable>(
 		if (Array.isArray(value)) {
 			if (sets.has(idx)) {
 				const result = new Set();
-				objects.push(result);
+				objects[idx] = result;
 				for (let i = 0; i < value.length; i++) {
 					result.add(reconstruct(value[i]));
 				}
-				return result;
+				return finish(result);
 			}
 
 			const length = value.length;
 			const arr = new Array(length);
-			objects.push(arr);
+			objects[idx] = arr;
 			for (let i = 0; i < length; i++) {
 				arr[i] = reconstruct(value[i]);
 			}
-			return arr;
+			return finish(arr);
 		}
 
 		if (typeof value === "object") {
 			if (maps.has(idx)) {
 				const result = new Map<string, any>();
-				objects.push(result);
+				objects[idx] = result;
 				const keys = Object.keys(value);
 				for (let i = 0; i < keys.length; i++) {
 					const key = keys[i];
 					result.set(key, reconstruct(value[key]));
 				}
-				return result;
+				return finish(result);
 			}
 
 			const result: Record<string, any> = {};
-			objects.push(result);
+			objects[idx] = result;
 			const keys = Object.keys(value);
 			for (let i = 0; i < keys.length; i++) {
 				const key = keys[i];
 				result[key] = reconstruct(value[key]);
 			}
-			return result;
+			return finish(result);
 		}
 
 		throw new Error(`Unsupported value in deserialization: ${value}`);
 	}
 
 	return reconstruct(data);
+}
+
+function isPrimitive(value: PlainJSON): value is Primitive {
+	return (
+		value == null ||
+		typeof value === "number" ||
+		typeof value === "string" ||
+		typeof value === "boolean"
+	);
 }
 
 const DATE_LITERAL_RE = /^\d{4}-\d{2}-\d{2}$/;

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -46,6 +46,8 @@ from pulse.helpers import (
 )
 from pulse.hooks.core import hooks
 from pulse.messages import (
+	ClientChannelConnectMessage,
+	ClientChannelDisconnectMessage,
 	ClientChannelMessage,
 	ClientChannelRequestMessage,
 	ClientChannelResponseMessage,
@@ -909,10 +911,25 @@ class App:
 			# Cancel any pending cleanup for active sessions (connected sessions stay alive)
 			self._cancel_render_cleanup(rid)
 			try:
-				if msg["type"] == "channel_message":
-					await self._handle_channel_message(render, session, msg)
+				if msg["type"] in (
+					"channel_message",
+					"channel_connect",
+					"channel_disconnect",
+				):
+					await self._handle_channel_message(
+						render,
+						session,
+						cast(
+							ClientChannelMessage
+							| ClientChannelConnectMessage
+							| ClientChannelDisconnectMessage,
+							msg,
+						),
+					)
 				else:
-					await self._handle_pulse_message(render, session, msg)
+					await self._handle_pulse_message(
+						render, session, cast(ClientPulseMessage, msg)
+					)
 			except Exception as e:
 				path = msg.get("path", "")
 				render.report_error(path, "server", e)
@@ -938,7 +955,6 @@ class App:
 				render.execute_callback(msg["path"], msg["callback"], msg["args"])
 			elif msg["type"] == "detach":
 				render.detach(msg["path"])
-				render.channels.remove_route(msg["path"])
 			elif msg["type"] == "api_result":
 				render.handle_api_result(dict(msg))
 			elif msg["type"] == "js_result":
@@ -975,8 +991,52 @@ class App:
 				)
 
 	async def _handle_channel_message(
-		self, render: RenderSession, session: UserSession, msg: ClientChannelMessage
+		self,
+		render: RenderSession,
+		session: UserSession,
+		msg: ClientChannelMessage
+		| ClientChannelConnectMessage
+		| ClientChannelDisconnectMessage,
 	) -> None:
+		if msg["type"] == "channel_connect":
+			channel_id = str(msg.get("channel", ""))
+
+			async def _next_connect() -> Ok[None]:
+				render.channels.handle_client_connect(msg)
+				return Ok(None)
+
+			with PulseContext.update(session=session, render=render):
+				res = await self.middleware.channel(
+					channel_id=channel_id,
+					event="__connect__",
+					payload=None,
+					request_id=None,
+					session=session.data,
+					next=_next_connect,
+				)
+
+			if isinstance(res, Deny):
+				render.channels.reject_client_connect(channel_id, "Denied")
+			return
+
+		if msg["type"] == "channel_disconnect":
+			channel_id = str(msg.get("channel", ""))
+
+			async def _next_disconnect() -> Ok[None]:
+				render.channels.handle_client_disconnect(msg)
+				return Ok(None)
+
+			with PulseContext.update(session=session, render=render):
+				await self.middleware.channel(
+					channel_id=channel_id,
+					event="__disconnect__",
+					payload=None,
+					request_id=None,
+					session=session.data,
+					next=_next_disconnect,
+				)
+			return
+
 		if msg.get("responseTo"):
 			msg = cast(ClientChannelResponseMessage, msg)
 			render.channels.handle_client_response(msg)

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -949,6 +949,8 @@ class App:
 							"attachId": attach_id,
 						}
 					)
+			elif msg["type"] == "client_resume":
+				render.resume(msg["resumeId"], msg["views"], msg["channels"])
 			elif msg["type"] == "update":
 				render.update_route(msg["path"], msg["routeInfo"])
 			elif msg["type"] == "callback":

--- a/packages/pulse/python/src/pulse/channel.py
+++ b/packages/pulse/python/src/pulse/channel.py
@@ -4,16 +4,19 @@ import uuid
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from pulse.context import PulseContext
 from pulse.messages import (
+	ClientChannelConnectMessage,
+	ClientChannelDisconnectMessage,
 	ClientChannelRequestMessage,
 	ClientChannelResponseMessage,
 	ServerChannelMessage,
 	ServerChannelRequestMessage,
 	ServerChannelResponseMessage,
 )
+from pulse.routing import ensure_absolute_path
 from pulse.scheduling import create_future
 
 if TYPE_CHECKING:
@@ -95,8 +98,15 @@ class ChannelsManager:
 			raise ValueError(f"Channel id '{channel_id}' is already in use")
 
 		route_path: str | None = None
+		mount_id: str | None = None
 		if bind_route and ctx.route is not None:
 			route_path = ctx.route.route_path
+			mount_id = ctx.source_mount_id
+			if mount_id is None:
+				try:
+					mount_id = render.get_route_mount(route_path).mount_id
+				except ValueError:
+					mount_id = None
 
 		channel = Channel(
 			self,
@@ -104,6 +114,7 @@ class ChannelsManager:
 			render_id=render.id,
 			session_id=session.sid,
 			route_path=route_path,
+			mount_id=mount_id,
 		)
 		self._channels[channel_id] = channel
 		if route_path is not None:
@@ -123,6 +134,81 @@ class ChannelsManager:
 			channel.closed = True
 			self.dispose_channel(channel, reason="route.unmount")
 		self._channels_by_route.pop(path, None)
+
+	def rebind_route_mount(
+		self, path: str, old_mount_id: str, new_mount_id: str
+	) -> None:
+		path = ensure_absolute_path(path)
+		for channel_id in self._channels_by_route.get(path, set()):
+			channel = self._channels.get(channel_id)
+			if channel is not None and channel.mount_id == old_mount_id:
+				channel.mount_id = new_mount_id
+
+	def handle_client_connect(self, message: ClientChannelConnectMessage) -> None:
+		channel_id = str(message.get("channel"))
+		channel = self._channels.get(channel_id)
+		if channel is None or channel.closed:
+			return
+
+		path = ensure_absolute_path(str(message.get("path", "")))
+		if channel.route_path is not None and path != channel.route_path:
+			logger.warning(
+				"Rejecting channel connect for wrong path: %s path=%s owner=%s",
+				channel_id,
+				path,
+				channel.route_path,
+			)
+			return
+
+		if channel.route_path is not None:
+			mount = self._render_session.route_mounts.get(channel.route_path)
+			if (
+				mount is None
+				or mount.state != "active"
+				or mount.mount_id != channel.mount_id
+			):
+				logger.warning(
+					"Rejecting stale channel connect: %s path=%s", channel_id, path
+				)
+				return
+
+		channel.connected = True
+
+	def handle_client_disconnect(self, message: ClientChannelDisconnectMessage) -> None:
+		channel_id = str(message.get("channel"))
+		channel = self._channels.get(channel_id)
+		if channel is None:
+			return
+		channel.connected = False
+		self._cancel_pending_for_channel(
+			channel_id, message="Channel has no connected client"
+		)
+
+	def disconnect_all(self) -> None:
+		for channel in self._channels.values():
+			channel.connected = False
+			self._cancel_pending_for_channel(
+				channel.id, message="Channel has no connected client"
+			)
+
+	def reject_client_connect(self, channel_id: str, message: str) -> None:
+		channel = self._channels.get(channel_id)
+		if channel is None:
+			return
+		channel.connected = False
+		try:
+			self.send_to_client(
+				channel=channel,
+				msg=ServerChannelRequestMessage(
+					type="channel_message",
+					channel=channel.id,
+					event="__close__",
+					payload={"reason": message},
+				),
+				allow_unconnected=True,
+			)
+		except ChannelClosed:
+			return
 
 	# ------------------------------------------------------------------
 	def handle_client_response(self, message: ClientChannelResponseMessage) -> None:
@@ -145,7 +231,7 @@ class ChannelsManager:
 	) -> None:
 		channel_id = str(message.get("channel"))
 		channel = self._channels.get(channel_id)
-		if channel is None:
+		if channel is None or channel.closed:
 			if request_id := message.get("requestId"):
 				self._send_error_response(channel_id, request_id, "Channel closed")
 			return
@@ -156,20 +242,16 @@ class ChannelsManager:
 			)
 			return
 
+		if not channel.connected:
+			if request_id := message.get("requestId"):
+				self._send_error_response(
+					channel_id, request_id, "Channel has no connected client"
+				)
+			return
+
 		event = message["event"]
 		payload = message.get("payload")
 		request_id = message.get("requestId")
-
-		if event == "__close__":
-			reason: str | None = None
-			if isinstance(payload, str):
-				reason = payload
-			elif isinstance(payload, dict):
-				raw_reason = cast(Any, payload.get("reason"))
-				if raw_reason is not None:
-					reason = str(raw_reason)
-			self.release_channel(channel.id, reason=reason)
-			return
 
 		route_ctx = None
 		source_mount_id = None
@@ -209,10 +291,13 @@ class ChannelsManager:
 					responseTo=request_id,
 					payload=result,
 				)
-				self.send_to_client(
-					channel=channel,
-					msg=msg,
-				)
+				try:
+					self.send_to_client(
+						channel=channel,
+						msg=msg,
+					)
+				except ChannelClosed:
+					return
 
 		render.create_task(_invoke(), name=f"channel:{channel_id}:{event}")
 
@@ -265,6 +350,7 @@ class ChannelsManager:
 			self.send_to_client(
 				channel=channel,
 				msg=msg,
+				allow_unconnected=True,
 			)
 		except ChannelClosed:
 			self.resolve_pending_error(request_id, ChannelClosed(message))
@@ -272,12 +358,14 @@ class ChannelsManager:
 	def send_error(self, channel_id: str, request_id: str, message: str) -> None:
 		self._send_error_response(channel_id, request_id, message)
 
-	def _cancel_pending_for_channel(self, channel_id: str) -> None:
+	def _cancel_pending_for_channel(
+		self, channel_id: str, *, message: str = "Channel closed"
+	) -> None:
 		for key, pending in list(self.pending_requests.items()):
 			if pending.channel_id != channel_id:
 				continue
 			if not pending.future.done():
-				pending.future.set_exception(ChannelClosed("Channel closed"))
+				pending.future.set_exception(ChannelClosed(message))
 			self.pending_requests.pop(key, None)
 
 	# ------------------------------------------------------------------
@@ -322,28 +410,37 @@ class ChannelsManager:
 		# print(f"Disposing channel id={channel.id} render={channel.render_id} session={channel.session_id} route={channel.route_path} reason={reason or 'unspecified'} pending={pending}")
 		self._cleanup_channel_refs(channel)
 		self._cancel_pending_for_channel(channel.id)
-		self._channels.pop(channel.id, None)
 		# Notify client that the channel has been closed
-		try:
-			msg = ServerChannelRequestMessage(
-				type="channel_message",
-				channel=channel.id,
-				event="__close__",
-				payload=None,
-			)
-			self.send_to_client(
-				channel=channel,
-				msg=msg,
-			)
-		except Exception:
-			print(f"Failed to send close notification for channel {channel.id}")
+		if channel.connected:
+			try:
+				msg = ServerChannelRequestMessage(
+					type="channel_message",
+					channel=channel.id,
+					event="__close__",
+					payload=None,
+				)
+				self.send_to_client(
+					channel=channel,
+					msg=msg,
+					allow_unconnected=True,
+				)
+			except Exception:
+				print(f"Failed to send close notification for channel {channel.id}")
+		channel.connected = False
+		channel.clear_handlers()
+		self._channels.pop(channel.id, None)
 
 	def send_to_client(
 		self,
 		*,
 		channel: "Channel",
 		msg: ServerChannelMessage,
+		allow_unconnected: bool = False,
 	) -> None:
+		if channel.closed and not allow_unconnected:
+			raise ChannelClosed(f"Channel '{channel.id}' is closed")
+		if not allow_unconnected and not channel.connected:
+			raise ChannelClosed("Channel has no connected client")
 		self._render_session.send(msg)
 
 
@@ -380,6 +477,8 @@ class Channel:
 	render_id: str
 	session_id: str
 	route_path: str | None
+	mount_id: str | None
+	connected: bool
 	_handlers: dict[str, list[ChannelHandler]]
 	closed: bool
 
@@ -391,12 +490,15 @@ class Channel:
 		render_id: str,
 		session_id: str,
 		route_path: str | None,
+		mount_id: str | None,
 	) -> None:
 		self._manager = manager
 		self.id = identifier
 		self.render_id = render_id
 		self.session_id = session_id
 		self.route_path = route_path
+		self.mount_id = mount_id
+		self.connected = False
 		self._handlers = defaultdict(list)
 		self.closed = False
 
@@ -464,6 +566,7 @@ class Channel:
 		"""
 
 		self._ensure_open()
+		self._ensure_connected()
 		msg = ServerChannelRequestMessage(
 			type="channel_message",
 			channel=self.id,
@@ -504,9 +607,9 @@ class Channel:
 		"""
 
 		self._ensure_open()
+		self._ensure_connected()
 		request_id = uuid.uuid4().hex
 		fut = create_future()
-		self._manager.register_pending(request_id, fut, self.id)
 		msg = ServerChannelRequestMessage(
 			type="channel_message",
 			channel=self.id,
@@ -518,6 +621,7 @@ class Channel:
 			channel=self,
 			msg=msg,
 		)
+		self._manager.register_pending(request_id, fut, self.id)
 		try:
 			if timeout is None:
 				return await fut
@@ -548,6 +652,13 @@ class Channel:
 	def _ensure_open(self) -> None:
 		if self.closed:
 			raise ChannelClosed(f"Channel '{self.id}' is closed")
+
+	def _ensure_connected(self) -> None:
+		if not self.connected:
+			raise ChannelClosed("Channel has no connected client")
+
+	def clear_handlers(self) -> None:
+		self._handlers.clear()
 
 	async def dispatch(
 		self, event: str, payload: Any, request_id: str | None

--- a/packages/pulse/python/src/pulse/channel.py
+++ b/packages/pulse/python/src/pulse/channel.py
@@ -344,6 +344,11 @@ class ChannelsManager:
 		channel: "Channel",
 		msg: ServerChannelMessage,
 	) -> None:
+		if channel.route_path is not None and "path" not in msg:
+			msg = cast(
+				ServerChannelMessage,
+				cast(object, {**msg, "path": channel.route_path}),
+			)
 		self._render_session.send(msg)
 
 

--- a/packages/pulse/python/src/pulse/channel.py
+++ b/packages/pulse/python/src/pulse/channel.py
@@ -174,6 +174,36 @@ class ChannelsManager:
 
 		channel.connected = True
 
+	def resume_client_channel(self, channel_id: str, path: str) -> bool:
+		channel = self._channels.get(channel_id)
+		if channel is None or channel.closed:
+			return False
+
+		path = ensure_absolute_path(path)
+		if channel.route_path is not None and path != channel.route_path:
+			logger.warning(
+				"Rejecting channel resume for wrong path: %s path=%s owner=%s",
+				channel_id,
+				path,
+				channel.route_path,
+			)
+			return False
+
+		if channel.route_path is not None:
+			mount = self._render_session.route_mounts.get(channel.route_path)
+			if (
+				mount is None
+				or mount.state != "active"
+				or mount.mount_id != channel.mount_id
+			):
+				logger.warning(
+					"Rejecting stale channel resume: %s path=%s", channel_id, path
+				)
+				return False
+
+		channel.connected = True
+		return True
+
 	def handle_client_disconnect(self, message: ClientChannelDisconnectMessage) -> None:
 		channel_id = str(message.get("channel"))
 		channel = self._channels.get(channel_id)

--- a/packages/pulse/python/src/pulse/messages.py
+++ b/packages/pulse/python/src/pulse/messages.py
@@ -156,6 +156,17 @@ class ClientChannelResponseMessage(TypedDict):
 	error: NotRequired[Any]
 
 
+class ClientChannelConnectMessage(TypedDict):
+	type: Literal["channel_connect"]
+	channel: str
+	path: str
+
+
+class ClientChannelDisconnectMessage(TypedDict):
+	type: Literal["channel_disconnect"]
+	channel: str
+
+
 class ClientJsResultMessage(TypedDict):
 	"""Result of client-side JS execution."""
 
@@ -188,7 +199,12 @@ ClientPulseMessage = (
 	| ClientJsResultMessage
 )
 ClientChannelMessage = ClientChannelRequestMessage | ClientChannelResponseMessage
-ClientMessage = ClientPulseMessage | ClientChannelMessage
+ClientChannelLifecycleMessage = (
+	ClientChannelConnectMessage | ClientChannelDisconnectMessage
+)
+ClientMessage = (
+	ClientPulseMessage | ClientChannelMessage | ClientChannelLifecycleMessage
+)
 
 
 class PrerenderPayload(TypedDict):

--- a/packages/pulse/python/src/pulse/messages.py
+++ b/packages/pulse/python/src/pulse/messages.py
@@ -55,6 +55,24 @@ class ServerReloadMessage(TypedDict):
 	type: Literal["reload"]
 
 
+class ServerResumeView(TypedDict):
+	path: str
+	attachId: NotRequired[str]
+
+
+class ServerResumeChannel(TypedDict):
+	channel: str
+	path: str
+
+
+class ServerResumeMessage(TypedDict):
+	type: Literal["server_resume"]
+	resumeId: str
+	status: Literal["ok", "reload"]
+	views: NotRequired[list[ServerResumeView]]
+	channels: NotRequired[list[ServerResumeChannel]]
+
+
 class ServerAttachAckMessage(TypedDict):
 	type: Literal["attach_ack"]
 	path: str
@@ -129,6 +147,24 @@ class ClientDetachMessage(TypedDict):
 	path: str
 
 
+class ClientResumeView(TypedDict):
+	path: str
+	routeInfo: RouteInfo
+	attachId: NotRequired[str]
+
+
+class ClientResumeChannel(TypedDict):
+	channel: str
+	path: str
+
+
+class ClientResumeMessage(TypedDict):
+	type: Literal["client_resume"]
+	resumeId: str
+	views: list[ClientResumeView]
+	channels: list[ClientResumeChannel]
+
+
 class ClientApiResultMessage(TypedDict):
 	type: Literal["api_result"]
 	id: str
@@ -184,6 +220,7 @@ ServerMessage = (
 	| ServerApiCallMessage
 	| ServerNavigateToMessage
 	| ServerReloadMessage
+	| ServerResumeMessage
 	| ServerAttachAckMessage
 	| ServerChannelMessage
 	| ServerJsExecMessage
@@ -195,6 +232,7 @@ ClientPulseMessage = (
 	| ClientAttachMessage
 	| ClientUpdateMessage
 	| ClientDetachMessage
+	| ClientResumeMessage
 	| ClientApiResultMessage
 	| ClientJsResultMessage
 )

--- a/packages/pulse/python/src/pulse/messages.py
+++ b/packages/pulse/python/src/pulse/messages.py
@@ -76,6 +76,7 @@ class ServerApiCallMessage(TypedDict):
 
 class ServerChannelRequestMessage(TypedDict):
 	type: Literal["channel_message"]
+	path: NotRequired[str]
 	channel: str
 	event: str
 	payload: Any
@@ -85,6 +86,7 @@ class ServerChannelRequestMessage(TypedDict):
 
 class ServerChannelResponseMessage(TypedDict):
 	type: Literal["channel_message"]
+	path: NotRequired[str]
 	channel: str
 	event: None
 	responseTo: str

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -341,6 +341,7 @@ class RenderSession:
 		"""WebSocket disconnected. Start queuing briefly before pausing."""
 		self._send_message = None
 		self.connected = False
+		self.channels.disconnect_all()
 
 		for mount in self.route_mounts.values():
 			if mount.state == "active":
@@ -525,6 +526,7 @@ class RenderSession:
 		if current is not mount:
 			return
 		try:
+			self.channels.remove_route(path)
 			self.route_mounts.pop(path, None)
 			self._ref_channels_by_route.pop(path, None)
 			mount.dispose()
@@ -534,11 +536,12 @@ class RenderSession:
 	def detach(self, path: str):
 		"""Client route unmounted. Dispose immediately outside dev StrictMode replay."""
 		path = ensure_absolute_path(path)
-		self._ref_channels_by_route.pop(path, None)
 		mount = self.route_mounts.get(path)
 		if not mount:
 			return
+		old_mount_id = mount.mount_id
 		mount.renew_mount_id()
+		self.channels.rebind_route_mount(path, old_mount_id, mount.mount_id)
 		if self.dev_strict_mode_detach_timeout > 0:
 			# React StrictMode in development intentionally replays mount effects as
 			# attach -> detach -> attach without another prerender. Keep the mount for

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -10,12 +10,17 @@ from pulse.channel import Channel
 from pulse.context import PulseContext
 from pulse.hooks.runtime import NotFoundInterrupt, RedirectInterrupt
 from pulse.messages import (
+	ClientResumeChannel,
+	ClientResumeView,
 	ServerApiCallMessage,
 	ServerErrorPhase,
 	ServerInitMessage,
 	ServerJsExecMessage,
 	ServerMessage,
 	ServerNavigateToMessage,
+	ServerResumeChannel,
+	ServerResumeMessage,
+	ServerResumeView,
 	ServerUpdateMessage,
 )
 from pulse.queries.store import QueryStore
@@ -504,6 +509,65 @@ class RenderSession:
 		if mount.state == "pending" and self._send_message:
 			mount.activate(self._send_message)
 		return mount.state == "active"
+
+	def resume(
+		self,
+		resume_id: str,
+		views: list[ClientResumeView],
+		channels: list[ClientResumeChannel],
+	) -> bool:
+		accepted_views: list[ServerResumeView] = []
+		accepted_paths: set[str] = set()
+
+		for view in views:
+			path = ensure_absolute_path(view["path"])
+			mount = self.route_mounts.get(path)
+			if mount is None or mount.state in ("idle", "closed"):
+				self.send(
+					ServerResumeMessage(
+						type="server_resume",
+						resumeId=resume_id,
+						status="reload",
+					)
+				)
+				return False
+			mount.update_route(view["routeInfo"])
+			if mount.state == "pending" and self._send_message:
+				mount.activate(self._send_message)
+			if mount.state != "active":
+				self.send(
+					ServerResumeMessage(
+						type="server_resume",
+						resumeId=resume_id,
+						status="reload",
+					)
+				)
+				return False
+			accepted_paths.add(path)
+			resumed_view: ServerResumeView = {"path": path}
+			if attach_id := view.get("attachId"):
+				resumed_view["attachId"] = attach_id
+			accepted_views.append(resumed_view)
+
+		accepted_channels: list[ServerResumeChannel] = []
+		for channel in channels:
+			channel_id = str(channel.get("channel", ""))
+			path = ensure_absolute_path(str(channel.get("path", "")))
+			if path not in accepted_paths:
+				continue
+			if self.channels.resume_client_channel(channel_id, path):
+				accepted_channels.append({"channel": channel_id, "path": path})
+
+		self.send(
+			ServerResumeMessage(
+				type="server_resume",
+				resumeId=resume_id,
+				status="ok",
+				views=accepted_views,
+				channels=accepted_channels,
+			)
+		)
+		return True
 
 	def update_route(self, path: str, route_info: RouteInfo):
 		"""Update routing state (query params, etc.) for attached path."""

--- a/packages/pulse/python/src/pulse/renderer.py
+++ b/packages/pulse/python/src/pulse/renderer.py
@@ -5,6 +5,7 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from types import NoneType
 from typing import Any, NamedTuple, TypeAlias, cast
+from typing import Literal as TypingLiteral
 
 from pulse.debounce import Debounced
 from pulse.helpers import values_equal
@@ -107,7 +108,10 @@ class RenderTree:
 
 
 class Renderer:
-	def __init__(self) -> None:
+	def __init__(
+		self, *, mode: TypingLiteral["persistent", "snapshot"] = "persistent"
+	) -> None:
+		self.mode: TypingLiteral["persistent", "snapshot"] = mode
 		self.callbacks: Callbacks = {}
 		self.operations: list[VDOMOperation] = []
 
@@ -417,6 +421,11 @@ class Renderer:
 				continue
 
 			if isinstance(value, RefHandle):
+				if self.mode == "snapshot":
+					if normalized is None:
+						normalized = current.copy()
+					normalized.pop(key, None)
+					continue
 				if key != "ref":
 					raise TypeError("RefHandle can only be used as the 'ref' prop")
 				eval_keys.add(key)
@@ -436,6 +445,11 @@ class Renderer:
 					}
 				continue
 			if isinstance(value, Debounced):
+				if self.mode == "snapshot":
+					if normalized is None:
+						normalized = current.copy()
+					normalized.pop(key, None)
+					continue
 				eval_keys.add(key)
 				if isinstance(old_value, (Element, PulseNode)):
 					unmount_element(old_value)
@@ -451,6 +465,11 @@ class Renderer:
 				continue
 
 			if callable(value):
+				if self.mode == "snapshot":
+					if normalized is None:
+						normalized = current.copy()
+					normalized.pop(key, None)
+					continue
 				eval_keys.add(key)
 				if isinstance(old_value, (Element, PulseNode)):
 					unmount_element(old_value)

--- a/packages/pulse/python/src/pulse/serializer.py
+++ b/packages/pulse/python/src/pulse/serializer.py
@@ -5,14 +5,14 @@ The format mirrors the TypeScript implementation in ``packages/pulse/js``.
 Serialized payload structure::
 
     (
-        ("refs|dates|sets|maps", payload),
+        ("refs|dates|sets|maps|pulse_nodes", payload),
     )
 
-- The first element is a compact metadata string with four pipe-separated
+- The first element is a compact metadata string with five pipe-separated
   comma-separated integer lists representing global node indices for:
-  ``refs``, ``dates``, ``sets``, ``maps``.
-- ``refs``  – indices where the payload entry is an integer pointing to a
-  previously visited node's index (shared refs/cycles).
+  ``refs``, ``dates``, ``sets``, ``maps``, ``pulse_nodes``.
+- ``refs``  – traversal indices where the payload entry is an integer pointing
+  to a previously visited node's index (shared refs/cycles).
 - ``dates`` – indices that should be materialised as temporal objects; the
   payload entry is an ISO 8601 string:
   - ``YYYY-MM-DD`` → ``datetime.date``
@@ -21,9 +21,11 @@ Serialized payload structure::
   items.
 - ``maps``  – indices that are ``Map`` instances; payload is an object mapping
   string keys to child payloads. Python reconstructs these as ``dict``.
+- ``pulse_nodes`` – indices that should be rendered as VDOM nodes by the JS
+  client.
 
-Nodes are assigned a single global index as they are visited (non-primitives
-only). This preserves shared references and cycles across nested structures
+Nodes are assigned a single global index as each payload slot is visited.
+This preserves shared references and cycles across nested structures
 containing primitives, lists/tuples, ``dict``/plain objects, ``set``, ``date``
 and ``datetime`` objects.
 """
@@ -34,11 +36,15 @@ import datetime as dt
 import math
 import types
 from dataclasses import fields, is_dataclass
-from typing import Any
+from typing import Any, TypeAlias
+
+from pulse.renderer import Renderer
+from pulse.transpiler.nodes import Element, Expr, PulseNode, Value, clone_renderable
 
 Primitive = int | float | str | bool | None
 PlainJSON = Primitive | list["PlainJSON"] | dict[str, "PlainJSON"]
-Serialized = tuple[tuple[list[int], list[int], list[int], list[int]], PlainJSON]
+SerializedMeta: TypeAlias = tuple[list[int], list[int], list[int], list[int], list[int]]
+Serialized = tuple[SerializedMeta, PlainJSON]
 
 __all__ = [
 	"serialize",
@@ -97,11 +103,19 @@ def serialize(data: Any) -> Serialized:
 	dates: list[int] = []
 	sets: list[int] = []
 	maps: list[int] = []
+	pulse_nodes: list[int] = []
 
 	global_index = 0
 
-	def process(value: Any) -> PlainJSON:
+	def process(value: Any) -> Any:
 		nonlocal global_index
+		unwrapped = unwrap_value(value)
+		if unwrapped is not value:
+			return process(unwrapped)
+
+		idx = global_index
+		global_index += 1
+
 		if value is None or isinstance(value, (bool, int, str)):
 			return value
 		if isinstance(value, float):
@@ -114,8 +128,27 @@ def serialize(data: Any) -> Serialized:
 				)
 			return value
 
-		idx = global_index
-		global_index += 1
+		if isinstance(value, (type, types.ModuleType)):
+			raise TypeError(f"Unsupported value in serialization: {type(value)!r}")
+
+		pulse_payload = None
+		if isinstance(value, Element):
+			pulse_payload = clone_renderable(value).render(Renderer(mode="snapshot"))
+		elif isinstance(value, PulseNode):
+			pulse_payload = clone_renderable(value).render(Renderer(mode="snapshot"))
+		elif isinstance(value, Expr):
+			pulse_payload = value.render()
+
+		if pulse_payload is not None and is_primitive(pulse_payload):
+			if isinstance(pulse_payload, float):
+				if math.isnan(pulse_payload):
+					return None
+				if math.isinf(pulse_payload):
+					raise ValueError(
+						f"Cannot serialize {pulse_payload}: Infinity is not valid JSON. "
+						+ "Replace with None or a sentinel value."
+					)
+			return pulse_payload
 
 		obj_id = id(value)
 		prev_ref = seen.get(obj_id)
@@ -123,6 +156,10 @@ def serialize(data: Any) -> Serialized:
 			refs.append(idx)
 			return prev_ref
 		seen[obj_id] = idx
+
+		if pulse_payload is not None:
+			pulse_nodes.append(idx)
+			value = pulse_payload
 
 		if isinstance(value, dt.datetime):
 			dates.append(idx)
@@ -161,7 +198,7 @@ def serialize(data: Any) -> Serialized:
 				dc_obj[f.name] = process(getattr(value, f.name))
 			return dc_obj
 
-		if callable(value) or isinstance(value, (type, types.ModuleType)):
+		if callable(value):
 			raise TypeError(f"Unsupported value in serialization: {type(value)!r}")
 
 		if hasattr(value, "__dict__"):
@@ -176,7 +213,7 @@ def serialize(data: Any) -> Serialized:
 
 	payload = process(data)
 
-	return ((refs, dates, sets, maps), payload)
+	return ((refs, dates, sets, maps, pulse_nodes), payload)
 
 
 def deserialize(
@@ -212,25 +249,26 @@ def deserialize(
 		restored = ps.deserialize(serialized)
 		```
 	"""
-	(refs, dates, sets, _maps), data = payload
+	(refs, dates, sets, _maps, _pulse_nodes), data = payload
 	refs = set(refs)
 	dates = set(dates)
 	sets = set(sets)
 	# we don't care about maps
 
-	objects: list[Any] = []
+	objects: dict[int, Any] = {}
+	global_index = 0
 
 	def reconstruct(value: PlainJSON) -> Any:
-		idx = len(objects)
+		nonlocal global_index
+		idx = global_index
+		global_index += 1
 
 		if idx in refs:
 			assert isinstance(value, (int, float)), (
 				"Reference payload must be numeric index"
 			)
-			# Placeholder to keep indices aligned
-			objects.append(None)
 			target_index = int(value)
-			assert 0 <= target_index < len(objects), (
+			assert target_index in objects, (
 				f"Dangling reference to index {target_index}"
 			)
 			return objects[target_index]
@@ -239,10 +277,10 @@ def deserialize(
 			assert isinstance(value, str), "Date payload must be an ISO string"
 			if _is_date_literal(value):
 				date_value = dt.date.fromisoformat(value)
-				objects.append(date_value)
+				objects[idx] = date_value
 				return date_value
 			dt_value = _datetime_from_iso(value)
-			objects.append(dt_value)
+			objects[idx] = dt_value
 			return dt_value
 
 		if value is None:
@@ -254,12 +292,12 @@ def deserialize(
 		if isinstance(value, list):
 			if idx in sets:
 				result_set: set[Any] = set()
-				objects.append(result_set)
+				objects[idx] = result_set
 				for entry in value:
 					result_set.add(reconstruct(entry))
 				return result_set
 			result_list: list[Any] = []
-			objects.append(result_list)
+			objects[idx] = result_list
 			for entry in value:
 				result_list.append(reconstruct(entry))
 			return result_list
@@ -267,7 +305,7 @@ def deserialize(
 		if isinstance(value, dict):
 			# Both maps and records are reconstructed as dictionaries in Python
 			result_dict: dict[str, Any] = {}
-			objects.append(result_dict)
+			objects[idx] = result_dict
 			for key, entry in value.items():
 				result_dict[str(key)] = reconstruct(entry)
 			return result_dict
@@ -275,6 +313,16 @@ def deserialize(
 		raise TypeError(f"Unsupported value in deserialization: {type(value)!r}")
 
 	return reconstruct(data)
+
+
+def unwrap_value(value: Any) -> Any:
+	if isinstance(value, Value):
+		return value.value
+	return value
+
+
+def is_primitive(value: Any) -> bool:
+	return value is None or isinstance(value, (bool, int, float, str))
 
 
 def _datetime_to_iso(value: dt.datetime) -> str:

--- a/packages/pulse/python/src/pulse/transpiler/nodes.py
+++ b/packages/pulse/python/src/pulse/transpiler/nodes.py
@@ -748,21 +748,20 @@ class Element(Expr):
 		return result
 
 	@override
-	def render(self):
-		"""Element rendering is handled by Renderer.render_node(), not render().
-
-		This method validates render-time constraints and raises TypeError
-		because Element produces VDOMElement, not VDOMExpr.
-		"""
+	def render(self, renderer: Any = None, path: str = ""):
+		"""Render this element as one-shot VDOM."""
 		# Validate key is string or numeric (not arbitrary Expr) during rendering
 		if self.key is not None and not isinstance(self.key, (str, int)):
 			raise TypeError(
 				f"Element key must be a string or int for rendering, got {type(self.key).__name__}. "
 				+ "Expression keys are only valid during transpilation (emit)."
 			)
-		raise TypeError(
-			"Element cannot be rendered as VDOMExpr; use Renderer.render_node() instead"
-		)
+		if renderer is None:
+			from pulse.renderer import Renderer
+
+			renderer = Renderer(mode="snapshot")
+		vdom, _normalized = renderer.render_node(self, path)
+		return vdom
 
 
 @dataclass(slots=True)
@@ -811,6 +810,51 @@ class PulseNode:
 			key=self.key,
 			name=self.name,
 		)
+
+	def render(self, renderer: Any = None, path: str = ""):
+		"""Render this component as one-shot VDOM."""
+		if renderer is None:
+			from pulse.renderer import Renderer
+
+			renderer = Renderer(mode="snapshot")
+		vdom, _normalized = renderer.render_component(self, path)
+		return vdom
+
+
+def clone_renderable(value: Any) -> Any:
+	if isinstance(value, Element):
+		props = None
+		if isinstance(value.props, dict):
+			props = {key: clone_renderable(entry) for key, entry in value.props.items()}
+		elif value.props is not None:
+			props = [
+				prop
+				if isinstance(prop, Spread)
+				else (prop[0], clone_renderable(prop[1]))
+				for prop in value.props
+			]
+		children = (
+			[clone_renderable(child) for child in value.children]
+			if value.children is not None
+			else None
+		)
+		return Element(
+			tag=value.tag,
+			props=props,
+			children=children,
+			key=value.key,
+		)
+	if isinstance(value, PulseNode):
+		return PulseNode(
+			fn=value.fn,
+			args=tuple(clone_renderable(arg) for arg in value.args),
+			kwargs={
+				key: clone_renderable(entry) for key, entry in value.kwargs.items()
+			},
+			key=value.key,
+			name=value.name,
+		)
+	return value
 
 
 # =============================================================================

--- a/packages/pulse/python/tests/test_channels.py
+++ b/packages/pulse/python/tests/test_channels.py
@@ -169,6 +169,36 @@ def test_stale_connect_during_detach_grace_is_rejected():
 	assert channel.closed is False
 
 
+def test_resume_omits_closed_channel_from_acceptance():
+	app, render, session = make_route_render()
+	sent: list[dict[str, Any]] = []
+	render.send = sent.append  # pyright: ignore[reportAttributeAccessIssue]
+	channel = create_route_channel(app, render, session, "closed-resume-channel")
+	connect_channel(render, channel)
+	channel.close()
+
+	ok = render.resume(
+		"resume-1",
+		[
+			{
+				"path": "/",
+				"routeInfo": app.routes.find("/").default_route_info(),
+				"attachId": "attach-1",
+			}
+		],
+		[{"channel": channel.id, "path": "/"}],
+	)
+
+	assert ok is True
+	assert sent[-1] == {
+		"type": "server_resume",
+		"resumeId": "resume-1",
+		"status": "ok",
+		"views": [{"path": "/", "attachId": "attach-1"}],
+		"channels": [],
+	}
+
+
 @pytest.mark.asyncio
 async def test_channel_request_resolves_on_response():
 	app = ps.App()

--- a/packages/pulse/python/tests/test_channels.py
+++ b/packages/pulse/python/tests/test_channels.py
@@ -49,6 +49,39 @@ async def test_channel_emit_sends_message():
 	assert message["payload"] == {"values": {"a": 1}}
 
 
+def test_route_bound_channel_emit_includes_path():
+	@ps.component
+	def view():
+		return ps.div()
+
+	app = ps.App([ps.Route("/", view)])
+	render = DummyRender()
+	session = SimpleNamespace(sid="session-route")
+
+	real_render = ps.RenderSession(render.id, app.routes)
+	real_render.send = render.send  # pyright: ignore[reportAttributeAccessIssue]
+
+	with ps.PulseContext(
+		app=app,
+		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
+		render=real_render,
+	):
+		real_render.prerender(["/"])
+		real_render.attach("/", app.routes.find("/").default_route_info())
+		mount = real_render.get_route_mount("/")
+		with ps.PulseContext.update(route=mount.route):
+			channel = real_render.channels.create("route-channel")
+			channel.emit("setValues", {"values": {"a": 1}})
+
+	assert len(render.sent) == 1
+	message = render.sent[0]
+	assert message["type"] == "channel_message"
+	assert message["path"] == "/"
+	assert message["channel"] == "route-channel"
+	assert message["event"] == "setValues"
+	assert message["payload"] == {"values": {"a": 1}}
+
+
 @pytest.mark.asyncio
 async def test_channel_request_resolves_on_response():
 	app = ps.App()

--- a/packages/pulse/python/tests/test_channels.py
+++ b/packages/pulse/python/tests/test_channels.py
@@ -1,11 +1,13 @@
 import asyncio
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any, cast, override
 
 import pulse as ps
 import pytest
-from pulse.channel import ChannelClosed
+from pulse.channel import Channel, ChannelClosed
 from pulse.messages import ClientChannelResponseMessage
+from pulse.render_session import RenderSession
+from pulse.test_helpers import wait_for
 from pulse.user_session import UserSession
 
 
@@ -18,6 +20,56 @@ class DummyRender:
 
 	def send(self, message: dict[str, Any]):
 		self.sent.append(message)
+
+
+def connect_channel(render: RenderSession, channel: Channel, path: str = "/") -> None:
+	render.channels.handle_client_connect(
+		{"type": "channel_connect", "channel": channel.id, "path": path}
+	)
+
+
+def make_route_render(
+	path: str = "/",
+	*,
+	dev_strict_mode_detach_timeout: float = 0.0,
+	middleware: ps.PulseMiddleware | None = None,
+) -> tuple[ps.App, RenderSession, UserSession]:
+	@ps.component
+	def view():
+		return ps.div()
+
+	app = ps.App([ps.Route(path, view)], middleware=middleware)
+	render = ps.RenderSession(
+		"render-1",
+		app.routes,
+		dev_strict_mode_detach_timeout=dev_strict_mode_detach_timeout,
+	)
+	session = cast(UserSession, cast(object, SimpleNamespace(sid="session-1", data={})))
+	render.connect(lambda _: None)
+	with ps.PulseContext(app=app, session=session, render=render):
+		render.prerender([path])
+		render.attach(path, app.routes.find(path).default_route_info())
+	return app, render, session
+
+
+def create_route_channel(
+	app: ps.App,
+	render: RenderSession,
+	session: UserSession,
+	identifier: str,
+	path: str = "/",
+) -> Channel:
+	mount = render.get_route_mount(path)
+	with ps.PulseContext(
+		app=app,
+		session=session,
+		render=render,
+		route=mount.route,
+		source_route_path=mount.route.route_path,
+		source_path=mount.route.pathname,
+		source_mount_id=mount.mount_id,
+	):
+		return render.channels.create(identifier)
 
 
 @pytest.mark.asyncio
@@ -39,6 +91,7 @@ async def test_channel_emit_sends_message():
 		render=real_render,
 	):
 		channel = real_render.channels.create("form-channel")
+		connect_channel(real_render, channel)
 		channel.emit("setValues", {"values": {"a": 1}})
 
 	assert len(render.sent) == 1
@@ -47,6 +100,73 @@ async def test_channel_emit_sends_message():
 	assert message["channel"] == "form-channel"
 	assert message["event"] == "setValues"
 	assert message["payload"] == {"values": {"a": 1}}
+
+
+def test_channel_emit_without_endpoint_raises_channel_closed():
+	app, render, session = make_route_render()
+	channel = create_route_channel(app, render, session, "closed-channel")
+
+	with pytest.raises(ChannelClosed, match="no connected client"):
+		channel.emit("notify", None)
+
+
+def test_connect_requires_matching_active_route_mount():
+	app, render, session = make_route_render()
+	channel = create_route_channel(app, render, session, "owned-channel")
+
+	render.channels.handle_client_connect(
+		{"type": "channel_connect", "channel": channel.id, "path": "/other"}
+	)
+	assert channel.connected is False
+
+	connect_channel(render, channel)
+	assert channel.connected is True
+
+
+@pytest.mark.asyncio
+async def test_dev_strict_mode_detach_preserves_route_channel_until_dispose():
+	app, render, session = make_route_render(dev_strict_mode_detach_timeout=0.01)
+	channel = create_route_channel(app, render, session, "strict-channel")
+	connect_channel(render, channel)
+
+	render.detach("/")
+
+	assert channel.closed is False
+	assert channel.connected is True
+	assert channel.id in render.channels._channels  # pyright: ignore[reportPrivateUsage]
+
+	await wait_for(lambda: channel.id not in render.channels._channels)  # pyright: ignore[reportPrivateUsage]
+	assert channel.closed is True
+
+
+def test_dev_strict_mode_replay_rebinds_route_channel_mount():
+	app, render, session = make_route_render(dev_strict_mode_detach_timeout=10.0)
+	channel = create_route_channel(app, render, session, "replay-channel")
+	connect_channel(render, channel)
+
+	render.detach("/")
+	render.channels.handle_client_disconnect(
+		{"type": "channel_disconnect", "channel": channel.id}
+	)
+	assert channel.closed is False
+	assert channel.connected is False
+
+	with ps.PulseContext(app=app, session=session, render=render):
+		render.attach("/", app.routes.find("/").default_route_info())
+	connect_channel(render, channel)
+
+	assert channel.connected is True
+
+
+def test_stale_connect_during_detach_grace_is_rejected():
+	app, render, session = make_route_render(dev_strict_mode_detach_timeout=10.0)
+	channel = create_route_channel(app, render, session, "stale-channel")
+
+	render.detach("/")
+	connect_channel(render, channel)
+
+	assert channel.connected is False
+	assert channel.closed is False
 
 
 @pytest.mark.asyncio
@@ -68,6 +188,7 @@ async def test_channel_request_resolves_on_response():
 		render=real_render,
 	):
 		channel = real_render.channels.create("req-channel")
+		connect_channel(real_render, channel)
 		pending = asyncio.create_task(channel.request("get", {"x": 1}))
 
 	await asyncio.sleep(0)
@@ -96,6 +217,45 @@ async def test_channel_request_resolves_on_response():
 
 
 @pytest.mark.asyncio
+async def test_channel_request_without_endpoint_raises_channel_closed():
+	app, render, session = make_route_render()
+	channel = create_route_channel(app, render, session, "req-closed")
+
+	with pytest.raises(ChannelClosed, match="no connected client"):
+		await channel.request("get", None)
+
+
+def test_client_request_without_connected_endpoint_gets_error_response():
+	app, render, session = make_route_render()
+	sent: list[dict[str, Any]] = []
+	render.send = sent.append  # pyright: ignore[reportAttributeAccessIssue]
+	channel = create_route_channel(app, render, session, "client-req-closed")
+
+	render.channels.handle_client_event(
+		render=render,
+		session=session,
+		message={
+			"type": "channel_message",
+			"channel": channel.id,
+			"event": "ping",
+			"payload": None,
+			"requestId": "client-req-1",
+		},
+	)
+
+	assert sent == [
+		{
+			"type": "channel_message",
+			"channel": channel.id,
+			"event": None,
+			"responseTo": "client-req-1",
+			"payload": None,
+			"error": "Channel has no connected client",
+		}
+	]
+
+
+@pytest.mark.asyncio
 async def test_channel_event_dispatch():
 	app = ps.App()
 	render = DummyRender()
@@ -116,6 +276,7 @@ async def test_channel_event_dispatch():
 		render=real_render,
 	):
 		channel = real_render.channels.create("event-channel")
+		connect_channel(real_render, channel)
 		channel.on("ping", lambda payload: received.append(payload))
 
 	with ps.PulseContext(
@@ -139,6 +300,108 @@ async def test_channel_event_dispatch():
 
 
 @pytest.mark.asyncio
+async def test_client_disconnect_rejects_pending_without_disposing_channel():
+	app, render, session = make_route_render()
+	sent: list[dict[str, Any]] = []
+	render.send = sent.append  # pyright: ignore[reportAttributeAccessIssue]
+	channel = create_route_channel(app, render, session, "disconnect-channel")
+	connect_channel(render, channel)
+	pending = asyncio.create_task(channel.request("get", None))
+
+	await asyncio.sleep(0)
+	render.channels.handle_client_disconnect(
+		{"type": "channel_disconnect", "channel": channel.id}
+	)
+
+	assert channel.closed is False
+	assert channel.connected is False
+	with pytest.raises(ChannelClosed, match="no connected client"):
+		await pending
+
+
+@pytest.mark.asyncio
+async def test_channel_lifecycle_runs_middleware_and_denial_notifies_client():
+	events: list[str] = []
+
+	class DenyConnectMiddleware(ps.PulseMiddleware):
+		@override
+		async def channel(
+			self,
+			*,
+			channel_id: str,
+			event: str,
+			payload: Any,
+			request_id: str | None,
+			session: dict[str, Any],
+			next: Any,
+		):
+			events.append(event)
+			if event == "__connect__":
+				return ps.Deny()
+			return await next()
+
+	app, render, session = make_route_render(middleware=DenyConnectMiddleware())
+	sent: list[dict[str, Any]] = []
+	render.send = sent.append  # pyright: ignore[reportAttributeAccessIssue]
+	channel = create_route_channel(app, render, session, "denied-channel")
+
+	await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
+		render,
+		session,
+		{"type": "channel_connect", "channel": channel.id, "path": "/"},
+	)
+
+	assert events == ["__connect__"]
+	assert channel.connected is False
+	assert sent == [
+		{
+			"type": "channel_message",
+			"channel": channel.id,
+			"event": "__close__",
+			"payload": {"reason": "Denied"},
+		}
+	]
+
+
+@pytest.mark.asyncio
+async def test_channel_connect_disconnect_lifecycle_middleware_events():
+	events: list[str] = []
+
+	class LogMiddleware(ps.PulseMiddleware):
+		@override
+		async def channel(
+			self,
+			*,
+			channel_id: str,
+			event: str,
+			payload: Any,
+			request_id: str | None,
+			session: dict[str, Any],
+			next: Any,
+		):
+			events.append(event)
+			return await next()
+
+	app, render, session = make_route_render(middleware=LogMiddleware())
+	channel = create_route_channel(app, render, session, "lifecycle-channel")
+
+	await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
+		render,
+		session,
+		{"type": "channel_connect", "channel": channel.id, "path": "/"},
+	)
+	await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
+		render,
+		session,
+		{"type": "channel_disconnect", "channel": channel.id},
+	)
+
+	assert events == ["__connect__", "__disconnect__"]
+	assert channel.connected is False
+	assert channel.closed is False
+
+
+@pytest.mark.asyncio
 async def test_channel_pending_cancelled_on_render_close():
 	app = ps.App()
 	render = DummyRender()
@@ -157,6 +420,7 @@ async def test_channel_pending_cancelled_on_render_close():
 		render=real_render,
 	):
 		channel = real_render.channels.create("close-channel")
+		connect_channel(real_render, channel)
 		pending = asyncio.create_task(channel.request("get", None))
 
 	real_render.close()

--- a/packages/pulse/python/tests/test_render_session.py
+++ b/packages/pulse/python/tests/test_render_session.py
@@ -808,6 +808,81 @@ async def test_reconnect_flushes_queue_when_pending():
 	session.close()
 
 
+def test_resume_missing_mount_requests_reload():
+	routes = RouteTree([Route("a", simple_component)])
+	session = RenderSession("test-id", routes)
+	messages: list[ServerMessage] = []
+	session.connect(messages.append)
+
+	with ps.PulseContext.update(render=session):
+		ok = session.resume(
+			"resume-1",
+			[
+				{
+					"path": "/a",
+					"routeInfo": make_route_info("/a"),
+					"attachId": "attach-1",
+				}
+			],
+			[],
+		)
+
+	assert ok is False
+	assert messages == [
+		{"type": "server_resume", "resumeId": "resume-1", "status": "reload"}
+	]
+
+	session.close()
+
+
+def test_resume_accepts_pending_mount_and_flushes_queue_after_snapshot():
+	routes = RouteTree([Route("a", StatefulCounter)])
+	session = RenderSession("test-id", routes)
+	messages: list[ServerMessage] = []
+	session.connect(messages.append)
+
+	with ps.PulseContext.update(render=session):
+		session.prerender(["/a"], make_route_info("/a"))
+		session.attach("/a", make_route_info("/a"))
+
+	session.disconnect()
+	mount = session.route_mounts["/a"]
+	session.execute_callback("/a", first_callback_key(session, "/a"), [])
+	session.flush()
+	assert mount.queue is not None
+	assert len(mount.queue) == 1
+
+	resume_messages: list[ServerMessage] = []
+	session.connect(resume_messages.append)
+	with ps.PulseContext.update(render=session):
+		ok = session.resume(
+			"resume-1",
+			[
+				{
+					"path": "/a",
+					"routeInfo": make_route_info("/a"),
+					"attachId": "attach-1",
+				}
+			],
+			[],
+		)
+
+	assert ok is True
+	assert [message["type"] for message in resume_messages] == [
+		"vdom_update",
+		"server_resume",
+	]
+	assert resume_messages[1] == {
+		"type": "server_resume",
+		"resumeId": "resume-1",
+		"status": "ok",
+		"views": [{"path": "/a", "attachId": "attach-1"}],
+		"channels": [],
+	}
+
+	session.close()
+
+
 def test_prerender_of_active_path_queues_updates_until_route_sync():
 	routes = make_routes()
 	session = RenderSession("test-id", routes)

--- a/packages/pulse/python/tests/test_renderer.py
+++ b/packages/pulse/python/tests/test_renderer.py
@@ -1228,10 +1228,15 @@ async def test_ref_on_mount_uses_route_context():
 	app = ps.App([ps.Route("/", WithRef)])
 	render = ps.RenderSession("render-ref-route-context", app.routes)
 	session: Any = SimpleNamespace(sid="session-ref-route-context")
+	render.connect(lambda _: None)
 	with ps.PulseContext(app=app, session=session, render=render):
 		render.prerender(["/"])
+		render.attach("/", app.routes.find("/").default_route_info())
 
 	assert handle is not None
+	render.channels.handle_client_connect(
+		{"type": "channel_connect", "channel": handle.channel_id, "path": "/"}
+	)
 	render.channels.handle_client_event(
 		render=render,
 		session=session,

--- a/packages/pulse/python/tests/test_serializer.py
+++ b/packages/pulse/python/tests/test_serializer.py
@@ -1,7 +1,15 @@
 import datetime as dt
 
+import pulse as ps
 import pytest
+from pulse.renderer import Renderer
 from pulse.serializer import deserialize, serialize
+from pulse.transpiler.nodes import Call, Identifier, Literal
+
+
+def pulse_nodes(meta: tuple[list[int], ...]) -> list[int]:
+	assert len(meta) == 5
+	return meta[4]
 
 
 def test_primitives_roundtrip_v3():
@@ -113,9 +121,17 @@ def test_date_roundtrip_v4():
 	assert parsed["day"] == day
 
 
+def test_date_after_primitive_preserves_traversal_index():
+	day = dt.date(2024, 1, 2)
+	payload = serialize(["x", day])
+	parsed = deserialize(payload)
+
+	assert parsed == ["x", day]
+
+
 def test_unsupported_values_raise_v3():
 	with pytest.raises(TypeError):
-		serialize({"x": lambda: None})
+		serialize(lambda: None)
 
 
 class TestNaNAndInfinity:
@@ -151,3 +167,120 @@ class TestNaNAndInfinity:
 		payload = serialize(data)
 		parsed = deserialize(payload)
 		assert parsed == data
+
+
+def test_user_vdom_sentinel_dict_remains_plain_data():
+	data = {"__pulse_vdom__": {"tag": "span"}}
+	(meta, payload) = serialize(data)
+	assert pulse_nodes(meta) == []
+	assert deserialize((meta, payload)) == data
+
+
+def test_nested_expr_serializes_with_pulse_node_metadata():
+	(meta, payload) = serialize({"value": Identifier("window")})
+	assert pulse_nodes(meta) == [1]
+	assert payload == {"value": {"t": "id", "name": "window"}}
+
+
+def test_nested_element_serializes_with_pulse_node_metadata():
+	(meta, payload) = serialize({"title": ps.span("Feedback")})
+	assert pulse_nodes(meta) == [1]
+	assert payload == {"title": {"tag": "span", "children": ["Feedback"]}}
+
+
+def test_snapshot_rendering_strips_callbacks_from_vdom_output():
+	(meta, payload) = serialize({"button": ps.button("Save", onClick=lambda: None)})
+	assert pulse_nodes(meta) == [1]
+	assert payload == {"button": {"tag": "button", "children": ["Save"]}}
+
+
+def test_snapshot_rendering_does_not_mutate_original_element():
+	def handler() -> None:
+		pass
+
+	button = ps.button("Save", onClick=handler)
+	serialize({"button": button})
+
+	assert button.props_dict()["onClick"] is handler
+	vdom = button.render(Renderer())
+	assert vdom["props"]["onClick"] == "$cb"
+	assert vdom["eval"] == ["onClick"]
+
+
+def test_snapshot_rendering_does_not_mutate_original_pulse_node():
+	@ps.component
+	def Label():
+		return ps.span("Saved")
+
+	node = Label()
+	serialize({"label": node})
+
+	assert node.hooks is None
+	assert node.contents is None
+
+
+def test_plain_payload_callbacks_are_unsupported():
+	def on_open(_notification: object) -> None:
+		pass
+
+	with pytest.raises(TypeError):
+		serialize(
+			{
+				"title": ps.span("Feedback"),
+				"message": "Done",
+				"onOpen": on_open,
+			}
+		)
+
+
+def test_snapshot_vdom_payload_is_recursively_serialized():
+	when = dt.datetime(2024, 4, 5, 6, 7, 8, tzinfo=dt.UTC)
+
+	(meta, payload) = serialize(
+		{
+			"title": ps.span(when),
+		}
+	)
+	assert pulse_nodes(meta) == [1]
+	assert meta[1] == [4]
+	assert payload == {
+		"title": {"tag": "span", "children": ["2024-04-05T06:07:08.000Z"]},
+	}
+	parsed = deserialize((meta, payload))
+	assert parsed["title"]["children"] == [when]
+
+
+def test_renderable_before_date_preserves_traversal_index():
+	day = dt.date(2024, 1, 2)
+	(meta, payload) = serialize([ps.span("x"), day])
+
+	assert pulse_nodes(meta) == [1]
+	assert meta[1] == [5]
+	assert payload == [{"tag": "span", "children": ["x"]}, "2024-01-02"]
+	assert deserialize((meta, payload)) == [
+		{"tag": "span", "children": ["x"]},
+		day,
+	]
+
+
+def test_reused_renderable_serializes_as_ref_to_pulse_node():
+	span = ps.span("x")
+	(meta, payload) = serialize([span, span])
+
+	assert pulse_nodes(meta) == [1]
+	assert meta[0] == [5]
+	assert payload == [{"tag": "span", "children": ["x"]}, 1]
+	parsed = deserialize((meta, payload))
+	assert parsed[0] is parsed[1]
+
+
+def test_js_exec_expr_can_include_element_payload():
+	expr = Call(Identifier("show"), [ps.span("Feedback"), Literal("Done")])
+	assert expr.render() == {
+		"t": "call",
+		"callee": {"t": "id", "name": "show"},
+		"args": [
+			{"tag": "span", "children": ["Feedback"]},
+			"Done",
+		],
+	}

--- a/skills/pulse/references/channels.md
+++ b/skills/pulse/references/channels.md
@@ -85,15 +85,22 @@ def ChatClient(*, channelId: str):
 
     # Send event to server
     def sendMessage(text: str):
+        if not bridge:
+            return
         bridge.emit("client:message", {"text": text})
 
     # Request with response
     async def askServer():
+        if not bridge:
+            return
         response = await bridge.request("client:request", {"data": "..."})
         print(response)
 
     # Listen for server events
     def setupListeners():
+        if not bridge:
+            return
+
         def onNotify(payload):
             print("Server notified:", payload)
 
@@ -150,6 +157,9 @@ def ChatWidget(*, channelId: str):
     draft, setDraft = useState("")
 
     def subscribe():
+        if not bridge:
+            return
+
         def onMessage(msg):
             setMessages(lambda prev: [*prev, msg])
 
@@ -158,7 +168,7 @@ def ChatWidget(*, channelId: str):
     useEffect(subscribe, [bridge])
 
     def send():
-        if draft.strip():
+        if bridge and draft.strip():
             bridge.emit("client:send", {"text": draft})
             setDraft("")
 

--- a/skills/pulse/references/helpers.md
+++ b/skills/pulse/references/helpers.md
@@ -146,7 +146,9 @@ serialized = ps.serialize(data)
 **Supported types:**
 - Primitives: `None`, `bool`, `int`, `float`, `str`
 - Collections: `list`, `tuple`, `dict`, `set`
-- `datetime.datetime` (as milliseconds since Unix epoch)
+- `datetime.datetime` (as UTC ISO 8601 strings)
+- `datetime.date` (as ISO date strings)
+- Pulse renderables: `Element`, `PulseNode`, and VDOM `Expr`
 - Dataclasses (as dict of fields)
 - Objects with `__dict__` (public attributes only)
 
@@ -168,6 +170,7 @@ wire = ps.serialize(data)
 - `NaN` floats become `None`
 - `Infinity` raises `ValueError`
 - Dict keys must be strings
+- Pulse renderables are snapshot-rendered; callbacks and refs are stripped
 - Private attributes (`_name`) excluded
 - Shared references/cycles preserved
 


### PR DESCRIPTION
First PR of the **custom-framework merge train** (1/6). Consolidates the already-reviewed cleanup split branches onto main with conflicts resolved: renderable payload serialization, notification callback stripping, renderable notification fields, channel hook manager API, explicit channel lifecycle, reconnect resume handshake, route-local message hydration, and Mantine channel hooks.

**Review notes**
- This is `origin/split/02`…`09` merged in order — the individual merge commits preserve each split for commit-by-commit review.
- Validated: `make all` green, `examples/main.py` boots and is interactive (counter, channels) on the React Router stack.

**Merge train**: merge this first; the next PR (`stack/2-view-identity`) retargets to main automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)