### PR TITLE
View identity: key the protocol by unique view ids

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -182,7 +182,6 @@
       "peerDependencies": {
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19",
-        "react-router": "^7",
       },
     },
     "tutorial/examples/web": {

--- a/bun.lock
+++ b/bun.lock
@@ -182,6 +182,7 @@
       "peerDependencies": {
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19",
+        "react-router": "^7",
       },
     },
     "tutorial/examples/web": {

--- a/packages/pulse-mantine/python/tests/test_form.py
+++ b/packages/pulse-mantine/python/tests/test_form.py
@@ -56,13 +56,13 @@ def build_context():
 				),
 			),
 		)
-		real_render.attach("/", route.default_route_info())
-	route_ctx = real_render.route_mounts["/"].route
+		view = real_render.view_for_path("/")
+		real_render.attach(view.id, route.default_route_info())
 
 	app.render_sessions[dummy_render.id] = real_render
 	app._render_to_user[dummy_render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
 	app.user_sessions[session.sid] = session  # pyright: ignore[reportArgumentType]
-	return app, dummy_render, session, real_render, route_ctx
+	return app, dummy_render, session, real_render, view
 
 
 def client_channel_request(message: object) -> ClientChannelRequestMessage:
@@ -70,19 +70,25 @@ def client_channel_request(message: object) -> ClientChannelRequestMessage:
 
 
 def connect_channel(real_render: ps.RenderSession, channel_id: str) -> None:
+	channel = real_render.channels._channels[channel_id]  # pyright: ignore[reportPrivateUsage]
 	real_render.channels.handle_client_connect(
-		{"type": "channel_connect", "channel": channel_id, "path": "/"}
+		{
+			"type": "channel_connect",
+			"channel": channel_id,
+			"view": channel.view_id or "",
+		}
 	)
 
 
 def test_form_recreates_channel_after_client_release():
-	app, render, session, real_render, route_ctx = build_context()
+	app, render, session, real_render, view = build_context()
 
 	with ps.PulseContext(
 		app=app,
 		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
 		render=real_render,
-		route=route_ctx,
+		route=view.route,
+		view=view,
 	):
 		form = MantineForm(
 			mode="uncontrolled",
@@ -98,7 +104,8 @@ def test_form_recreates_channel_after_client_release():
 		app=app,
 		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
 		render=real_render,
-		route=route_ctx,
+		route=view.route,
+		view=view,
 	):
 		form.render()
 		connect_channel(real_render, form._channel.id)
@@ -111,13 +118,14 @@ def test_form_recreates_channel_after_client_release():
 
 @pytest.mark.asyncio
 async def test_form_sync_handler_survives_channel_recreation():
-	app, _render, session, real_render, route_ctx = build_context()
+	app, _render, session, real_render, view = build_context()
 
 	with ps.PulseContext(
 		app=app,
 		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
 		render=real_render,
-		route=route_ctx,
+		route=view.route,
+		view=view,
 	):
 		form = MantineForm(syncMode="change", initialValues={"query": ""})
 		first_channel_id = form._channel.id  # pyright: ignore[reportPrivateUsage]
@@ -128,7 +136,8 @@ async def test_form_sync_handler_survives_channel_recreation():
 		app=app,
 		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
 		render=real_render,
-		route=route_ctx,
+		route=view.route,
+		view=view,
 	):
 		form.render()
 		connect_channel(real_render, form._channel.id)
@@ -150,13 +159,14 @@ async def test_form_sync_handler_survives_channel_recreation():
 
 
 def test_form_exposes_submit_state():
-	app, _render, session, real_render, route_ctx = build_context()
+	app, _render, session, real_render, view = build_context()
 
 	with ps.PulseContext(
 		app=app,
 		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
 		render=real_render,
-		route=route_ctx,
+		route=view.route,
+		view=view,
 	):
 		form = MantineForm()
 
@@ -169,7 +179,7 @@ def test_form_exposes_submit_state():
 
 @pytest.mark.asyncio
 async def test_submit_state_resets_after_successful_submit():
-	app, _render, session, real_render, route_ctx = build_context()
+	app, _render, session, real_render, view = build_context()
 	started = asyncio.Event()
 	release = asyncio.Event()
 	received: list[dict[str, Any]] = []
@@ -183,7 +193,8 @@ async def test_submit_state_resets_after_successful_submit():
 		app=app,
 		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
 		render=real_render,
-		route=route_ctx,
+		route=view.route,
+		view=view,
 	):
 		form = MantineForm()
 		form.render(onSubmit=handle_submit)
@@ -207,7 +218,7 @@ async def test_submit_state_resets_after_successful_submit():
 
 @pytest.mark.asyncio
 async def test_submit_accepts_registry_deserialized_data():
-	app, _render, session, real_render, route_ctx = build_context()
+	app, _render, session, real_render, view = build_context()
 	received: list[dict[str, Any]] = []
 
 	async def handle_submit(values: dict[str, Any]):
@@ -217,7 +228,8 @@ async def test_submit_accepts_registry_deserialized_data():
 		app=app,
 		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
 		render=real_render,
-		route=route_ctx,
+		route=view.route,
+		view=view,
 	):
 		form = MantineForm()
 		form.render(onSubmit=handle_submit)
@@ -231,7 +243,7 @@ async def test_submit_accepts_registry_deserialized_data():
 
 @pytest.mark.asyncio
 async def test_submit_state_resets_after_failed_submit():
-	app, _render, session, real_render, route_ctx = build_context()
+	app, _render, session, real_render, view = build_context()
 	started = asyncio.Event()
 	release = asyncio.Event()
 
@@ -244,7 +256,8 @@ async def test_submit_state_resets_after_failed_submit():
 		app=app,
 		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
 		render=real_render,
-		route=route_ctx,
+		route=view.route,
+		view=view,
 	):
 		form = MantineForm()
 		form.render(onSubmit=handle_submit)

--- a/packages/pulse-mantine/python/tests/test_notifications.py
+++ b/packages/pulse-mantine/python/tests/test_notifications.py
@@ -34,10 +34,10 @@ def build_context():
 
 def build_route_context():
 	@ps.component
-	def view():
+	def page():
 		return ps.div()
 
-	app = ps.App([ps.Route("/", view)])
+	app = ps.App([ps.Route("/", page)])
 	render = DummyRender()
 	session = SimpleNamespace(sid="session-1")
 
@@ -55,14 +55,19 @@ def build_route_context():
 		render=real_render,
 	):
 		real_render.prerender(["/"])
-		real_render.attach("/", app.routes.find("/").default_route_info())
-	mount = real_render.get_route_mount("/")
-	return app, render, session, real_render, mount
+		view = real_render.view_for_path("/")
+		real_render.attach(view.id, app.routes.find("/").default_route_info())
+	return app, render, session, real_render, view
 
 
 def connect_channel(real_render: ps.RenderSession, channel_id: str) -> None:
+	channel = real_render.channels._channels[channel_id]  # pyright: ignore[reportPrivateUsage]
 	real_render.channels.handle_client_connect(
-		{"type": "channel_connect", "channel": channel_id, "path": "/"}
+		{
+			"type": "channel_connect",
+			"channel": channel_id,
+			"view": channel.view_id or "",
+		}
 	)
 
 
@@ -143,7 +148,7 @@ def test_notification_update_state_keeps_callbacks_server_side():
 
 
 def test_notification_show_serializes_renderable_fields():
-	app, render, session, real_render, mount = build_route_context()
+	app, render, session, real_render, view = build_route_context()
 
 	def on_open(notification: dict[str, Any]) -> None:
 		notification["opened"] = True
@@ -152,7 +157,8 @@ def test_notification_show_serializes_renderable_fields():
 		app=app,
 		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
 		render=real_render,
-		route=mount.route,
+		route=view.route,
+		view=view,
 	):
 		store = NotificationsStore()
 		connect_channel(real_render, store._channel.id)  # pyright: ignore[reportPrivateUsage]
@@ -169,7 +175,7 @@ def test_notification_show_serializes_renderable_fields():
 	meta, payload = serialized
 	assert meta[4]
 	assert store.registry[ident]["onOpen"] is on_open
-	assert payload["path"] == "/"
+	assert payload["view"] == view.id
 	assert payload["payload"] == {
 		"id": ident,
 		"title": {"tag": "span", "children": ["Upload"]},
@@ -179,7 +185,7 @@ def test_notification_show_serializes_renderable_fields():
 
 
 def test_notification_update_serializes_renderable_fields():
-	app, render, session, real_render, mount = build_route_context()
+	app, render, session, real_render, view = build_route_context()
 
 	def on_close(notification: dict[str, Any]) -> None:
 		notification["closed"] = True
@@ -188,7 +194,8 @@ def test_notification_update_serializes_renderable_fields():
 		app=app,
 		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
 		render=real_render,
-		route=mount.route,
+		route=view.route,
+		view=view,
 	):
 		store = NotificationsStore()
 		connect_channel(real_render, store._channel.id)  # pyright: ignore[reportPrivateUsage]
@@ -206,7 +213,7 @@ def test_notification_update_serializes_renderable_fields():
 	meta, payload = serialized
 	assert meta[4]
 	assert store.registry["toast"]["onClose"] is on_close
-	assert payload["path"] == "/"
+	assert payload["view"] == view.id
 	assert payload["payload"] == {
 		"id": "toast",
 		"title": {"tag": "span", "children": ["Upload"]},
@@ -215,7 +222,7 @@ def test_notification_update_serializes_renderable_fields():
 
 
 def test_notification_update_state_serializes_renderable_fields():
-	app, render, session, real_render, mount = build_route_context()
+	app, render, session, real_render, view = build_route_context()
 
 	def on_close(notification: dict[str, Any]) -> None:
 		notification["closed"] = True
@@ -224,7 +231,8 @@ def test_notification_update_state_serializes_renderable_fields():
 		app=app,
 		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
 		render=real_render,
-		route=mount.route,
+		route=view.route,
+		view=view,
 	):
 		store = NotificationsStore()
 		connect_channel(real_render, store._channel.id)  # pyright: ignore[reportPrivateUsage]
@@ -243,7 +251,7 @@ def test_notification_update_state_serializes_renderable_fields():
 	meta, payload = serialized
 	assert meta[4]
 	assert store.registry["toast"]["onClose"] is on_close
-	assert payload["path"] == "/"
+	assert payload["view"] == view.id
 	assert payload["payload"] == {
 		"notifications": [
 			{

--- a/packages/pulse/js/package.json
+++ b/packages/pulse/js/package.json
@@ -47,8 +47,7 @@
 	},
 	"peerDependencies": {
 		"react": "^18 || ^19",
-		"react-dom": "^18 || ^19",
-		"react-router": "^7"
+		"react-dom": "^18 || ^19"
 	},
 	"publishConfig": {
 		"exports": {

--- a/packages/pulse/js/package.json
+++ b/packages/pulse/js/package.json
@@ -47,7 +47,8 @@
 	},
 	"peerDependencies": {
 		"react": "^18 || ^19",
-		"react-dom": "^18 || ^19"
+		"react-dom": "^18 || ^19",
+		"react-router": "^7"
 	},
 	"publishConfig": {
 		"exports": {

--- a/packages/pulse/js/src/channel.test.ts
+++ b/packages/pulse/js/src/channel.test.ts
@@ -147,7 +147,7 @@ describe("ChannelBridge", () => {
 		);
 		expect(() => first.on("event", vi.fn())).not.toThrow();
 		expect(sent).toEqual([
-			expect.objectContaining({ type: "channel_connect", channel: "chan-1", path: "/a" }),
+			expect.objectContaining({ type: "channel_connect", channel: "chan-1", view: "/a" }),
 		]);
 
 		client.releaseChannel("chan-1", "/a");
@@ -179,7 +179,7 @@ describe("ChannelBridge", () => {
 		lease.release();
 
 		expect(sent).toEqual([
-			expect.objectContaining({ type: "channel_connect", path: "/view" }),
+			expect.objectContaining({ type: "channel_connect", view: "/view" }),
 			expect.objectContaining({ type: "channel_disconnect", channel: "chan-1" }),
 		]);
 	});

--- a/packages/pulse/js/src/channel.ts
+++ b/packages/pulse/js/src/channel.ts
@@ -67,7 +67,7 @@ export class ChannelBridge {
 	constructor(
 		private client: PulseSocketIOClient,
 		public readonly id: string,
-		public readonly path: string,
+		public readonly viewId: string,
 	) {}
 
 	emit(event: string, payload?: any): void {
@@ -262,13 +262,13 @@ export class ChannelBridge {
 
 class ClientPulseChannelManager implements PulseChannelManager {
 	#client: PulseSocketIOClient;
-	#path: string;
+	#viewId: string;
 	#leases = new Map<string, { channelId: string; released: boolean }>();
 	#disposed = false;
 
-	constructor(client: PulseSocketIOClient, path: string) {
+	constructor(client: PulseSocketIOClient, viewId: string) {
 		this.#client = client;
-		this.#path = path;
+		this.#viewId = viewId;
 	}
 
 	acquire(channelId: string): PulseChannelLease {
@@ -281,7 +281,7 @@ class ClientPulseChannelManager implements PulseChannelManager {
 		if (this.#leases.has(channelId)) {
 			throw new Error(`PulseChannelManager already acquired channel '${channelId}'`);
 		}
-		const bridge = this.#client.acquireChannel(channelId, this.#path);
+		const bridge = this.#client.acquireChannel(channelId, this.#viewId);
 		const lease = { channelId, released: false };
 		this.#leases.set(channelId, lease);
 		return {
@@ -306,13 +306,13 @@ class ClientPulseChannelManager implements PulseChannelManager {
 		if (lease.released) return;
 		lease.released = true;
 		this.#leases.delete(lease.channelId);
-		this.#client.releaseChannel(lease.channelId, this.#path);
+		this.#client.releaseChannel(lease.channelId, this.#viewId);
 	}
 }
 
 export function createPulseChannelManager(
 	client: PulseSocketIOClient,
-	path: string,
+	viewId: string,
 ): PulseChannelManager {
-	return new ClientPulseChannelManager(client, path);
+	return new ClientPulseChannelManager(client, viewId);
 }

--- a/packages/pulse/js/src/client.test.ts
+++ b/packages/pulse/js/src/client.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, mock, vi } from "bun:test";
 import React from "react";
 import { act, render } from "@testing-library/react";
-import { MemoryRouter } from "react-router";
 import { deserialize, serialize } from "./serialize/serializer";
 import type { Serialized } from "./serialize/serializer";
 
@@ -110,7 +109,7 @@ describe("PulseSocketIOClient attach ack", () => {
 		await connected;
 
 		const attach = sentMessages()[0]!;
-		expect(attach).toMatchObject({ type: "attach", path: "/" });
+		expect(attach).toMatchObject({ type: "attach", view: "/" });
 
 		client.invokeCallback("/", "1.onClick", []);
 		expect(sentMessages()).toHaveLength(1);
@@ -119,14 +118,14 @@ describe("PulseSocketIOClient attach ack", () => {
 			"message",
 			serialize({
 				type: "attach_ack",
-				path: "/",
+				view: "/",
 				attachId: attach.attachId,
 			}),
 		);
 
 		expect(sentMessages()[1]).toMatchObject({
 			type: "callback",
-			path: "/",
+			view: "/",
 			callback: "1.onClick",
 		});
 	});
@@ -145,7 +144,7 @@ describe("PulseSocketIOClient attach ack", () => {
 			"message",
 			serialize({
 				type: "attach_ack",
-				path: "/",
+				view: "/",
 				attachId: attach.attachId,
 			}),
 		);
@@ -168,7 +167,7 @@ describe("PulseSocketIOClient attach ack", () => {
 		await connected;
 
 		expect(sentMessages()).toEqual([
-			{ type: "channel_connect", channel: "chan-1", path: "/view" },
+			{ type: "channel_connect", channel: "chan-1", view: "/view" },
 		]);
 	});
 
@@ -192,7 +191,7 @@ describe("PulseSocketIOClient attach ack", () => {
 				type: "client_resume",
 				resumeId: expect.any(String),
 				views: [],
-				channels: [{ channel: "chan-1", path: "/view" }],
+				channels: [{ channel: "chan-1", view: "/view" }],
 			},
 		]);
 		const resume = sentMessages()[0]!;
@@ -203,7 +202,7 @@ describe("PulseSocketIOClient attach ack", () => {
 				resumeId: resume.resumeId,
 				status: "ok",
 				views: [],
-				channels: [{ channel: "chan-1", path: "/view" }],
+				channels: [{ channel: "chan-1", view: "/view" }],
 			}),
 		);
 		expect(() => bridge.emit("after-reconnect")).not.toThrow();
@@ -234,7 +233,7 @@ describe("PulseSocketIOClient attach ack", () => {
 		const resume = sentMessages(secondSocket)[0]!;
 		expect(resume).toMatchObject({
 			type: "client_resume",
-			views: [{ path: "/", routeInfo }],
+			views: [{ view: "/", routeInfo }],
 		});
 		// Complete the handshake so reconnect timers are cleared for later tests.
 		secondSocket.trigger(
@@ -243,7 +242,7 @@ describe("PulseSocketIOClient attach ack", () => {
 				type: "server_resume",
 				resumeId: resume.resumeId,
 				status: "ok",
-				views: [{ path: "/", attachId: resume.views[0].attachId }],
+				views: [{ view: "/", attachId: resume.views[0].attachId }],
 				channels: [],
 			}),
 		);
@@ -379,7 +378,7 @@ describe("PulseSocketIOClient attach ack", () => {
 				type: "client_resume",
 				resumeId: expect.any(String),
 				views: [],
-				channels: [{ channel: "chan-1", path: "/view" }],
+				channels: [{ channel: "chan-1", view: "/view" }],
 			},
 		]);
 		const resume = sentMessages()[0]!;
@@ -390,7 +389,7 @@ describe("PulseSocketIOClient attach ack", () => {
 				resumeId: resume.resumeId,
 				status: "ok",
 				views: [],
-				channels: [{ channel: "chan-1", path: "/view" }],
+				channels: [{ channel: "chan-1", view: "/view" }],
 			}),
 		);
 
@@ -399,7 +398,7 @@ describe("PulseSocketIOClient attach ack", () => {
 				type: "client_resume",
 				resumeId: resume.resumeId,
 				views: [],
-				channels: [{ channel: "chan-1", path: "/view" }],
+				channels: [{ channel: "chan-1", view: "/view" }],
 			},
 		]);
 	});
@@ -416,7 +415,7 @@ describe("PulseSocketIOClient attach ack", () => {
 			"message",
 			serialize({
 				type: "attach_ack",
-				path: "/",
+				view: "/",
 				attachId: attach.attachId,
 			}),
 		);
@@ -430,7 +429,7 @@ describe("PulseSocketIOClient attach ack", () => {
 			{
 				type: "client_resume",
 				resumeId: expect.any(String),
-				views: [{ path: "/", routeInfo, attachId: attach.attachId }],
+				views: [{ view: "/", routeInfo, attachId: attach.attachId }],
 				channels: [],
 			},
 		]);
@@ -442,14 +441,14 @@ describe("PulseSocketIOClient attach ack", () => {
 				type: "server_resume",
 				resumeId: resume.resumeId,
 				status: "ok",
-				views: [{ path: "/", attachId: attach.attachId }],
+				views: [{ view: "/", attachId: attach.attachId }],
 				channels: [],
 			}),
 		);
 
 		expect(sentMessages()[1]).toMatchObject({
 			type: "callback",
-			path: "/",
+			view: "/",
 			callback: "1.onClick",
 		});
 	});
@@ -483,7 +482,7 @@ describe("PulseSocketIOClient attach ack", () => {
 				type: "client_resume",
 				resumeId: resume.resumeId,
 				views: [],
-				channels: [{ channel: "chan-1", path: "/view" }],
+				channels: [{ channel: "chan-1", view: "/view" }],
 			},
 		]);
 		expect(() => bridge.emit("after-refusal")).toThrow("Channel is closed");
@@ -518,7 +517,7 @@ describe("PulseSocketIOClient attach ack", () => {
 			[[], [], [], [], [12]],
 			{
 				type: "js_exec",
-				path: "/a",
+				view: "/a",
 				id: "exec-1",
 				expr: {
 					t: "call",
@@ -576,7 +575,7 @@ describe("PulseSocketIOClient attach ack", () => {
 			[[], [], [], [], [6]],
 			{
 				type: "channel_message",
-				path: "/a",
+				view: "/a",
 				channel: "chan-1",
 				event: "ping",
 				payload: {
@@ -632,12 +631,17 @@ describe("PulseProvider connection handling", () => {
 
 	it("handles initial connection errors without an unhandled rejection", async () => {
 		const { PulseProvider } = await import("./pulse");
+		const { PulseRouterProvider } = await import("./router");
 		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
 
 		render(
 			React.createElement(
-				MemoryRouter,
-				null,
+				PulseRouterProvider,
+				{
+					routes: [{ id: "/", index: true }],
+					routeLoaders: {},
+					initialUrl: "http://pulse.test/",
+				},
 				React.createElement(
 					PulseProvider,
 					{

--- a/packages/pulse/js/src/client.test.ts
+++ b/packages/pulse/js/src/client.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, mock, vi } from "bun:test";
 import React from "react";
 import { act, render } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
 import { deserialize, serialize } from "./serialize/serializer";
 import type { Serialized } from "./serialize/serializer";
 
@@ -631,17 +632,12 @@ describe("PulseProvider connection handling", () => {
 
 	it("handles initial connection errors without an unhandled rejection", async () => {
 		const { PulseProvider } = await import("./pulse");
-		const { PulseRouterProvider } = await import("./router");
 		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
 
 		render(
 			React.createElement(
-				PulseRouterProvider,
-				{
-					routes: [{ id: "/", index: true }],
-					routeLoaders: {},
-					initialUrl: "http://pulse.test/",
-				} as React.ComponentProps<typeof PulseRouterProvider>,
+				MemoryRouter,
+				null,
 				React.createElement(
 					PulseProvider,
 					{

--- a/packages/pulse/js/src/client.test.ts
+++ b/packages/pulse/js/src/client.test.ts
@@ -641,7 +641,7 @@ describe("PulseProvider connection handling", () => {
 					routes: [{ id: "/", index: true }],
 					routeLoaders: {},
 					initialUrl: "http://pulse.test/",
-				},
+				} as React.ComponentProps<typeof PulseRouterProvider>,
 				React.createElement(
 					PulseProvider,
 					{

--- a/packages/pulse/js/src/client.tsx
+++ b/packages/pulse/js/src/client.tsx
@@ -1,4 +1,4 @@
-import type { NavigateFunction } from "./router";
+import type { NavigateFunction } from "react-router";
 import { io, type Socket } from "socket.io-client";
 import { ChannelBridge, PulseChannelResetError } from "./channel";
 import type { RouteInfo } from "./helpers";

--- a/packages/pulse/js/src/client.tsx
+++ b/packages/pulse/js/src/client.tsx
@@ -1,4 +1,4 @@
-import type { NavigateFunction } from "react-router";
+import type { NavigateFunction } from "./router";
 import { io, type Socket } from "socket.io-client";
 import { ChannelBridge, PulseChannelResetError } from "./channel";
 import type { RouteInfo } from "./helpers";
@@ -58,11 +58,11 @@ export interface PulseClient {
 	isConnected(): boolean;
 	onConnectionChange(listener: ConnectionStatusListener): () => void;
 	// Messages
-	updateRoute(path: string, routeInfo: RouteInfo): void;
-	invokeCallback(path: string, callback: string, args: any[]): void;
+	updateRoute(viewId: string, routeInfo: RouteInfo): void;
+	invokeCallback(viewId: string, callback: string, args: any[]): void;
 	// VDOM subscription
-	attach(path: string, view: MountedView): void;
-	detach(path: string): void;
+	attach(viewId: string, view: MountedView): void;
+	detach(viewId: string): void;
 }
 
 export class PulseSocketIOClient {
@@ -73,7 +73,7 @@ export class PulseSocketIOClient {
 	#socket: Socket | null = null;
 	#messageQueue: ClientMessage[];
 	#connectionListeners: Set<ConnectionStatusListener> = new Set();
-	#channels: Map<string, { path: string; bridge: ChannelBridge }> = new Map();
+	#channels: Map<string, { view: string; bridge: ChannelBridge }> = new Map();
 	#url: string;
 	#frameworkNavigate: NavigateFunction;
 	#directives: Directives;
@@ -214,8 +214,8 @@ export class PulseSocketIOClient {
 					return;
 				}
 				// Send attach for all active views on connect/reconnect
-				for (const [path, route] of this.#activeViews) {
-					this.#sendAttach(path, route.routeInfo, socket);
+				for (const [viewId, view] of this.#activeViews) {
+					this.#sendAttach(viewId, view.routeInfo, socket);
 				}
 				for (const [channel, endpoint] of this.#channels) {
 					socket.emit(
@@ -223,14 +223,14 @@ export class PulseSocketIOClient {
 						serialize({
 							type: "channel_connect",
 							channel,
-							path: endpoint.path,
+							view: endpoint.view,
 						}),
 					);
 				}
 
 				for (const payload of this.#messageQueue) {
 					// Already sent above
-					if (payload.type === "attach" && this.#activeViews.has(payload.path)) {
+					if (payload.type === "attach" && this.#activeViews.has(payload.view)) {
 						continue;
 					}
 					if (
@@ -298,37 +298,37 @@ export class PulseSocketIOClient {
 		}
 	}
 
-	public attach(path: string, view: MountedView) {
-		if (this.#activeViews.has(path)) {
-			throw new Error(`Path ${path} is already attached`);
+	public attach(viewId: string, view: MountedView) {
+		if (this.#activeViews.has(viewId)) {
+			throw new Error(`View ${viewId} is already attached`);
 		}
-		this.#activeViews.set(path, view);
-		this.#sendAttach(path, view.routeInfo);
+		this.#activeViews.set(viewId, view);
+		this.#sendAttach(viewId, view.routeInfo);
 	}
 
-	public updateRoute(path: string, routeInfo: RouteInfo) {
-		const view = this.#activeViews.get(path);
+	public updateRoute(viewId: string, routeInfo: RouteInfo) {
+		const view = this.#activeViews.get(viewId);
 		if (view) {
 			view.routeInfo = routeInfo;
 			this.sendMessage({
 				type: "update",
-				path,
+				view: viewId,
 				routeInfo,
 			});
 		}
 	}
 
-	public detach(path: string) {
-		this.#activeViews.delete(path);
-		this.#activeAttachIds.delete(path);
-		this.#ackedAttachIds.delete(path);
-		this.#pendingCallbacks.delete(path);
+	public detach(viewId: string) {
+		this.#activeViews.delete(viewId);
+		this.#activeAttachIds.delete(viewId);
+		this.#ackedAttachIds.delete(viewId);
+		this.#pendingCallbacks.delete(viewId);
 		for (const [channel, endpoint] of [...this.#channels]) {
-			if (endpoint.path === path) {
+			if (endpoint.view === viewId) {
 				this.#releaseChannel(channel, endpoint);
 			}
 		}
-		void this.sendMessage({ type: "detach", path });
+		void this.sendMessage({ type: "detach", view: viewId });
 	}
 
 	public suspend() {
@@ -383,22 +383,29 @@ export class PulseSocketIOClient {
 		// console.log("[PulseClient] Received message:", message);
 		switch (message.type) {
 			case "vdom_init": {
-				const route = this.#activeViews.get(message.path);
-				// Ignore messages for paths that are not mounted
-				if (!route) return;
-				route.onInit(message);
+				const view = this.#activeViews.get(message.view);
+				// Ignore messages for views that are not mounted
+				if (!view) return;
+				view.onInit(message);
 				break;
 			}
 			case "vdom_update": {
-				const route = this.#activeViews.get(message.path);
-				if (!route) return; // Not an active path; discard
-				route.onUpdate(message.ops);
+				const view = this.#activeViews.get(message.view);
+				if (!view) return; // Not an active view; discard
+				view.onUpdate(message.ops);
 				break;
 			}
 			case "server_error": {
-				const route = this.#activeViews.get(message.path);
-				if (!route) return; // discard for inactive paths
-				route.onServerError(message.error);
+				if (message.view === undefined) {
+					// Session-level error: surface on every active view.
+					for (const view of this.#activeViews.values()) {
+						view.onServerError(message.error);
+					}
+					break;
+				}
+				const view = this.#activeViews.get(message.view);
+				if (!view) return; // discard for inactive views
+				view.onServerError(message.error);
 				break;
 			}
 			case "api_call": {
@@ -406,18 +413,15 @@ export class PulseSocketIOClient {
 				break;
 			}
 			case "navigate_to": {
-				if (message.sourceRoutePath && message.sourcePath) {
-					const view = this.#activeViews.get(message.sourceRoutePath);
-					if (!view || view.routeInfo.pathname !== message.sourcePath) break;
-				} else if (message.sourcePath) {
-					let sourceActive = false;
-					for (const view of this.#activeViews.values()) {
-						if (view.routeInfo.pathname === message.sourcePath) {
-							sourceActive = true;
-							break;
-						}
+				if (message.sourceView) {
+					const view = this.#activeViews.get(message.sourceView);
+					if (!view) break;
+					if (
+						message.sourcePathname &&
+						view.routeInfo.pathname !== message.sourcePathname
+					) {
+						break;
 					}
-					if (!sourceActive) break;
 				}
 				const replace = !!message.replace;
 				let dest = message.path || "";
@@ -461,7 +465,7 @@ export class PulseSocketIOClient {
 				break;
 			}
 			case "attach_ack": {
-				this.#handleAttachAck(message.path, message.attachId);
+				this.#handleAttachAck(message.view, message.attachId);
 				break;
 			}
 			case "channel_message": {
@@ -529,15 +533,15 @@ export class PulseSocketIOClient {
 		}
 	}
 
-	public invokeCallback(path: string, callback: string, args: any[]) {
-		if (!this.#activeViews.has(path)) return;
+	public invokeCallback(viewId: string, callback: string, args: any[]) {
+		if (!this.#activeViews.has(viewId)) return;
 		const message: ClientCallbackMessage = {
 			type: "callback",
-			path,
+			view: viewId,
 			callback,
 			args: args.map(extractEvent),
 		};
-		if (this.#isAttachAcked(path)) {
+		if (this.#isAttachAcked(viewId)) {
 			this.sendMessage(message);
 			return;
 		}
@@ -545,7 +549,7 @@ export class PulseSocketIOClient {
 	}
 
 	#handleJsExec(message: ServerJsExecMessage) {
-		const view = this.#activeViews.get(message.path);
+		const view = this.#activeViews.get(message.view);
 		if (!view) {
 			// View unmounted before the message arrived - send result back to unblock
 			// the server-side future (which is likely already cancelled anyway).
@@ -569,23 +573,23 @@ export class PulseSocketIOClient {
 		this.sendMessage(msg);
 	}
 
-	public acquireChannel(id: string, path = ""): ChannelBridge {
+	public acquireChannel(id: string, viewId = ""): ChannelBridge {
 		if (this.#channels.has(id)) {
 			throw new Error(`Pulse channel '${id}' is already acquired`);
 		}
-		const bridge = new ChannelBridge(this, id, path);
-		this.#channels.set(id, { path, bridge });
+		const bridge = new ChannelBridge(this, id, viewId);
+		this.#channels.set(id, { view: viewId, bridge });
 		this.sendMessage({
 			type: "channel_connect",
 			channel: id,
-			path,
+			view: viewId,
 		});
 		return bridge;
 	}
 
-	public releaseChannel(id: string, path = ""): void {
+	public releaseChannel(id: string, viewId = ""): void {
 		const endpoint = this.#channels.get(id);
-		if (!endpoint || endpoint.path !== path) {
+		if (!endpoint || endpoint.view !== viewId) {
 			return;
 		}
 		this.#releaseChannel(id, endpoint);
@@ -614,17 +618,17 @@ export class PulseSocketIOClient {
 		this.#resumePending = true;
 		this.#pendingResumeId = resumeId;
 		const views: ClientResumeMessage["views"] = [];
-		for (const [path, view] of this.#activeViews) {
-			const attachId = this.#activeAttachIds.get(path);
+		for (const [viewId, view] of this.#activeViews) {
+			const attachId = this.#activeAttachIds.get(viewId);
 			views.push({
-				path,
+				view: viewId,
 				routeInfo: view.routeInfo,
 				...(attachId ? { attachId } : {}),
 			});
 		}
 		const channels: ClientResumeMessage["channels"] = [];
 		for (const [channel, endpoint] of this.#channels) {
-			channels.push({ channel, path: endpoint.path });
+			channels.push({ channel, view: endpoint.view });
 		}
 		socket.emit(
 			"message",
@@ -652,24 +656,24 @@ export class PulseSocketIOClient {
 			return;
 		}
 
-		const acceptedViews = new Set((message.views ?? []).map((view) => view.path));
+		const acceptedViews = new Set((message.views ?? []).map((view) => view.view));
 		const acceptedChannels = new Map(
-			(message.channels ?? []).map((channel) => [channel.channel, channel.path]),
+			(message.channels ?? []).map((channel) => [channel.channel, channel.view]),
 		);
 
-		for (const path of [...this.#pendingCallbacks.keys()]) {
-			if (!acceptedViews.has(path)) {
-				this.#pendingCallbacks.delete(path);
+		for (const viewId of [...this.#pendingCallbacks.keys()]) {
+			if (!acceptedViews.has(viewId)) {
+				this.#pendingCallbacks.delete(viewId);
 			}
 		}
 		for (const view of message.views ?? []) {
-			const attachId = view.attachId ?? this.#activeAttachIds.get(view.path);
-			if (attachId && this.#activeAttachIds.get(view.path) === attachId) {
-				this.#ackedAttachIds.set(view.path, attachId);
+			const attachId = view.attachId ?? this.#activeAttachIds.get(view.view);
+			if (attachId && this.#activeAttachIds.get(view.view) === attachId) {
+				this.#ackedAttachIds.set(view.view, attachId);
 			}
 		}
 		for (const [channel, endpoint] of [...this.#channels]) {
-			if (acceptedChannels.get(channel) !== endpoint.path) {
+			if (acceptedChannels.get(channel) !== endpoint.view) {
 				endpoint.bridge.dispose(
 					new PulseChannelResetError("Channel was not resumed"),
 				);
@@ -680,8 +684,8 @@ export class PulseSocketIOClient {
 		const queued = this.#messageQueue;
 		this.#messageQueue = [];
 		this.#resumePending = false;
-		for (const path of acceptedViews) {
-			this.#flushPendingCallbacks(path);
+		for (const viewId of acceptedViews) {
+			this.#flushPendingCallbacks(viewId);
 		}
 		for (const payload of queued) {
 			if (this.#shouldReplayAfterResume(payload, acceptedViews, acceptedChannels)) {
@@ -707,7 +711,7 @@ export class PulseSocketIOClient {
 			return false;
 		}
 		if (payload.type === "callback") {
-			return acceptedViews.has(payload.path);
+			return acceptedViews.has(payload.view);
 		}
 		if (payload.type === "channel_message") {
 			return acceptedChannels.has(payload.channel);
@@ -733,25 +737,25 @@ export class PulseSocketIOClient {
 	}
 
 	#handleSerializedJsExec(data: Serialized, raw: Record<string, unknown>): void {
-		const path = raw.path;
-		if (typeof path !== "string") {
+		const viewId = raw.view;
+		if (typeof viewId !== "string") {
 			return;
 		}
-		const view = this.#activeViews.get(path);
+		const view = this.#activeViews.get(viewId);
 		if (!view) {
 			if (typeof raw.id === "string") this.#sendJsResult(raw.id, undefined, null);
 			return;
 		}
-		this.#handleServerMessage(this.#deserializeForView(data, view, "js_exec", path));
+		this.#handleServerMessage(this.#deserializeForView(data, view, "js_exec", viewId));
 	}
 
 	#handleSerializedChannelMessage(
 		data: Serialized,
 		raw: Record<string, unknown>,
 	): boolean {
-		const path = raw.path;
-		if (typeof path === "string") {
-			const view = this.#activeViews.get(path);
+		const viewId = raw.view;
+		if (typeof viewId === "string") {
+			const view = this.#activeViews.get(viewId);
 			if (!view) {
 				if (typeof raw.channel === "string") {
 					this.#dropChannel(
@@ -762,7 +766,7 @@ export class PulseSocketIOClient {
 				return true;
 			}
 			this.#handleServerMessage(
-				this.#deserializeForView(data, view, "channel_message", path),
+				this.#deserializeForView(data, view, "channel_message", viewId),
 			);
 			return true;
 		}
@@ -784,13 +788,13 @@ export class PulseSocketIOClient {
 		data: Serialized,
 		view: MountedView,
 		type: string,
-		path: string,
+		viewId: string,
 	): ServerMessage {
 		try {
 			return view.deserializeMessage(data);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
-			throw new Error(`[Pulse] Failed to deserialize ${type} for path '${path}': ${message}`);
+			throw new Error(`[Pulse] Failed to deserialize ${type} for view '${viewId}': ${message}`);
 		}
 	}
 
@@ -806,13 +810,13 @@ export class PulseSocketIOClient {
 		return data[0][4].length > 0;
 	}
 
-	#sendAttach(path: string, routeInfo: RouteInfo, socket?: Socket): void {
-		const attachId = `${path}:${++this.#nextAttachId}`;
-		this.#activeAttachIds.set(path, attachId);
-		this.#ackedAttachIds.delete(path);
+	#sendAttach(viewId: string, routeInfo: RouteInfo, socket?: Socket): void {
+		const attachId = `${viewId}:${++this.#nextAttachId}`;
+		this.#activeAttachIds.set(viewId, attachId);
+		this.#ackedAttachIds.delete(viewId);
 		const message = {
 			type: "attach" as const,
-			path,
+			view: viewId,
 			routeInfo,
 			attachId,
 		};
@@ -823,28 +827,28 @@ export class PulseSocketIOClient {
 		this.sendMessage(message);
 	}
 
-	#isAttachAcked(path: string): boolean {
-		const attachId = this.#activeAttachIds.get(path);
-		return attachId !== undefined && this.#ackedAttachIds.get(path) === attachId;
+	#isAttachAcked(viewId: string): boolean {
+		const attachId = this.#activeAttachIds.get(viewId);
+		return attachId !== undefined && this.#ackedAttachIds.get(viewId) === attachId;
 	}
 
-	#handleAttachAck(path: string, attachId: string): void {
-		if (this.#activeAttachIds.get(path) !== attachId) return;
-		this.#ackedAttachIds.set(path, attachId);
-		this.#flushPendingCallbacks(path);
+	#handleAttachAck(viewId: string, attachId: string): void {
+		if (this.#activeAttachIds.get(viewId) !== attachId) return;
+		this.#ackedAttachIds.set(viewId, attachId);
+		this.#flushPendingCallbacks(viewId);
 	}
 
 	#queueCallback(message: ClientCallbackMessage): void {
-		const queue = this.#pendingCallbacks.get(message.path) ?? [];
+		const queue = this.#pendingCallbacks.get(message.view) ?? [];
 		queue.push(message);
-		this.#pendingCallbacks.set(message.path, queue);
+		this.#pendingCallbacks.set(message.view, queue);
 	}
 
-	#flushPendingCallbacks(path: string): void {
-		if (!this.#activeViews.has(path) || !this.#isAttachAcked(path)) return;
-		const queue = this.#pendingCallbacks.get(path);
+	#flushPendingCallbacks(viewId: string): void {
+		if (!this.#activeViews.has(viewId) || !this.#isAttachAcked(viewId)) return;
+		const queue = this.#pendingCallbacks.get(viewId);
 		if (!queue) return;
-		this.#pendingCallbacks.delete(path);
+		this.#pendingCallbacks.delete(viewId);
 		for (const message of queue) {
 			this.sendMessage(message);
 		}
@@ -852,7 +856,7 @@ export class PulseSocketIOClient {
 
 	#releaseChannel(
 		id: string,
-		endpoint: { path: string; bridge: ChannelBridge },
+		endpoint: { view: string; bridge: ChannelBridge },
 	): void {
 		this.#channels.delete(id);
 		endpoint.bridge.dispose(new PulseChannelResetError("Channel released"));

--- a/packages/pulse/js/src/helpers.ts
+++ b/packages/pulse/js/src/helpers.ts
@@ -1,5 +1,3 @@
-import type { LoaderFunctionArgs } from "react-router";
-
 export interface RouteInfo {
 	pathname: string;
 	hash: string;
@@ -9,22 +7,25 @@ export interface RouteInfo {
 	catchall: string[];
 }
 
-export function extractServerRouteInfo({ params, request }: LoaderFunctionArgs) {
-	const { "*": catchall = "", ...pathParams } = params;
-	const parsedUrl = new URL(request.url);
-	const query = parsedUrl.search.startsWith("?")
-		? parsedUrl.search.slice(1)
-		: parsedUrl.search;
-	const hash = parsedUrl.hash.startsWith("#")
-		? parsedUrl.hash.slice(1)
-		: parsedUrl.hash;
+export interface LocationLike {
+	pathname: string;
+	search: string;
+	hash: string;
+}
 
+export function buildRouteInfo(
+	location: LocationLike,
+	pathParams: Record<string, string | undefined>,
+	catchall: string[],
+): RouteInfo {
+	const query = location.search.startsWith("?") ? location.search.slice(1) : location.search;
+	const hash = location.hash.startsWith("#") ? location.hash.slice(1) : location.hash;
 	return {
+		pathname: location.pathname,
 		hash,
-		pathname: parsedUrl.pathname,
 		query,
-		queryParams: Object.fromEntries(parsedUrl.searchParams.entries()),
+		queryParams: Object.fromEntries(new URLSearchParams(location.search).entries()),
 		pathParams,
-		catchall: catchall.length > 1 ? catchall.split("/") : [],
-	} satisfies RouteInfo;
+		catchall,
+	};
 }

--- a/packages/pulse/js/src/index.ts
+++ b/packages/pulse/js/src/index.ts
@@ -13,7 +13,8 @@ export type { PulseFormProps } from "./form";
 export { FormSubmissionError, PulseForm, submitForm } from "./form";
 export type { RouteInfo } from "./helpers";
 // Server helpers
-export { extractServerRouteInfo } from "./helpers";
+export { buildRouteInfo, type LocationLike } from "./helpers";
+export * from "./router";
 // Messages (types only)
 export type {
 	ClientApiResultMessage,
@@ -39,14 +40,14 @@ export type {
 export type { PulseConfig, PulsePrerender, PulseProviderProps } from "./pulse";
 // Core React bindings
 export {
-	PulseViewPathContext,
+	PulseViewIdContext,
 	PulseProvider,
 	PulseView,
 	usePulseChannel,
 	usePulseChannelManager,
-	usePulseChannelManagerForPath,
+	usePulseChannelManagerForView,
 	usePulseClient,
-	usePulseViewPath,
+	usePulseViewId,
 } from "./pulse";
 // Renderer helpers
 // Renderer (structural expressions + eval-keyed props)

--- a/packages/pulse/js/src/messages.ts
+++ b/packages/pulse/js/src/messages.ts
@@ -5,16 +5,20 @@
 import type { RouteInfo } from "./helpers";
 import type { VDOM, VDOMNode, VDOMUpdate } from "./vdom";
 
-// Based on pulse/messages.py
+// Based on pulse/messages.py. All view-scoped messages carry the unique id of
+// the owning view (`view`).
 export interface ServerInitMessage {
 	type: "vdom_init";
-	path: string;
+	view: string;
+	// Route pattern path (e.g. "/users/:id"), used to associate the view with
+	// its generated route module.
+	routePath: string;
 	vdom: VDOM;
 }
 
 export interface ServerUpdateMessage {
 	type: "vdom_update";
-	path: string;
+	view: string;
 	ops: VDOMUpdate[];
 }
 
@@ -27,7 +31,8 @@ export interface ServerError {
 
 export interface ServerErrorMessage {
 	type: "server_error";
-	path: string;
+	// Omitted for session-level errors that are not tied to a view
+	view?: string;
 	error: ServerError;
 }
 
@@ -43,7 +48,7 @@ export interface ServerApiCallMessage {
 
 export interface ServerChannelRequestMessage {
 	type: "channel_message";
-	path?: string;
+	view?: string;
 	channel: string;
 	event: string;
 	payload?: any;
@@ -54,7 +59,7 @@ export interface ServerChannelRequestMessage {
 
 export interface ServerChannelResponseMessage {
 	type: "channel_message";
-	path?: string;
+	view?: string;
 	channel: string;
 	event?: undefined;
 	responseTo: string;
@@ -70,9 +75,8 @@ export interface ServerNavigateToMessage {
 	path: string;
 	replace: boolean;
 	hard: boolean;
-	sourceRoutePath?: string;
-	sourcePath?: string;
-	sourceMountId?: string;
+	sourceView?: string;
+	sourcePathname?: string;
 }
 
 export interface ServerReloadMessage {
@@ -80,13 +84,13 @@ export interface ServerReloadMessage {
 }
 
 export interface ServerResumeView {
-	path: string;
+	view: string;
 	attachId?: string;
 }
 
 export interface ServerResumeChannel {
 	channel: string;
-	path: string;
+	view: string;
 }
 
 export interface ServerResumeMessage {
@@ -99,13 +103,13 @@ export interface ServerResumeMessage {
 
 export interface ServerAttachAckMessage {
 	type: "attach_ack";
-	path: string;
+	view: string;
 	attachId: string;
 }
 
 export interface ServerJsExecMessage {
 	type: "js_exec";
-	path: string;
+	view: string;
 	id: string;
 	expr: VDOMNode;
 }
@@ -125,36 +129,36 @@ export type ServerMessage =
 
 export interface ClientCallbackMessage {
 	type: "callback";
-	path: string;
+	view: string;
 	callback: string;
 	args: any[];
 }
 
 export interface ClientAttachMessage {
 	type: "attach";
-	path: string;
+	view: string;
 	routeInfo: RouteInfo;
 	attachId: string;
 }
 export interface ClientUpdateMessage {
 	type: "update";
-	path: string;
+	view: string;
 	routeInfo: RouteInfo;
 }
 export interface ClientDetachMessage {
 	type: "detach";
-	path: string;
+	view: string;
 }
 
 export interface ClientResumeView {
-	path: string;
+	view: string;
 	routeInfo: RouteInfo;
 	attachId?: string;
 }
 
 export interface ClientResumeChannel {
 	channel: string;
-	path: string;
+	view: string;
 }
 
 export interface ClientResumeMessage {
@@ -198,7 +202,7 @@ export type ClientChannelMessage = ClientChannelRequestMessage | ClientChannelRe
 export interface ClientChannelConnectMessage {
 	type: "channel_connect";
 	channel: string;
-	path: string;
+	view: string;
 }
 
 export interface ClientChannelDisconnectMessage {

--- a/packages/pulse/js/src/pulse.test.tsx
+++ b/packages/pulse/js/src/pulse.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "bun:test";
 import { render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { PulseProvider, PulseView, usePulseChannel, usePulseViewId } from "./pulse";
-import { PulseRouterProvider } from "./router";
+import { MemoryRouter } from "react-router";
 
 vi.mock("socket.io-client", () => ({
 	io: () => ({
@@ -25,11 +25,7 @@ describe("PulseView channel hooks", () => {
 		}
 
 		render(
-			<PulseRouterProvider
-				routes={[{ id: "/test", path: "test" }]}
-				routeLoaders={{}}
-				initialUrl="http://pulse.test/test"
-			>
+			<MemoryRouter initialEntries={["/test"]}>
 				<PulseProvider
 					config={{
 						serverAddress: "http://pulse.test",
@@ -53,7 +49,7 @@ describe("PulseView channel hooks", () => {
 				>
 					<PulseView path="/test" registry={{ Probe }} />
 				</PulseProvider>
-			</PulseRouterProvider>,
+			</MemoryRouter>,
 		);
 
 		await waitFor(() => {

--- a/packages/pulse/js/src/pulse.test.tsx
+++ b/packages/pulse/js/src/pulse.test.tsx
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "bun:test";
 import { render, screen, waitFor } from "@testing-library/react";
 import React from "react";
-import { MemoryRouter } from "react-router";
-import { PulseProvider, PulseView, usePulseChannel, usePulseViewPath } from "./pulse";
+import { PulseProvider, PulseView, usePulseChannel, usePulseViewId } from "./pulse";
+import { PulseRouterProvider } from "./router";
 
 vi.mock("socket.io-client", () => ({
 	io: () => ({
@@ -14,18 +14,22 @@ vi.mock("socket.io-client", () => ({
 }));
 
 describe("PulseView channel hooks", () => {
-	it("provides view path context and returns null before channel effect runs", async () => {
-		const states: Array<{ path: string; channel: string | null }> = [];
+	it("provides view id context and returns null before channel effect runs", async () => {
+		const states: Array<{ viewId: string; channel: string | null }> = [];
 
 		function Probe() {
-			const path = usePulseViewPath();
+			const viewId = usePulseViewId();
 			const channel = usePulseChannel("chan-1");
-			states.push({ path, channel: channel?.id ?? null });
+			states.push({ viewId, channel: channel?.id ?? null });
 			return <div data-testid="channel">{channel?.id ?? "null"}</div>;
 		}
 
 		render(
-			<MemoryRouter initialEntries={["/test"]}>
+			<PulseRouterProvider
+				routes={[{ id: "/test", path: "test" }]}
+				routeLoaders={{}}
+				initialUrl="http://pulse.test/test"
+			>
 				<PulseProvider
 					config={{
 						serverAddress: "http://pulse.test",
@@ -40,6 +44,8 @@ describe("PulseView channel hooks", () => {
 						directives: {},
 						views: {
 							"/test": {
+								view: "view-1",
+								routePath: "/test",
 								vdom: { tag: "$$Probe" },
 							},
 						},
@@ -47,13 +53,13 @@ describe("PulseView channel hooks", () => {
 				>
 					<PulseView path="/test" registry={{ Probe }} />
 				</PulseProvider>
-			</MemoryRouter>,
+			</PulseRouterProvider>,
 		);
 
 		await waitFor(() => {
 			expect(screen.getByTestId("channel")).toHaveTextContent("chan-1");
 		});
-		expect(states[0]).toEqual({ path: "/test", channel: null });
-		expect(states.at(-1)).toEqual({ path: "/test", channel: "chan-1" });
+		expect(states[0]).toEqual({ viewId: "view-1", channel: null });
+		expect(states.at(-1)).toEqual({ viewId: "view-1", channel: "chan-1" });
 	});
 });

--- a/packages/pulse/js/src/pulse.tsx
+++ b/packages/pulse/js/src/pulse.tsx
@@ -8,14 +8,14 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { useNavigate, useRouteInfo } from "./router";
+import { useLocation, useNavigate, useParams } from "react-router";
 import {
 	createPulseChannelManager,
 	type ChannelBridge,
 	type PulseChannelManager,
 } from "./channel";
 import { type ConnectionStatus, type Directives, PulseSocketIOClient } from "./client";
-import type { RouteInfo } from "./helpers";
+import { buildRouteInfo, type RouteInfo } from "./helpers";
 import type { ServerError } from "./messages";
 import { VDOMRenderer } from "./renderer";
 import { deserialize } from "./serialize/serializer";
@@ -146,6 +146,20 @@ export interface PulseProviderProps {
 	children: ReactNode;
 	config: PulseConfig;
 	prerender: PulsePrerender;
+}
+
+function useRouteInfo(): RouteInfo {
+	const location = useLocation();
+	const params = useParams();
+	// biome-ignore lint/correctness/useExhaustiveDependencies: using hacky deep equality for params
+	return useMemo(() => {
+		const { "*": catchall = "", ...pathParams } = params;
+		return buildRouteInfo(
+			location,
+			pathParams,
+			catchall.length > 0 ? catchall.split("/") : [],
+		);
+	}, [location.hash, location.pathname, location.search, JSON.stringify(params)]);
 }
 
 const inBrowser = typeof window !== "undefined";

--- a/packages/pulse/js/src/pulse.tsx
+++ b/packages/pulse/js/src/pulse.tsx
@@ -8,7 +8,7 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { useLocation, useNavigate, useParams } from "react-router";
+import { useNavigate, useRouteInfo } from "./router";
 import {
 	createPulseChannelManager,
 	type ChannelBridge,
@@ -38,6 +38,10 @@ export interface PulseConfig {
 }
 
 export type PulsePrerenderView = {
+	// Unique id of the server-side view
+	view: string;
+	// Route pattern path (e.g. "/users/:id")
+	routePath: string;
 	vdom: VDOM;
 };
 
@@ -52,7 +56,7 @@ export type PulsePrerender = {
 // Context for the client, provided by PulseProvider
 const PulseClientContext = createContext<PulseSocketIOClient | null>(null);
 const PulsePrerenderContext = createContext<PulsePrerender | null>(null);
-export const PulseViewPathContext = createContext<string | null>(null);
+export const PulseViewIdContext = createContext<string | null>(null);
 
 export const usePulseClient = () => {
 	const client = useContext(PulseClientContext);
@@ -74,22 +78,25 @@ export const usePulsePrerender = (path: string) => {
 	return view;
 };
 
-export const usePulseViewPath = () => {
-	const path = useContext(PulseViewPathContext);
-	if (!path) {
-		throw new Error("usePulseViewPath must be used within a PulseView");
+export const usePulseViewId = () => {
+	const viewId = useContext(PulseViewIdContext);
+	if (!viewId) {
+		throw new Error("usePulseViewId must be used within a PulseView");
 	}
-	return path;
+	return viewId;
 };
 
 export function usePulseChannelManager(): PulseChannelManager {
-	const path = usePulseViewPath();
-	return usePulseChannelManagerForPath(path);
+	const viewId = usePulseViewId();
+	return usePulseChannelManagerForView(viewId);
 }
 
-export function usePulseChannelManagerForPath(path: string): PulseChannelManager {
+export function usePulseChannelManagerForView(viewId: string): PulseChannelManager {
 	const client = usePulseClient();
-	const manager = useMemo(() => createPulseChannelManager(client, path), [client, path]);
+	const manager = useMemo(
+		() => createPulseChannelManager(client, viewId),
+		[client, viewId],
+	);
 	const pendingDispose = useRef<{
 		manager: PulseChannelManager;
 		timer: ReturnType<typeof setTimeout>;
@@ -150,7 +157,7 @@ function reportConnectionError(err: unknown) {
 
 export function PulseProvider({ children, config, prerender }: PulseProviderProps) {
 	const [status, setStatus] = useState<ConnectionStatus>("ok");
-	const rrNavigate = useNavigate();
+	const navigate = useNavigate();
 	const { directives } = prerender;
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: another useEffect syncs the directives without recreating the client
@@ -158,10 +165,10 @@ export function PulseProvider({ children, config, prerender }: PulseProviderProp
 		return new PulseSocketIOClient(
 			config.serverAddress,
 			directives,
-			rrNavigate,
+			navigate,
 			config.connectionStatus,
 		);
-	}, [config.serverAddress, rrNavigate, config.connectionStatus]);
+	}, [config.serverAddress, navigate, config.connectionStatus]);
 	useEffect(() => client.setDirectives(directives), [client, directives]);
 
 	useEffect(() => {
@@ -252,42 +259,22 @@ export interface PulseViewProps {
 
 export function PulseView({ path, registry }: PulseViewProps) {
 	const client = usePulseClient();
-	const channels = usePulseChannelManagerForPath(path);
 	const initialView = usePulsePrerender(path);
+	const viewId = initialView.view;
+	const channels = usePulseChannelManagerForView(viewId);
 	const renderer = useMemo(
-		() => new VDOMRenderer(client, channels, path, registry),
-		[client, channels, path, registry],
+		() => new VDOMRenderer(client, channels, viewId, registry),
+		[client, channels, viewId, registry],
 	);
 	const [tree, setTree] = useState<ReactNode>(() => renderer.init(initialView));
 	const [serverError, setServerError] = useState<ServerError | null>(null);
 
-	const location = useLocation();
-	const params = useParams();
-
-	// biome-ignore lint/correctness/useExhaustiveDependencies: using hacky deep equality for params
-	const routeInfo = useMemo(() => {
-		const { "*": catchall = "", ...pathParams } = params;
-		const queryParams = new URLSearchParams(location.search);
-		const query = location.search.startsWith("?")
-			? location.search.slice(1)
-			: location.search;
-		const hash = location.hash.startsWith("#")
-			? location.hash.slice(1)
-			: location.hash;
-		return {
-			hash,
-			pathname: location.pathname,
-			query,
-			queryParams: Object.fromEntries(queryParams.entries()),
-			pathParams,
-			catchall: catchall.length > 0 ? catchall.split("/") : [],
-		} satisfies RouteInfo;
-	}, [location.hash, location.pathname, location.search, JSON.stringify(params)]);
+	const routeInfo = useRouteInfo();
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: We don't want to detach on navigation, so another useEffect syncs the routeInfo on navigation.
 	useEffect(() => {
 		if (inBrowser) {
-			client.attach(path, {
+			client.attach(viewId, {
 				routeInfo,
 				onInit: (view) => {
 					setTree(renderer.init(view));
@@ -314,17 +301,17 @@ export function PulseView({ path, registry }: PulseViewProps) {
 			return () => {
 				renderer.clearPendingCallbacks();
 				renderer.dispose();
-				client.detach(path);
+				client.detach(viewId);
 			};
 		}
 		//  routeInfo is NOT included here on purpose
-	}, [client, renderer, path]);
+	}, [client, renderer, viewId]);
 
 	useEffect(() => {
 		if (inBrowser) {
-			client.updateRoute(path, routeInfo);
+			client.updateRoute(viewId, routeInfo);
 		}
-	}, [client, path, routeInfo]);
+	}, [client, viewId, routeInfo]);
 	// Hack for our current prerendering setup on client-side navigation. Will be improved soon
 	const hasRendered = useRef(false);
 	useIsomorphicLayoutEffect(() => {
@@ -345,7 +332,7 @@ export function PulseView({ path, registry }: PulseViewProps) {
 		return <ServerErrorPopup error={serverError} />;
 	}
 
-	return <PulseViewPathContext.Provider value={path}>{tree}</PulseViewPathContext.Provider>;
+	return <PulseViewIdContext.Provider value={viewId}>{tree}</PulseViewIdContext.Provider>;
 }
 
 function ServerErrorPopup({ error }: { error: ServerError }) {

--- a/packages/pulse/js/src/renderer.tsx
+++ b/packages/pulse/js/src/renderer.tsx
@@ -56,7 +56,7 @@ type ElementMeta = {
 
 export class VDOMRenderer {
 	#client: PulseSocketIOClient;
-	#path: string;
+	#viewId: string;
 	#registry: ComponentRegistry;
 	#refRegistry: RefRegistry;
 
@@ -69,11 +69,11 @@ export class VDOMRenderer {
 	constructor(
 		client: PulseSocketIOClient,
 		channels: PulseChannelManager,
-		path: string,
+		viewId: string,
 		registry: ComponentRegistry = {},
 	) {
 		this.#client = client;
-		this.#path = path;
+		this.#viewId = viewId;
 		this.#registry = registry;
 		this.#callbackEntries = new Set();
 		this.#metaMap = new WeakMap();
@@ -302,7 +302,7 @@ export class VDOMRenderer {
 		if (!entry) {
 			const fire = (args: any[]) => {
 				const key = this.#propPath(meta.path ?? "", prop);
-				this.#client.invokeCallback(this.#path, key, args);
+				this.#client.invokeCallback(this.#viewId, key, args);
 			};
 			entry = {
 				fn: (...args: any[]) => {

--- a/packages/pulse/js/src/router/index.ts
+++ b/packages/pulse/js/src/router/index.ts
@@ -1,0 +1,34 @@
+export { Link, type LinkProps } from "./link";
+export {
+	matchRoutes,
+	normalizePathname,
+	type MatchResult,
+	type PulseRoute,
+} from "./match";
+export {
+	getRouteModule,
+	loadRouteModule,
+	prefetchRouteModules,
+	preloadRoutesForPath,
+	type RouteLoader,
+	type RouteLoaderMap,
+	type RouteModule,
+} from "./modules";
+export {
+	Outlet,
+	PulseRouterProvider,
+	type PulseRouterProviderProps,
+	PulseRoutes,
+	resolveHref,
+	scrollToHash,
+	useLocation,
+	useNavigate,
+	useNavigationError,
+	useParams,
+	useRouteInfo,
+	useRouter,
+	type NavigateFunction,
+	type NavigateOptions,
+	type NavigationError,
+	type NavigationTarget,
+} from "./router";

--- a/packages/pulse/js/src/router/link.tsx
+++ b/packages/pulse/js/src/router/link.tsx
@@ -1,0 +1,115 @@
+import type { AnchorHTMLAttributes, MouseEvent } from "react";
+import { useCallback, useEffect, useRef } from "react";
+import { useRouter } from "./router";
+
+export type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+	to: string;
+	/**
+	 * Prefetch strategy:
+	 * - "intent" (default): prefetch on hover/focus
+	 * - "viewport": prefetch when the link scrolls into view
+	 * - "render": prefetch as soon as the link renders
+	 * - "none": never prefetch
+	 */
+	prefetch?: "none" | "intent" | "render" | "viewport";
+	/** Skip client routing and let the browser load the document. */
+	reloadDocument?: boolean;
+	replace?: boolean;
+};
+
+export function Link({
+	to,
+	prefetch = "intent",
+	reloadDocument,
+	replace,
+	onClick,
+	onMouseEnter,
+	onFocus,
+	...rest
+}: LinkProps) {
+	const { navigate, prefetch: prefetchRoute } = useRouter();
+	const ref = useRef<HTMLAnchorElement | null>(null);
+
+	useEffect(() => {
+		if (prefetch === "render") {
+			prefetchRoute(to);
+		}
+	}, [prefetch, prefetchRoute, to]);
+
+	useEffect(() => {
+		if (prefetch !== "viewport") {
+			return;
+		}
+		const el = ref.current;
+		if (!el || !("IntersectionObserver" in window)) {
+			return;
+		}
+		const observer = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					if (entry.isIntersecting) {
+						prefetchRoute(to);
+						observer.disconnect();
+						break;
+					}
+				}
+			},
+			{ rootMargin: "50px" },
+		);
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, [prefetch, prefetchRoute, to]);
+
+	const handleClick = useCallback(
+		(event: MouseEvent<HTMLAnchorElement>) => {
+			onClick?.(event);
+			if (
+				event.defaultPrevented ||
+				event.button !== 0 ||
+				event.metaKey ||
+				event.altKey ||
+				event.ctrlKey ||
+				event.shiftKey
+			) {
+				return;
+			}
+			if (reloadDocument) {
+				return;
+			}
+			event.preventDefault();
+			navigate(to, { replace });
+		},
+		[navigate, onClick, reloadDocument, replace, to],
+	);
+
+	const handleMouseEnter = useCallback(
+		(event: MouseEvent<HTMLAnchorElement>) => {
+			onMouseEnter?.(event);
+			if (prefetch === "intent") {
+				prefetchRoute(to);
+			}
+		},
+		[onMouseEnter, prefetch, prefetchRoute, to],
+	);
+
+	const handleFocus = useCallback(
+		(event: React.FocusEvent<HTMLAnchorElement>) => {
+			onFocus?.(event);
+			if (prefetch === "intent") {
+				prefetchRoute(to);
+			}
+		},
+		[onFocus, prefetch, prefetchRoute, to],
+	);
+
+	return (
+		<a
+			{...rest}
+			ref={ref}
+			href={to}
+			onClick={handleClick}
+			onMouseEnter={handleMouseEnter}
+			onFocus={handleFocus}
+		/>
+	);
+}

--- a/packages/pulse/js/src/router/match.test.ts
+++ b/packages/pulse/js/src/router/match.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "bun:test";
+import { matchRoutes, type PulseRoute } from "./match";
+
+const tree: PulseRoute[] = [
+	{ id: "/", index: true },
+	{ id: "/about", path: "about" },
+	{
+		id: "/users",
+		path: "users",
+		children: [
+			{ id: "/users/", index: true },
+			{ id: "/users/new", path: "new" },
+			{ id: "/users/:id", path: ":id" },
+			{ id: "/users/:id/edit", path: ":id/edit" },
+		],
+	},
+	{
+		id: "<layout>",
+		children: [
+			{ id: "/dashboard", path: "dashboard" },
+			{
+				id: "<layout>/settings",
+				path: "settings",
+				children: [{ id: "/settings/", index: true }],
+			},
+		],
+	},
+	{ id: "/docs/:section?", path: "docs/:section?" },
+	{ id: "/files/*", path: "files/*" },
+];
+
+describe("matchRoutes", () => {
+	it("matches the index route", () => {
+		const match = matchRoutes(tree, "/");
+		expect(match?.matches.map((r) => r.id)).toEqual(["/"]);
+	});
+
+	it("matches static routes", () => {
+		const match = matchRoutes(tree, "/about");
+		expect(match?.matches.map((r) => r.id)).toEqual(["/about"]);
+	});
+
+	it("normalizes trailing slashes", () => {
+		const match = matchRoutes(tree, "/about/");
+		expect(match?.matches.map((r) => r.id)).toEqual(["/about"]);
+	});
+
+	it("matches nested index routes", () => {
+		const match = matchRoutes(tree, "/users");
+		expect(match?.matches.map((r) => r.id)).toEqual(["/users", "/users/"]);
+	});
+
+	it("prefers static segments over dynamic ones", () => {
+		const match = matchRoutes(tree, "/users/new");
+		expect(match?.matches.map((r) => r.id)).toEqual(["/users", "/users/new"]);
+	});
+
+	it("extracts dynamic params", () => {
+		const match = matchRoutes(tree, "/users/42");
+		expect(match?.matches.map((r) => r.id)).toEqual(["/users", "/users/:id"]);
+		expect(match?.params).toEqual({ id: "42" });
+	});
+
+	it("matches multi-segment dynamic routes", () => {
+		const match = matchRoutes(tree, "/users/42/edit");
+		expect(match?.matches.map((r) => r.id)).toEqual(["/users", "/users/:id/edit"]);
+		expect(match?.params).toEqual({ id: "42" });
+	});
+
+	it("matches through pathless layouts", () => {
+		const match = matchRoutes(tree, "/dashboard");
+		expect(match?.matches.map((r) => r.id)).toEqual(["<layout>", "/dashboard"]);
+	});
+
+	it("matches nested layouts with index children", () => {
+		const match = matchRoutes(tree, "/settings");
+		expect(match?.matches.map((r) => r.id)).toEqual([
+			"<layout>",
+			"<layout>/settings",
+			"/settings/",
+		]);
+	});
+
+	it("matches optional params when present", () => {
+		const match = matchRoutes(tree, "/docs/intro");
+		expect(match?.matches.map((r) => r.id)).toEqual(["/docs/:section?"]);
+		expect(match?.params).toEqual({ section: "intro" });
+	});
+
+	it("matches optional params when absent", () => {
+		const match = matchRoutes(tree, "/docs");
+		expect(match?.matches.map((r) => r.id)).toEqual(["/docs/:section?"]);
+		expect(match?.params).toEqual({});
+	});
+
+	it("captures catch-all segments", () => {
+		const match = matchRoutes(tree, "/files/a/b/c");
+		expect(match?.matches.map((r) => r.id)).toEqual(["/files/*"]);
+		expect(match?.catchall).toEqual(["a", "b", "c"]);
+	});
+
+	it("matches catch-all with no segments", () => {
+		const match = matchRoutes(tree, "/files");
+		expect(match?.matches.map((r) => r.id)).toEqual(["/files/*"]);
+		expect(match?.catchall).toEqual([]);
+	});
+
+	it("returns null for unknown paths", () => {
+		expect(matchRoutes(tree, "/nope")).toBeNull();
+		expect(matchRoutes(tree, "/users/42/nope")).toBeNull();
+	});
+});

--- a/packages/pulse/js/src/router/match.ts
+++ b/packages/pulse/js/src/router/match.ts
@@ -1,0 +1,249 @@
+/**
+ * Route matching for the Pulse router.
+ *
+ * Mirrors the Python matcher in `pulse/routing.py` (`match_route_tree`):
+ * static segments score higher than dynamic (`:id`), dynamic higher than
+ * optional (`:id?`), and catch-all (`*`) lowest. Layouts are pathless nodes
+ * that never consume URL segments.
+ */
+
+export type PulseRoute = {
+	id: string;
+	path?: string;
+	index?: boolean;
+	children?: PulseRoute[];
+};
+
+export type MatchResult = {
+	matches: PulseRoute[];
+	params: Record<string, string | undefined>;
+	catchall: string[];
+};
+
+type RouteSegment = {
+	name: string;
+	dynamic: boolean;
+	optional: boolean;
+	splat: boolean;
+};
+
+export function normalizePathname(pathname: string): string {
+	if (!pathname.startsWith("/")) {
+		pathname = `/${pathname}`;
+	}
+	if (pathname.length > 1 && pathname.endsWith("/")) {
+		return pathname.slice(0, -1);
+	}
+	return pathname;
+}
+
+function splitPathname(pathname: string): string[] {
+	const normalized = normalizePathname(pathname);
+	const stripped = normalized.replace(/^\/+|\/+$/g, "");
+	return stripped.length ? stripped.split("/") : [];
+}
+
+function parseRoutePath(path: string | undefined): RouteSegment[] {
+	if (!path) {
+		return [];
+	}
+	const trimmed = path.replace(/^\/+|\/+$/g, "");
+	if (!trimmed) {
+		return [];
+	}
+	return trimmed.split("/").map((part) => {
+		const optional = part.endsWith("?");
+		const raw = optional ? part.slice(0, -1) : part;
+		const splat = raw === "*";
+		const dynamic = raw.startsWith(":");
+		const name = dynamic ? raw.slice(1) : raw;
+		return { name, dynamic, optional, splat };
+	});
+}
+
+type SegmentMatch = {
+	consumed: number;
+	params: Record<string, string | undefined>;
+	catchall: string[];
+	score: number;
+};
+
+function matchSegments(
+	routeSegments: RouteSegment[],
+	pathSegments: string[],
+	index = 0,
+): SegmentMatch[] {
+	if (index >= routeSegments.length) {
+		return [{ consumed: 0, params: {}, catchall: [], score: 0 }];
+	}
+
+	const segment = routeSegments[index]!;
+
+	if (segment.splat) {
+		return [
+			{
+				consumed: pathSegments.length,
+				params: {},
+				catchall: pathSegments.slice(),
+				score: 0,
+			},
+		];
+	}
+
+	const results: SegmentMatch[] = [];
+	const head = pathSegments[0];
+
+	if (head !== undefined) {
+		if (segment.dynamic) {
+			for (const next of matchSegments(routeSegments, pathSegments.slice(1), index + 1)) {
+				results.push({
+					consumed: 1 + next.consumed,
+					params: { ...next.params, [segment.name]: head },
+					catchall: next.catchall,
+					score: 2 + next.score,
+				});
+			}
+		} else if (segment.name === head) {
+			for (const next of matchSegments(routeSegments, pathSegments.slice(1), index + 1)) {
+				results.push({
+					consumed: 1 + next.consumed,
+					params: { ...next.params },
+					catchall: next.catchall,
+					score: 3 + next.score,
+				});
+			}
+		}
+	}
+
+	if (segment.optional) {
+		for (const next of matchSegments(routeSegments, pathSegments, index + 1)) {
+			results.push({
+				consumed: next.consumed,
+				params: { ...next.params },
+				catchall: next.catchall,
+				score: next.score,
+			});
+		}
+	}
+
+	return results;
+}
+
+type MatchCandidate = {
+	matches: PulseRoute[];
+	params: Record<string, string | undefined>;
+	catchall: string[];
+	remaining: string[];
+	score: number;
+};
+
+function matchBranch(
+	routes: PulseRoute[],
+	pathSegments: string[],
+	parentMatches: PulseRoute[] = [],
+	parentParams: Record<string, string | undefined> = {},
+	parentCatchall: string[] = [],
+	parentScore = 0,
+): MatchCandidate[] {
+	const results: MatchCandidate[] = [];
+
+	for (const route of routes) {
+		const isLayout = route.path == null && !route.index;
+		if (isLayout) {
+			if (!route.children || route.children.length === 0) {
+				continue;
+			}
+			results.push(
+				...matchBranch(
+					route.children,
+					pathSegments,
+					[...parentMatches, route],
+					parentParams,
+					parentCatchall,
+					parentScore,
+				),
+			);
+			continue;
+		}
+
+		if (route.index || route.path === "") {
+			if (pathSegments.length === 0) {
+				results.push({
+					matches: [...parentMatches, route],
+					params: { ...parentParams },
+					catchall: parentCatchall.slice(),
+					remaining: [],
+					score: parentScore + 4,
+				});
+			}
+			continue;
+		}
+
+		const segments = parseRoutePath(route.path);
+		for (const match of matchSegments(segments, pathSegments)) {
+			const remaining = pathSegments.slice(match.consumed);
+			const nextParams = { ...parentParams, ...match.params };
+			const nextCatchall = match.catchall.length > 0 ? match.catchall : parentCatchall;
+			const nextScore = parentScore + match.score;
+			const nextMatches = [...parentMatches, route];
+
+			if (route.children && route.children.length > 0) {
+				const childMatches = matchBranch(
+					route.children,
+					remaining,
+					nextMatches,
+					nextParams,
+					nextCatchall,
+					nextScore,
+				);
+				if (childMatches.length > 0) {
+					results.push(...childMatches);
+					continue;
+				}
+			}
+
+			if (remaining.length === 0) {
+				results.push({
+					matches: nextMatches,
+					params: nextParams,
+					catchall: nextCatchall,
+					remaining: [],
+					score: nextScore,
+				});
+			}
+		}
+	}
+
+	return results;
+}
+
+function pickBestMatch(candidates: MatchCandidate[]): MatchCandidate | null {
+	if (candidates.length === 0) {
+		return null;
+	}
+	let best = candidates[0]!;
+	for (const candidate of candidates.slice(1)) {
+		if (candidate.score > best.score) {
+			best = candidate;
+			continue;
+		}
+		if (candidate.score === best.score && candidate.matches.length > best.matches.length) {
+			best = candidate;
+		}
+	}
+	return best;
+}
+
+export function matchRoutes(routes: PulseRoute[], pathname: string): MatchResult | null {
+	const segments = splitPathname(pathname);
+	const candidates = matchBranch(routes, segments);
+	const best = pickBestMatch(candidates);
+	if (!best || best.remaining.length > 0) {
+		return null;
+	}
+	return {
+		matches: best.matches,
+		params: best.params,
+		catchall: best.catchall,
+	};
+}

--- a/packages/pulse/js/src/router/modules.ts
+++ b/packages/pulse/js/src/router/modules.ts
@@ -1,0 +1,113 @@
+/**
+ * Route module loading + caching.
+ *
+ * Modules are cached by route id, keyed to the loader function that produced
+ * them: when codegen or HMR swaps the loader map, stale entries reload
+ * transparently. Loading is observable so the router re-renders when a module
+ * arrives (e.g. after an HMR invalidation).
+ */
+import type { ComponentType } from "react";
+import { matchRoutes, type PulseRoute } from "./match";
+
+export type RouteModule = {
+	default: ComponentType<any>;
+	registry?: Record<string, unknown>;
+	path?: string;
+};
+
+export type RouteLoader = () => Promise<RouteModule>;
+export type RouteLoaderMap = Record<string, RouteLoader>;
+
+type CacheEntry = {
+	loader: RouteLoader;
+	module?: RouteModule;
+	promise?: Promise<RouteModule>;
+};
+
+const cache = new Map<string, CacheEntry>();
+const listeners = new Set<() => void>();
+let version = 0;
+
+function notify() {
+	version += 1;
+	for (const listener of listeners) {
+		listener();
+	}
+}
+
+export function subscribeRouteModules(listener: () => void): () => void {
+	listeners.add(listener);
+	return () => listeners.delete(listener);
+}
+
+export function getRouteModulesVersion(): number {
+	return version;
+}
+
+export function getRouteModule(id: string, loaders: RouteLoaderMap): RouteModule | null {
+	const entry = cache.get(id);
+	if (entry && entry.loader === loaders[id] && entry.module) {
+		return entry.module;
+	}
+	return null;
+}
+
+export function loadRouteModule(id: string, loaders: RouteLoaderMap): Promise<RouteModule> {
+	const loader = loaders[id];
+	if (!loader) {
+		return Promise.reject(new Error(`[Pulse] No route loader registered for '${id}'`));
+	}
+	const entry = cache.get(id);
+	if (entry && entry.loader === loader) {
+		if (entry.module) return Promise.resolve(entry.module);
+		if (entry.promise) return entry.promise;
+	}
+	const next: CacheEntry = { loader };
+	next.promise = loader().then(
+		(mod) => {
+			// A newer loader may have replaced this entry while loading.
+			if (cache.get(id) === next) {
+				next.module = mod;
+				next.promise = undefined;
+				notify();
+			}
+			return mod;
+		},
+		(error) => {
+			if (cache.get(id) === next) {
+				cache.delete(id);
+			}
+			throw error;
+		},
+	);
+	cache.set(id, next);
+	return next.promise;
+}
+
+export async function preloadRoutesForPath(
+	routes: PulseRoute[],
+	loaders: RouteLoaderMap,
+	pathname: string,
+): Promise<void> {
+	const match = matchRoutes(routes, pathname);
+	if (!match) {
+		return;
+	}
+	await Promise.all(match.matches.map((route) => loadRouteModule(route.id, loaders)));
+}
+
+export function prefetchRouteModules(
+	routes: PulseRoute[],
+	loaders: RouteLoaderMap,
+	pathname: string,
+): void {
+	const match = matchRoutes(routes, pathname);
+	if (!match) {
+		return;
+	}
+	for (const route of match.matches) {
+		loadRouteModule(route.id, loaders).catch((error) => {
+			console.error(`[Pulse] Failed to prefetch route module '${route.id}':`, error);
+		});
+	}
+}

--- a/packages/pulse/js/src/router/router.test.tsx
+++ b/packages/pulse/js/src/router/router.test.tsx
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, it, vi } from "bun:test";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { Link } from "./link";
+import type { PulseRoute } from "./match";
+import type { RouteLoaderMap } from "./modules";
+import {
+	Outlet,
+	PulseRouterProvider,
+	PulseRoutes,
+	resolveHref,
+	useNavigate,
+	useNavigationError,
+	useRouteInfo,
+} from "./router";
+
+function HomePage() {
+	return <div data-testid="page">home</div>;
+}
+
+function LayoutShell() {
+	return (
+		<div data-testid="layout">
+			<Outlet />
+		</div>
+	);
+}
+
+function UserPage() {
+	const info = useRouteInfo();
+	return <div data-testid="page">user:{info.pathParams.id}</div>;
+}
+
+const routes: PulseRoute[] = [
+	{ id: "/", index: true },
+	{
+		id: "<layout>",
+		children: [{ id: "/users/:id", path: "users/:id" }],
+	},
+];
+
+const routeLoaders: RouteLoaderMap = {
+	"/": async () => ({ default: HomePage }),
+	"<layout>": async () => ({ default: LayoutShell }),
+	"/users/:id": async () => ({ default: UserPage }),
+};
+
+function NavButton({ to, label }: { to: string; label: string }) {
+	const navigate = useNavigate();
+	return (
+		<button type="button" data-testid={`nav-${label}`} onClick={() => navigate(to)}>
+			{label}
+		</button>
+	);
+}
+
+function ErrorProbe() {
+	const error = useNavigationError();
+	return <div data-testid="nav-error">{error ? error.error.message : "none"}</div>;
+}
+
+describe("resolveHref", () => {
+	it("keeps absolute and external URLs", () => {
+		expect(resolveHref("/a/b", "/c")).toBe("/a/b");
+		expect(resolveHref("https://example.com/x", "/c")).toBe("https://example.com/x");
+		expect(resolveHref("mailto:a@b.c", "/c")).toBe("mailto:a@b.c");
+	});
+
+	it("treats protocol-relative URLs as external", () => {
+		expect(resolveHref("//evil.com/x", "/c")).toBe("//evil.com/x");
+	});
+
+	it("resolves relative paths", () => {
+		expect(resolveHref("child", "/parent")).toBe("/parent/child");
+		expect(resolveHref("../sibling", "/parent/child")).toBe("/parent/sibling");
+		expect(resolveHref("./here", "/parent")).toBe("/parent/here");
+	});
+});
+
+describe("PulseRouterProvider", () => {
+	beforeEach(() => {
+		window.history.replaceState(null, "", "/");
+	});
+
+	it("renders the initial route once modules load", async () => {
+		render(
+			<PulseRouterProvider routes={routes} routeLoaders={routeLoaders} initialUrl="http://t/">
+				<PulseRoutes />
+			</PulseRouterProvider>,
+		);
+		await waitFor(() => {
+			expect(screen.getByTestId("page")).toHaveTextContent("home");
+		});
+	});
+
+	it("navigates between routes and renders nested layouts", async () => {
+		const onNavigate = vi.fn(async () => {});
+		render(
+			<PulseRouterProvider
+				routes={routes}
+				routeLoaders={routeLoaders}
+				initialUrl="http://t/"
+				onNavigate={onNavigate}
+			>
+				<NavButton to="/users/7" label="user" />
+				<PulseRoutes />
+			</PulseRouterProvider>,
+		);
+		await waitFor(() => {
+			expect(screen.getByTestId("page")).toHaveTextContent("home");
+		});
+
+		await act(async () => {
+			screen.getByTestId("nav-user").click();
+		});
+
+		await waitFor(() => {
+			expect(screen.getByTestId("layout")).toBeInTheDocument();
+			expect(screen.getByTestId("page")).toHaveTextContent("user:7");
+		});
+		expect(onNavigate).toHaveBeenCalledTimes(1);
+		expect(window.location.pathname).toBe("/users/7");
+	});
+
+	it("drops navigations superseded by a newer one", async () => {
+		let resolveFirst: (() => void) | null = null;
+		const onNavigate = vi.fn((target: { location: { pathname: string } }) => {
+			if (target.location.pathname === "/users/1") {
+				return new Promise<void>((resolve) => {
+					resolveFirst = resolve;
+				});
+			}
+			return Promise.resolve();
+		});
+
+		render(
+			<PulseRouterProvider
+				routes={routes}
+				routeLoaders={routeLoaders}
+				initialUrl="http://t/"
+				onNavigate={onNavigate}
+			>
+				<NavButton to="/users/1" label="one" />
+				<NavButton to="/users/2" label="two" />
+				<PulseRoutes />
+			</PulseRouterProvider>,
+		);
+		await waitFor(() => {
+			expect(screen.getByTestId("page")).toHaveTextContent("home");
+		});
+
+		await act(async () => {
+			screen.getByTestId("nav-one").click();
+		});
+		await act(async () => {
+			screen.getByTestId("nav-two").click();
+		});
+		await waitFor(() => {
+			expect(screen.getByTestId("page")).toHaveTextContent("user:2");
+		});
+
+		// The slow first navigation resolves afterwards and must not win.
+		await act(async () => {
+			resolveFirst?.();
+			await Promise.resolve();
+		});
+		expect(screen.getByTestId("page")).toHaveTextContent("user:2");
+		expect(window.location.pathname).toBe("/users/2");
+	});
+
+	it("surfaces navigation errors without committing", async () => {
+		const onNavigate = vi.fn(async () => {
+			throw new Error("prerender failed");
+		});
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		render(
+			<PulseRouterProvider
+				routes={routes}
+				routeLoaders={routeLoaders}
+				initialUrl="http://t/"
+				onNavigate={onNavigate}
+			>
+				<NavButton to="/users/7" label="user" />
+				<ErrorProbe />
+				<PulseRoutes />
+			</PulseRouterProvider>,
+		);
+		await waitFor(() => {
+			expect(screen.getByTestId("page")).toHaveTextContent("home");
+		});
+
+		await act(async () => {
+			screen.getByTestId("nav-user").click();
+		});
+
+		await waitFor(() => {
+			expect(screen.getByTestId("nav-error")).toHaveTextContent("prerender failed");
+		});
+		// Still on the home page, URL unchanged.
+		expect(screen.getByTestId("page")).toHaveTextContent("home");
+		expect(window.location.pathname).toBe("/");
+		consoleError.mockRestore();
+	});
+
+	it("Link clicks navigate client-side and prefetch on hover", async () => {
+		const onNavigate = vi.fn(async () => {});
+		const onPrefetch = vi.fn();
+		render(
+			<PulseRouterProvider
+				routes={routes}
+				routeLoaders={routeLoaders}
+				initialUrl="http://t/"
+				onNavigate={onNavigate}
+				onPrefetch={onPrefetch}
+			>
+				<Link to="/users/9" data-testid="link">
+					user 9
+				</Link>
+				<PulseRoutes />
+			</PulseRouterProvider>,
+		);
+		await waitFor(() => {
+			expect(screen.getByTestId("page")).toHaveTextContent("home");
+		});
+
+		const link = screen.getByTestId("link");
+		await act(async () => {
+			link.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+		});
+		await waitFor(() => {
+			expect(onPrefetch).toHaveBeenCalledTimes(1);
+		});
+		expect(onPrefetch.mock.calls[0]![0].location.pathname).toBe("/users/9");
+
+		await act(async () => {
+			link.click();
+		});
+		await waitFor(() => {
+			expect(screen.getByTestId("page")).toHaveTextContent("user:9");
+		});
+	});
+});

--- a/packages/pulse/js/src/router/router.tsx
+++ b/packages/pulse/js/src/router/router.tsx
@@ -1,0 +1,439 @@
+import {
+	createContext,
+	type ReactNode,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	useSyncExternalStore,
+} from "react";
+import { buildRouteInfo, type LocationLike, type RouteInfo } from "../helpers";
+import { matchRoutes, type MatchResult, normalizePathname, type PulseRoute } from "./match";
+import {
+	getRouteModule,
+	getRouteModulesVersion,
+	loadRouteModule,
+	preloadRoutesForPath,
+	prefetchRouteModules,
+	type RouteLoaderMap,
+	subscribeRouteModules,
+} from "./modules";
+
+export type NavigateOptions = {
+	replace?: boolean;
+	preventScrollReset?: boolean;
+};
+
+export type NavigateFunction = (to: string | number, options?: NavigateOptions) => void;
+
+export type NavigationTarget = {
+	location: LocationLike;
+	match: MatchResult;
+};
+
+export type NavigationError = {
+	error: Error;
+	location: LocationLike;
+};
+
+type RouterState = {
+	location: LocationLike;
+	matches: PulseRoute[];
+	params: Record<string, string | undefined>;
+	catchall: string[];
+	routeInfo: RouteInfo;
+	navigate: NavigateFunction;
+	prefetch: (to: string) => void;
+	isNavigating: boolean;
+	navigationError: NavigationError | null;
+	routes: PulseRoute[];
+	routeLoaders: RouteLoaderMap;
+};
+
+const RouterContext = createContext<RouterState | null>(null);
+const OutletIndexContext = createContext(0);
+
+const inBrowser = typeof window !== "undefined";
+
+function isExternalHref(href: string): boolean {
+	// Protocol-relative URLs (//host/...) and explicit schemes are external.
+	return href.startsWith("//") || /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(href);
+}
+
+export function resolveHref(to: string, basePathname: string): string {
+	if (isExternalHref(to)) {
+		return to;
+	}
+	if (to.startsWith("/")) {
+		const url = new URL(to, "http://pulse");
+		return normalizePathname(url.pathname) + url.search + url.hash;
+	}
+	const base = basePathname.endsWith("/") ? basePathname : `${basePathname}/`;
+	const url = new URL(to, `http://pulse${base}`);
+	return normalizePathname(url.pathname) + url.search + url.hash;
+}
+
+function currentWindowLocation(): LocationLike {
+	return {
+		pathname: normalizePathname(window.location.pathname),
+		search: window.location.search,
+		hash: window.location.hash,
+	};
+}
+
+function locationToUrl(location: LocationLike): string {
+	return `${location.pathname}${location.search}${location.hash}`;
+}
+
+// ---------------------------------------------------------------------------
+// Scroll restoration
+//
+// Each history entry gets a key stored in history.state; scroll positions are
+// remembered per key so back/forward restores them even when two entries share
+// a pathname.
+// ---------------------------------------------------------------------------
+
+const scrollPositions = new Map<string, { x: number; y: number }>();
+let nextHistoryKey = 0;
+
+function readHistoryKey(): string {
+	const state = window.history.state;
+	if (state && typeof state.__pulseKey === "string") {
+		return state.__pulseKey;
+	}
+	return "initial";
+}
+
+function newHistoryKey(): string {
+	nextHistoryKey += 1;
+	return `p${nextHistoryKey}-${Date.now().toString(36)}`;
+}
+
+export function scrollToHash(hash: string): void {
+	const id = hash.startsWith("#") ? hash.slice(1) : hash;
+	if (!id) return;
+	const element = document.getElementById(id);
+	if (element) {
+		element.scrollIntoView();
+	}
+}
+
+export interface PulseRouterProviderProps {
+	routes: PulseRoute[];
+	routeLoaders: RouteLoaderMap;
+	/** URL of the initial request; required for SSR, optional in the browser. */
+	initialUrl?: string;
+	/**
+	 * Called before a navigation commits. Typically fetches the new views from
+	 * the Pulse server. Throwing aborts the navigation.
+	 */
+	onNavigate?: (target: NavigationTarget) => Promise<void>;
+	/** Called when a link wants to prefetch a target URL. */
+	onPrefetch?: (target: NavigationTarget) => void;
+	children: ReactNode;
+}
+
+export function PulseRouterProvider({
+	routes,
+	routeLoaders,
+	initialUrl,
+	onNavigate,
+	onPrefetch,
+	children,
+}: PulseRouterProviderProps) {
+	const initialLocation = useMemo<LocationLike>(() => {
+		if (initialUrl) {
+			const url = new URL(initialUrl, "http://pulse");
+			return {
+				pathname: normalizePathname(url.pathname),
+				search: url.search,
+				hash: url.hash,
+			};
+		}
+		if (inBrowser) {
+			return currentWindowLocation();
+		}
+		return { pathname: "/", search: "", hash: "" };
+	}, [initialUrl]);
+
+	const initialMatch = useMemo(
+		() => matchRoutes(routes, initialLocation.pathname),
+		[initialLocation.pathname, routes],
+	);
+
+	const [location, setLocation] = useState<LocationLike>(initialLocation);
+	const [matchState, setMatchState] = useState<MatchResult | null>(initialMatch);
+	const [isNavigating, setIsNavigating] = useState(false);
+	const [navigationError, setNavigationError] = useState<NavigationError | null>(null);
+	const latestLocationRef = useRef<LocationLike>(initialLocation);
+	const navSeqRef = useRef(0);
+
+	useEffect(() => {
+		if (!inBrowser) return;
+		window.history.scrollRestoration = "manual";
+	}, []);
+
+	const applyNavigation = useCallback(
+		async (
+			nextLocation: LocationLike,
+			options: NavigateOptions & { pop?: boolean; onError?: (error: Error) => void } = {},
+		) => {
+			const seq = ++navSeqRef.current;
+			const match = matchRoutes(routes, nextLocation.pathname);
+			if (!match) {
+				// Unknown route: let the server handle it with a full document load.
+				// On popstate the URL has already changed, so a reload resyncs both.
+				if (inBrowser) {
+					if (options.pop) {
+						window.location.reload();
+					} else {
+						window.location.assign(locationToUrl(nextLocation));
+					}
+				}
+				return;
+			}
+
+			setIsNavigating(true);
+			try {
+				await preloadRoutesForPath(routes, routeLoaders, nextLocation.pathname);
+				if (onNavigate) {
+					await onNavigate({ location: nextLocation, match });
+				}
+				if (seq !== navSeqRef.current) {
+					// Superseded by a newer navigation; drop this one.
+					return;
+				}
+				let popKey: string | null = null;
+				if (inBrowser) {
+					if (options.pop) {
+						popKey = readHistoryKey();
+					} else {
+						scrollPositions.set(readHistoryKey(), {
+							x: window.scrollX,
+							y: window.scrollY,
+						});
+						const url = locationToUrl(nextLocation);
+						const state = { __pulseKey: newHistoryKey() };
+						if (options.replace) {
+							window.history.replaceState(state, "", url);
+						} else {
+							window.history.pushState(state, "", url);
+						}
+					}
+				}
+				latestLocationRef.current = nextLocation;
+				setLocation(nextLocation);
+				setMatchState(match);
+				setNavigationError(null);
+				if (inBrowser && !options.preventScrollReset) {
+					requestAnimationFrame(() => {
+						if (seq !== navSeqRef.current) return;
+						if (popKey !== null) {
+							const saved = scrollPositions.get(popKey);
+							window.scrollTo(saved?.x ?? 0, saved?.y ?? 0);
+						} else if (nextLocation.hash) {
+							scrollToHash(nextLocation.hash);
+						} else {
+							window.scrollTo(0, 0);
+						}
+					});
+				}
+			} catch (rawError) {
+				if (seq !== navSeqRef.current) {
+					return;
+				}
+				const error = rawError instanceof Error ? rawError : new Error(String(rawError));
+				console.error("[Pulse] Navigation failed:", error);
+				options.onError?.(error);
+				if (options.pop && inBrowser) {
+					// The browser URL already moved; reload to resync.
+					window.location.reload();
+					return;
+				}
+				setNavigationError({ error, location: nextLocation });
+			} finally {
+				if (seq === navSeqRef.current) {
+					setIsNavigating(false);
+				}
+			}
+		},
+		[onNavigate, routeLoaders, routes],
+	);
+
+	const navigate = useCallback<NavigateFunction>(
+		(to, options = {}) => {
+			if (typeof to === "number") {
+				if (inBrowser) {
+					window.history.go(to);
+				}
+				return;
+			}
+			const href = resolveHref(to, latestLocationRef.current.pathname);
+			if (isExternalHref(href)) {
+				if (inBrowser) {
+					if (options.replace) {
+						window.location.replace(href);
+					} else {
+						window.location.assign(href);
+					}
+				}
+				return;
+			}
+			const url = new URL(href, "http://pulse");
+			void applyNavigation(
+				{
+					pathname: normalizePathname(url.pathname),
+					search: url.search,
+					hash: url.hash,
+				},
+				options,
+			);
+		},
+		[applyNavigation],
+	);
+
+	const prefetch = useCallback(
+		(to: string) => {
+			const href = resolveHref(to, latestLocationRef.current.pathname);
+			if (isExternalHref(href)) {
+				return;
+			}
+			const url = new URL(href, "http://pulse");
+			const pathname = normalizePathname(url.pathname);
+			prefetchRouteModules(routes, routeLoaders, pathname);
+			if (onPrefetch) {
+				const match = matchRoutes(routes, pathname);
+				if (match) {
+					onPrefetch({
+						location: { pathname, search: url.search, hash: url.hash },
+						match,
+					});
+				}
+			}
+		},
+		[onPrefetch, routeLoaders, routes],
+	);
+
+	useEffect(() => {
+		if (!inBrowser) {
+			return;
+		}
+		const onPop = () => {
+			void applyNavigation(currentWindowLocation(), { pop: true });
+		};
+		window.addEventListener("popstate", onPop);
+		return () => window.removeEventListener("popstate", onPop);
+	}, [applyNavigation]);
+
+	const routeInfo = useMemo(() => {
+		if (!matchState) {
+			return buildRouteInfo(location, {}, []);
+		}
+		return buildRouteInfo(location, matchState.params, matchState.catchall);
+	}, [location, matchState]);
+
+	const value = useMemo<RouterState>(() => {
+		return {
+			location,
+			matches: matchState?.matches ?? [],
+			params: matchState?.params ?? {},
+			catchall: matchState?.catchall ?? [],
+			navigate,
+			prefetch,
+			isNavigating,
+			navigationError,
+			routeInfo,
+			routes,
+			routeLoaders,
+		};
+	}, [
+		location,
+		matchState,
+		navigate,
+		prefetch,
+		isNavigating,
+		navigationError,
+		routeInfo,
+		routes,
+		routeLoaders,
+	]);
+
+	return <RouterContext.Provider value={value}>{children}</RouterContext.Provider>;
+}
+
+export function useRouter(): RouterState {
+	const ctx = useContext(RouterContext);
+	if (!ctx) {
+		throw new Error("Pulse router is not available");
+	}
+	return ctx;
+}
+
+export function useLocation(): LocationLike {
+	return useRouter().location;
+}
+
+export function useNavigate(): NavigateFunction {
+	return useRouter().navigate;
+}
+
+export function useParams(): Record<string, string | undefined> {
+	return useRouter().params;
+}
+
+export function useRouteInfo(): RouteInfo {
+	return useRouter().routeInfo;
+}
+
+export function useNavigationError(): NavigationError | null {
+	return useRouter().navigationError;
+}
+
+function useRouteModulesVersion(): number {
+	return useSyncExternalStore(
+		subscribeRouteModules,
+		getRouteModulesVersion,
+		getRouteModulesVersion,
+	);
+}
+
+function RouteMatch({ index }: { index: number }) {
+	const { matches, routeLoaders } = useRouter();
+	useRouteModulesVersion();
+	const match = matches[index];
+
+	useEffect(() => {
+		if (match && !getRouteModule(match.id, routeLoaders)) {
+			loadRouteModule(match.id, routeLoaders).catch((error) => {
+				console.error(`[Pulse] Failed to load route module '${match.id}':`, error);
+			});
+		}
+	}, [match, routeLoaders]);
+
+	if (!match) {
+		return null;
+	}
+	const mod = getRouteModule(match.id, routeLoaders);
+	if (!mod) {
+		// Module load is in flight; the version subscription re-renders us when
+		// it lands.
+		return null;
+	}
+	const Component = mod.default;
+	return (
+		<OutletIndexContext.Provider value={index + 1}>
+			<Component />
+		</OutletIndexContext.Provider>
+	);
+}
+
+export function PulseRoutes() {
+	return <RouteMatch index={0} />;
+}
+
+export function Outlet() {
+	const index = useContext(OutletIndexContext);
+	return <RouteMatch index={index} />;
+}

--- a/packages/pulse/js/test/happydom.ts
+++ b/packages/pulse/js/test/happydom.ts
@@ -1,3 +1,3 @@
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 
-GlobalRegistrator.register();
+GlobalRegistrator.register({ url: "http://localhost/" });

--- a/packages/pulse/python/src/pulse/__init__.py
+++ b/packages/pulse/python/src/pulse/__init__.py
@@ -1428,7 +1428,7 @@ from pulse.render_session import (
 	RenderSession as RenderSession,
 )
 from pulse.render_session import (
-	RouteMount as RouteMount,
+	View as View,
 )
 from pulse.render_session import run_js as run_js
 

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -818,7 +818,7 @@ class App:
 			# Allow reconnects where the provided renderId no longer exists by creating a new RenderSession
 			render = self.render_sessions.get(rid)
 			if render is None:
-				# The client will try to attach to a non-existing RouteMount, which will cause a reload down the line
+				# The client will try to attach to a non-existing View, which will cause a reload down the line
 				render = self.create_render(
 					rid, session, client_address=get_client_address_socketio(environ)
 				)
@@ -862,7 +862,7 @@ class App:
 					)
 					res = _normalize_connect_response(res)
 				except Exception as exc:
-					render.report_error("/", "connect", exc)
+					render.report_error(None, "connect", exc)
 					res = Ok(None)
 				if isinstance(res, Deny):
 					# Tear down the created session if denied
@@ -986,32 +986,31 @@ class App:
 						render, session, cast(ClientPulseMessage, msg)
 					)
 			except Exception as e:
-				path = msg.get("path", "")
-				render.report_error(path, "server", e)
+				render.report_error(msg.get("view"), "server", e)
 
 	async def _handle_pulse_message(
 		self, render: RenderSession, session: UserSession, msg: ClientPulseMessage
 	) -> None:
 		async def _next() -> Ok[None]:
 			if msg["type"] == "attach":
-				attached = render.attach(msg["path"], msg["routeInfo"])
+				attached = render.attach(msg["view"], msg["routeInfo"])
 				attach_id = msg.get("attachId")
 				if attached and isinstance(attach_id, str):
 					render.send(
 						{
 							"type": "attach_ack",
-							"path": msg["path"],
+							"view": msg["view"],
 							"attachId": attach_id,
 						}
 					)
 			elif msg["type"] == "client_resume":
 				render.resume(msg["resumeId"], msg["views"], msg["channels"])
 			elif msg["type"] == "update":
-				render.update_route(msg["path"], msg["routeInfo"])
+				render.update_route(msg["view"], msg["routeInfo"])
 			elif msg["type"] == "callback":
-				render.execute_callback(msg["path"], msg["callback"], msg["args"])
+				render.execute_callback(msg["view"], msg["callback"], msg["args"])
 			elif msg["type"] == "detach":
-				render.detach(msg["path"])
+				render.detach(msg["view"])
 			elif msg["type"] == "api_result":
 				render.handle_api_result(dict(msg))
 			elif msg["type"] == "js_result":
@@ -1039,9 +1038,8 @@ class App:
 				return
 
 			if isinstance(res, Deny):
-				path = cast(str, msg.get("path", "api_response"))
 				render.report_error(
-					path,
+					msg.get("view"),
 					"server",
 					Exception("Request denied by server"),
 					{"kind": "deny"},

--- a/packages/pulse/python/src/pulse/channel.py
+++ b/packages/pulse/python/src/pulse/channel.py
@@ -16,7 +16,6 @@ from pulse.messages import (
 	ServerChannelRequestMessage,
 	ServerChannelResponseMessage,
 )
-from pulse.routing import ensure_absolute_path
 from pulse.scheduling import create_future
 
 if TYPE_CHECKING:
@@ -74,18 +73,18 @@ class ChannelsManager:
 
 	_render_session: "RenderSession"
 	_channels: dict[str, "Channel"]
-	_channels_by_route: dict[str, set[str]]
+	_channels_by_view: dict[str, set[str]]
 	pending_requests: dict[str, PendingRequest]
 
 	def __init__(self, render_session: "RenderSession") -> None:
 		self._render_session = render_session
 		self._channels = {}
-		self._channels_by_route = defaultdict(set)
+		self._channels_by_view = defaultdict(set)
 		self.pending_requests = {}
 
 	# ------------------------------------------------------------------
 	def create(
-		self, identifier: str | None = None, *, bind_route: bool = True
+		self, identifier: str | None = None, *, bind_view: bool = True
 	) -> "Channel":
 		ctx = PulseContext.get()
 		render = ctx.render
@@ -97,52 +96,52 @@ class ChannelsManager:
 		if channel_id in self._channels:
 			raise ValueError(f"Channel id '{channel_id}' is already in use")
 
-		route_path: str | None = None
-		mount_id: str | None = None
-		if bind_route and ctx.route is not None:
-			route_path = ctx.route.route_path
-			mount_id = ctx.source_mount_id
-			if mount_id is None:
-				try:
-					mount_id = render.get_route_mount(route_path).mount_id
-				except ValueError:
-					mount_id = None
+		view_id = ctx.view.id if bind_view and ctx.view is not None else None
 
 		channel = Channel(
 			self,
 			channel_id,
 			render_id=render.id,
 			session_id=session.sid,
-			route_path=route_path,
-			mount_id=mount_id,
+			view_id=view_id,
 		)
 		self._channels[channel_id] = channel
-		if route_path is not None:
-			self._channels_by_route[route_path].add(channel_id)
+		if view_id is not None:
+			self._channels_by_view[view_id].add(channel_id)
 		return channel
 
 	# ------------------------------------------------------------------
-	def remove_route(self, path: str) -> None:
-		# route_path is already an absolute path
-		route_channels = list(self._channels_by_route.get(path, set()))
-		# if route_channels:
-		# 	print(f"Disposing {len(route_channels)} channel(s) for route {route_path}")
-		for channel_id in route_channels:
+	def remove_view(self, view_id: str) -> None:
+		view_channels = list(self._channels_by_view.get(view_id, set()))
+		for channel_id in view_channels:
 			channel = self._channels.get(channel_id)
 			if channel is None:
 				continue
 			channel.closed = True
-			self.dispose_channel(channel, reason="route.unmount")
-		self._channels_by_route.pop(path, None)
+			self.dispose_channel(channel, reason="view.unmount")
+		self._channels_by_view.pop(view_id, None)
 
-	def rebind_route_mount(
-		self, path: str, old_mount_id: str, new_mount_id: str
-	) -> None:
-		path = ensure_absolute_path(path)
-		for channel_id in self._channels_by_route.get(path, set()):
-			channel = self._channels.get(channel_id)
-			if channel is not None and channel.mount_id == old_mount_id:
-				channel.mount_id = new_mount_id
+	def _validate_client_endpoint(
+		self, channel: "Channel", view_id: str, action: str
+	) -> bool:
+		if channel.view_id is None:
+			return True
+		if view_id != channel.view_id:
+			logger.warning(
+				"Rejecting channel %s for wrong view: %s view=%s owner=%s",
+				action,
+				channel.id,
+				view_id,
+				channel.view_id,
+			)
+			return False
+		view = self._render_session.views.get(channel.view_id)
+		if view is None or view.state != "active":
+			logger.warning(
+				"Rejecting stale channel %s: %s view=%s", action, channel.id, view_id
+			)
+			return False
+		return True
 
 	def handle_client_connect(self, message: ClientChannelConnectMessage) -> None:
 		channel_id = str(message.get("channel"))
@@ -150,56 +149,19 @@ class ChannelsManager:
 		if channel is None or channel.closed:
 			return
 
-		path = ensure_absolute_path(str(message.get("path", "")))
-		if channel.route_path is not None and path != channel.route_path:
-			logger.warning(
-				"Rejecting channel connect for wrong path: %s path=%s owner=%s",
-				channel_id,
-				path,
-				channel.route_path,
-			)
+		view_id = str(message.get("view", ""))
+		if not self._validate_client_endpoint(channel, view_id, "connect"):
 			return
-
-		if channel.route_path is not None:
-			mount = self._render_session.route_mounts.get(channel.route_path)
-			if (
-				mount is None
-				or mount.state != "active"
-				or mount.mount_id != channel.mount_id
-			):
-				logger.warning(
-					"Rejecting stale channel connect: %s path=%s", channel_id, path
-				)
-				return
 
 		channel.connected = True
 
-	def resume_client_channel(self, channel_id: str, path: str) -> bool:
+	def resume_client_channel(self, channel_id: str, view_id: str) -> bool:
 		channel = self._channels.get(channel_id)
 		if channel is None or channel.closed:
 			return False
 
-		path = ensure_absolute_path(path)
-		if channel.route_path is not None and path != channel.route_path:
-			logger.warning(
-				"Rejecting channel resume for wrong path: %s path=%s owner=%s",
-				channel_id,
-				path,
-				channel.route_path,
-			)
+		if not self._validate_client_endpoint(channel, view_id, "resume"):
 			return False
-
-		if channel.route_path is not None:
-			mount = self._render_session.route_mounts.get(channel.route_path)
-			if (
-				mount is None
-				or mount.state != "active"
-				or mount.mount_id != channel.mount_id
-			):
-				logger.warning(
-					"Rejecting stale channel resume: %s path=%s", channel_id, path
-				)
-				return False
 
 		channel.connected = True
 		return True
@@ -283,15 +245,11 @@ class ChannelsManager:
 		payload = message.get("payload")
 		request_id = message.get("requestId")
 
-		route_ctx = None
-		source_mount_id = None
-		if channel.route_path is not None:
-			try:
-				mount = render.get_route_mount(channel.route_path)
-				route_ctx = mount.route
-				source_mount_id = mount.mount_id
-			except Exception:
-				route_ctx = None
+		view = (
+			render.views.get(channel.view_id) if channel.view_id is not None else None
+		)
+		route_ctx = view.route if view is not None else None
+		source_pathname = route_ctx.pathname if route_ctx is not None else None
 
 		async def _invoke() -> None:
 			try:
@@ -299,11 +257,8 @@ class ChannelsManager:
 					session=session,
 					render=render,
 					route=route_ctx,
-					source_route_path=(
-						route_ctx.route_path if route_ctx is not None else None
-					),
-					source_path=route_ctx.pathname if route_ctx is not None else None,
-					source_mount_id=source_mount_id,
+					view=view,
+					source_pathname=source_pathname,
 				):
 					result = await channel.dispatch(event, payload, request_id)
 			except Exception as exc:
@@ -419,12 +374,12 @@ class ChannelsManager:
 
 	# ------------------------------------------------------------------
 	def _cleanup_channel_refs(self, channel: "Channel") -> None:
-		if channel.route_path is not None:
-			route_bucket = self._channels_by_route.get(channel.route_path)
-			if route_bucket is not None:
-				route_bucket.discard(channel.id)
-				if not route_bucket:
-					self._channels_by_route.pop(channel.route_path, None)
+		if channel.view_id is not None:
+			view_bucket = self._channels_by_view.get(channel.view_id)
+			if view_bucket is not None:
+				view_bucket.discard(channel.id)
+				if not view_bucket:
+					self._channels_by_view.pop(channel.view_id, None)
 
 	def dispose_channel(
 		self,
@@ -432,12 +387,6 @@ class ChannelsManager:
 		*,
 		reason: str | None = None,
 	) -> None:
-		# pending = sum(
-		# 	1
-		# 	for pending in self.pending_requests.values()
-		# 	if pending.channel_id == channel.id
-		# )
-		# print(f"Disposing channel id={channel.id} render={channel.render_id} session={channel.session_id} route={channel.route_path} reason={reason or 'unspecified'} pending={pending}")
 		self._cleanup_channel_refs(channel)
 		self._cancel_pending_for_channel(channel.id)
 		# Notify client that the channel has been closed
@@ -471,10 +420,10 @@ class ChannelsManager:
 			raise ChannelClosed(f"Channel '{channel.id}' is closed")
 		if not allow_unconnected and not channel.connected:
 			raise ChannelClosed("Channel has no connected client")
-		if channel.route_path is not None and "path" not in msg:
+		if channel.view_id is not None and "view" not in msg:
 			msg = cast(
 				ServerChannelMessage,
-				cast(object, {**msg, "path": channel.route_path}),
+				cast(object, {**msg, "view": channel.view_id}),
 			)
 		self._render_session.send(msg)
 
@@ -489,7 +438,7 @@ class Channel:
 		id: Channel identifier (auto-generated UUID or user-provided).
 		render_id: Associated render session ID.
 		session_id: Associated user session ID.
-		route_path: Route path this channel is bound to, or None.
+		view_id: Id of the view this channel is bound to, or None.
 		closed: Whether the channel has been closed.
 
 	Example:
@@ -511,8 +460,7 @@ class Channel:
 	id: str
 	render_id: str
 	session_id: str
-	route_path: str | None
-	mount_id: str | None
+	view_id: str | None
 	connected: bool
 	_handlers: dict[str, list[ChannelHandler]]
 	closed: bool
@@ -524,15 +472,13 @@ class Channel:
 		*,
 		render_id: str,
 		session_id: str,
-		route_path: str | None,
-		mount_id: str | None,
+		view_id: str | None,
 	) -> None:
 		self._manager = manager
 		self.id = identifier
 		self.render_id = render_id
 		self.session_id = session_id
-		self.route_path = route_path
-		self.mount_id = mount_id
+		self.view_id = view_id
 		self.connected = False
 		self._handlers = defaultdict(list)
 		self.closed = False

--- a/packages/pulse/python/src/pulse/codegen/templates/layout.py
+++ b/packages/pulse/python/src/pulse/codegen/templates/layout.py
@@ -1,7 +1,7 @@
 from mako.template import Template
 
 LAYOUT_TEMPLATE = Template(
-	"""import { deserialize, extractServerRouteInfo, PulseProvider, type PulseConfig, type PulsePrerender } from "pulse-ui-client";
+	"""import { buildRouteInfo, deserialize, PulseProvider, type PulseConfig, type PulsePrerender } from "pulse-ui-client";
 import { Outlet, data, type LoaderFunctionArgs, type ClientLoaderFunctionArgs } from "react-router";
 import { matchRoutes } from "react-router";
 import { rrPulseRouteTree } from "./routes.runtime";
@@ -17,6 +17,17 @@ export const config: PulseConfig = {
     reconnectErrorDelay: ${int(connection_status.reconnect_error_delay * 1000)},
   },
 };
+
+// Build the RouteInfo payload from React Router loader args
+function extractServerRouteInfo({ params, request }: LoaderFunctionArgs | ClientLoaderFunctionArgs) {
+  const { "*": catchall = "", ...pathParams } = params;
+  const parsedUrl = new URL(request.url);
+  return buildRouteInfo(
+    { pathname: parsedUrl.pathname, search: parsedUrl.search, hash: parsedUrl.hash },
+    pathParams,
+    catchall.length > 1 ? catchall.split("/") : [],
+  );
+}
 
 
 // Server loader: perform initial prerender, abort on first redirect/not-found

--- a/packages/pulse/python/src/pulse/context.py
+++ b/packages/pulse/python/src/pulse/context.py
@@ -8,7 +8,7 @@ from pulse.routing import RouteContext
 
 if TYPE_CHECKING:
 	from pulse.app import App
-	from pulse.render_session import RenderSession
+	from pulse.render_session import RenderSession, View
 	from pulse.user_session import UserSession
 
 _UNSET = object()
@@ -26,9 +26,10 @@ class PulseContext:
 		session: Per-user session (UserSession or None).
 		render: Per-connection render session (RenderSession or None).
 		route: Active route context (RouteContext or None).
-		source_route_path: Route mount path that originated the active callback/effect.
-		source_path: URL pathname that originated the active callback/effect.
-		source_mount_id: Route mount lifecycle id that originated the active callback/effect.
+		view: View that originated the active render/callback/effect.
+		source_pathname: URL pathname captured when the active callback/effect
+			was invoked. Used to drop view-bound navigations after the URL has
+			changed within the same view.
 
 	Example:
 		```python
@@ -44,9 +45,8 @@ class PulseContext:
 	session: "UserSession | None" = None
 	render: "RenderSession | None" = None
 	route: "RouteContext | None" = None
-	source_route_path: str | None = None
-	source_path: str | None = None
-	source_mount_id: str | None = None
+	view: "View | None" = None
+	source_pathname: str | None = None
 	_token: "Token[PulseContext | None] | None" = None
 
 	@classmethod
@@ -70,9 +70,8 @@ class PulseContext:
 		session: Any = _UNSET,
 		render: Any = _UNSET,
 		route: Any = _UNSET,
-		source_route_path: Any = _UNSET,
-		source_path: Any = _UNSET,
-		source_mount_id: Any = _UNSET,
+		view: Any = _UNSET,
+		source_pathname: Any = _UNSET,
 	) -> "PulseContext":
 		"""Create a new context with updated values.
 
@@ -82,9 +81,8 @@ class PulseContext:
 			session: New session (optional, inherits if not provided).
 			render: New render session (optional, inherits if not provided).
 			route: New route context (optional, inherits if not provided).
-			source_route_path: New source route path (optional, inherits if not provided).
-			source_path: New source URL path (optional, inherits if not provided).
-			source_mount_id: New source mount id (optional, inherits if not provided).
+			view: New originating view (optional, inherits if not provided).
+			source_pathname: New captured pathname (optional, inherits if not provided).
 
 		Returns:
 			New PulseContext instance with updated values.
@@ -95,14 +93,9 @@ class PulseContext:
 			session=ctx.session if session is _UNSET else session,
 			render=ctx.render if render is _UNSET else render,
 			route=ctx.route if route is _UNSET else route,
-			source_route_path=(
-				ctx.source_route_path
-				if source_route_path is _UNSET
-				else source_route_path
-			),
-			source_path=ctx.source_path if source_path is _UNSET else source_path,
-			source_mount_id=(
-				ctx.source_mount_id if source_mount_id is _UNSET else source_mount_id
+			view=ctx.view if view is _UNSET else view,
+			source_pathname=(
+				ctx.source_pathname if source_pathname is _UNSET else source_pathname
 			),
 		)
 

--- a/packages/pulse/python/src/pulse/forms.py
+++ b/packages/pulse/python/src/pulse/forms.py
@@ -69,14 +69,14 @@ class FormRegistration:
 	Attributes:
 		id: Unique form identifier.
 		render_id: Associated render session ID.
-		route_path: Route path this form is bound to.
+		view_id: Id of the view this form is bound to.
 		session_id: Associated user session ID.
 		on_submit: Async callback for form submission.
 	"""
 
 	id: str
 	render_id: str
-	route_path: str
+	view_id: str
 	session_id: str
 	on_submit: Callable[[FormData], Awaitable[None]]
 
@@ -95,7 +95,7 @@ class FormRegistry(Disposable):
 	def register(
 		self,
 		render_id: str,
-		route_id: str,
+		view_id: str,
 		session_id: str,
 		on_submit: Callable[[FormData], Awaitable[None]],
 	) -> FormRegistration:
@@ -103,7 +103,7 @@ class FormRegistry(Disposable):
 
 		Args:
 			render_id: Render session ID.
-			route_id: Route path.
+			view_id: Id of the view the form was rendered in.
 			session_id: User session ID.
 			on_submit: Async callback for form submission.
 
@@ -113,7 +113,7 @@ class FormRegistry(Disposable):
 		registration = FormRegistration(
 			uuid.uuid4().hex,
 			render_id=render_id,
-			route_path=route_id,
+			view_id=view_id,
 			session_id=session_id,
 			on_submit=on_submit,
 		)
@@ -179,20 +179,19 @@ class FormRegistry(Disposable):
 				del data["__data__"]
 
 		try:
-			mount = self._render.get_route_mount(registration.route_path)
+			view = self._render.get_view(registration.view_id)
 		except ValueError as exc:
 			self.unregister(form_id)
 			raise HTTPException(
 				status_code=410,
-				detail="Form route is no longer mounted",
+				detail="Form view is no longer mounted",
 			) from exc
 
 		with PulseContext.update(
 			render=self._render,
-			route=mount.route,
-			source_route_path=registration.route_path,
-			source_path=mount.route.pathname,
-			source_mount_id=mount.mount_id,
+			route=view.route,
+			view=view,
+			source_pathname=view.route.pathname,
 		):
 			await call_flexible(registration.on_submit, data)
 
@@ -377,12 +376,12 @@ class ManualForm(Disposable):
 		"""
 		ctx = PulseContext.get()
 		render = ctx.render
-		route = ctx.route
+		view = ctx.view
 		session = ctx.session
 		if render is None:
 			raise RuntimeError("ManualForm must be created during a render pass")
-		if route is None:
-			raise RuntimeError("ManualForm requires an active route context")
+		if view is None:
+			raise RuntimeError("ManualForm requires an active view context")
 		if session is None:
 			raise RuntimeError("ManualForm requires an active user session")
 
@@ -391,7 +390,7 @@ class ManualForm(Disposable):
 		self._registration = render.forms.register(
 			session_id=session.sid,
 			render_id=render.id,
-			route_id=route.route_path,
+			view_id=view.id,
 			on_submit=self.wrap_on_submit(on_submit),
 		)
 

--- a/packages/pulse/python/src/pulse/hooks/runtime.py
+++ b/packages/pulse/python/src/pulse/hooks/runtime.py
@@ -235,9 +235,9 @@ def navigate(
 			a new one (default: False).
 		hard: If True, performs a full page reload instead of client-side
 			navigation (default: False).
-		force: If True, navigate even if the route that requested navigation
-			has since unmounted. Defaults to False, so navigation is bound to
-			the current route when called from a route context.
+		force: If True, navigate even if the view that requested navigation
+			has since unmounted or changed URL. Defaults to False, so navigation
+			is bound to the originating view when called from a view context.
 
 	Raises:
 		RuntimeError: If called outside of a Pulse callback context.
@@ -259,11 +259,9 @@ def navigate(
 		"replace": replace,
 		"hard": hard,
 	}
-	if not force and ctx.route is not None:
-		message["sourceRoutePath"] = ctx.source_route_path or ctx.route.route_path
-		message["sourcePath"] = ctx.source_path or ctx.route.pathname
-		if ctx.source_mount_id is not None:
-			message["sourceMountId"] = ctx.source_mount_id
+	if not force and ctx.view is not None:
+		message["sourceView"] = ctx.view.id
+		message["sourcePathname"] = ctx.source_pathname or ctx.view.route.pathname
 	ctx.render.send(message)
 
 

--- a/packages/pulse/python/src/pulse/messages.py
+++ b/packages/pulse/python/src/pulse/messages.py
@@ -9,13 +9,17 @@ from pulse.transpiler.vdom import VDOM, VDOMNode, VDOMOperation
 # ====================
 class ServerInitMessage(TypedDict):
 	type: Literal["vdom_init"]
-	path: str
+	# Unique id of the view this VDOM belongs to
+	view: str
+	# Route pattern path (e.g. "/users/:id"), used by the client to associate
+	# the view with its generated route module.
+	routePath: str
 	vdom: VDOM
 
 
 class ServerUpdateMessage(TypedDict):
 	type: Literal["vdom_update"]
-	path: str
+	view: str
 	ops: list[VDOMOperation]
 
 
@@ -37,7 +41,8 @@ class ServerErrorInfo(TypedDict, total=False):
 
 class ServerErrorMessage(TypedDict):
 	type: Literal["server_error"]
-	path: str
+	# Omitted for session-level errors that are not tied to a view
+	view: NotRequired[str]
 	error: ServerErrorInfo
 
 
@@ -46,9 +51,11 @@ class ServerNavigateToMessage(TypedDict):
 	path: str
 	replace: bool
 	hard: bool
-	sourceRoutePath: NotRequired[str]
-	sourcePath: NotRequired[str]
-	sourceMountId: NotRequired[str]
+	# Origin view id + pathname captured when the navigation was requested.
+	# Route-bound navigations are dropped when the origin view is gone or its
+	# URL has changed since.
+	sourceView: NotRequired[str]
+	sourcePathname: NotRequired[str]
 
 
 class ServerReloadMessage(TypedDict):
@@ -56,13 +63,13 @@ class ServerReloadMessage(TypedDict):
 
 
 class ServerResumeView(TypedDict):
-	path: str
+	view: str
 	attachId: NotRequired[str]
 
 
 class ServerResumeChannel(TypedDict):
 	channel: str
-	path: str
+	view: str
 
 
 class ServerResumeMessage(TypedDict):
@@ -75,7 +82,7 @@ class ServerResumeMessage(TypedDict):
 
 class ServerAttachAckMessage(TypedDict):
 	type: Literal["attach_ack"]
-	path: str
+	view: str
 	attachId: str
 
 
@@ -94,7 +101,7 @@ class ServerApiCallMessage(TypedDict):
 
 class ServerChannelRequestMessage(TypedDict):
 	type: Literal["channel_message"]
-	path: NotRequired[str]
+	view: NotRequired[str]
 	channel: str
 	event: str
 	payload: Any
@@ -104,7 +111,7 @@ class ServerChannelRequestMessage(TypedDict):
 
 class ServerChannelResponseMessage(TypedDict):
 	type: Literal["channel_message"]
-	path: NotRequired[str]
+	view: NotRequired[str]
 	channel: str
 	event: None
 	responseTo: str
@@ -116,7 +123,7 @@ class ServerJsExecMessage(TypedDict):
 	"""Execute JavaScript expression on the client."""
 
 	type: Literal["js_exec"]
-	path: str
+	view: str
 	id: str
 	expr: VDOMNode
 
@@ -126,38 +133,38 @@ class ServerJsExecMessage(TypedDict):
 # ====================
 class ClientCallbackMessage(TypedDict):
 	type: Literal["callback"]
-	path: str
+	view: str
 	callback: str
 	args: list[Any]
 
 
 class ClientAttachMessage(TypedDict):
 	type: Literal["attach"]
-	path: str
+	view: str
 	routeInfo: RouteInfo
 	attachId: NotRequired[str]
 
 
 class ClientUpdateMessage(TypedDict):
 	type: Literal["update"]
-	path: str
+	view: str
 	routeInfo: RouteInfo
 
 
 class ClientDetachMessage(TypedDict):
 	type: Literal["detach"]
-	path: str
+	view: str
 
 
 class ClientResumeView(TypedDict):
-	path: str
+	view: str
 	routeInfo: RouteInfo
 	attachId: NotRequired[str]
 
 
 class ClientResumeChannel(TypedDict):
 	channel: str
-	path: str
+	view: str
 
 
 class ClientResumeMessage(TypedDict):
@@ -197,7 +204,7 @@ class ClientChannelResponseMessage(TypedDict):
 class ClientChannelConnectMessage(TypedDict):
 	type: Literal["channel_connect"]
 	channel: str
-	path: str
+	view: str
 
 
 class ClientChannelDisconnectMessage(TypedDict):
@@ -238,13 +245,13 @@ ClientPulseMessage = (
 	| ClientApiResultMessage
 	| ClientJsResultMessage
 )
-ClientChannelMessage = ClientChannelRequestMessage | ClientChannelResponseMessage
-ClientChannelLifecycleMessage = (
-	ClientChannelConnectMessage | ClientChannelDisconnectMessage
+ClientChannelMessage = (
+	ClientChannelRequestMessage
+	| ClientChannelResponseMessage
+	| ClientChannelConnectMessage
+	| ClientChannelDisconnectMessage
 )
-ClientMessage = (
-	ClientPulseMessage | ClientChannelMessage | ClientChannelLifecycleMessage
-)
+ClientMessage = ClientPulseMessage | ClientChannelMessage
 
 
 class PrerenderPayload(TypedDict):

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -195,7 +195,9 @@ class View:
 	):
 		if self.state == "pending":
 			if self.queue is None:
-				raise RuntimeError(f"Pending view missing queue for {self.route_path!r}")
+				raise RuntimeError(
+					f"Pending view missing queue for {self.route_path!r}"
+				)
 			self.queue.append(message)
 			return
 		if self.state == "active":
@@ -612,9 +614,7 @@ class RenderSession:
 		if view.render_batch_renders > self.render_loop_limit:
 			if view.effect:
 				view.effect.pause()
-			raise RenderLoopError(
-				view.route_path, view.render_batch_renders, batch_id
-			)
+			raise RenderLoopError(view.route_path, view.render_batch_renders, batch_id)
 
 	def _render_with_interrupts(
 		self,

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -13,6 +13,7 @@ from pulse.messages import (
 	ClientResumeChannel,
 	ClientResumeView,
 	ServerApiCallMessage,
+	ServerErrorMessage,
 	ServerErrorPhase,
 	ServerInitMessage,
 	ServerJsExecMessage,
@@ -56,17 +57,17 @@ class JsExecError(Exception):
 
 
 class RenderLoopError(RuntimeError):
-	path: str
+	route_path: str
 	renders: int
 	batch_id: int
 
-	def __init__(self, path: str, renders: int, batch_id: int) -> None:
+	def __init__(self, route_path: str, renders: int, batch_id: int) -> None:
 		super().__init__(
 			"Detected an infinite render loop in Pulse. "
-			+ f"Render path '{path}' exceeded {renders} renders in reactive batch {batch_id}. "
+			+ f"Render path '{route_path}' exceeded {renders} renders in reactive batch {batch_id}. "
 			+ "This usually happens when a render or effect mutates state without a guard."
 		)
-		self.path = path
+		self.route_path = route_path
 		self.renders = renders
 		self.batch_id = batch_id
 
@@ -88,54 +89,57 @@ def run_js(expr: Any, *, result: bool = False) -> asyncio.Future[Any] | None:
 	return ctx.render.run_js(expr, result=result)
 
 
-MountState = Literal["pending", "active", "idle", "closed"]
+ViewState = Literal["pending", "active", "idle", "closed"]
 PendingAction = Literal["idle", "dispose"]
 T_Render = TypeVar("T_Render")
 
 
-class RouteMount:
+class View:
+	"""A single rendered route or layout instance for one client.
+
+	Each view is anchored to a unique id for its entire lifetime. Protocol
+	messages between server and client are scoped to this id, so stale actors
+	(callbacks, channels, navigations from disposed views) are rejected
+	structurally instead of via path + generation counters.
+	"""
+
+	id: str
 	render: "RenderSession"
-	path: str
+	route_path: str
 	route: RouteContext
 	tree: RenderTree
 	effect: Effect | None
-	_pulse_ctx: PulseContext | None
 	initialized: bool
-	state: MountState
+	state: ViewState
 	pending_action: PendingAction | None
 	queue: list[ServerMessage] | None
 	queue_timeout: TimerHandleLike | None
-	mount_id: str
 	render_batch_id: int
 	render_batch_renders: int
 
 	def __init__(
 		self,
 		render: "RenderSession",
-		path: str,
+		route_path: str,
 		route: Route | Layout,
 		route_info: RouteInfo,
 	) -> None:
+		self.id = uuid.uuid4().hex
 		self.render = render
-		self.path = ensure_absolute_path(path)
-		self.route = RouteContext(route_info, route, render, self.path)
+		self.route_path = ensure_absolute_path(route_path)
+		self.route = RouteContext(route_info, route, render, self.route_path)
 		self.effect = None
-		self._pulse_ctx = None
 		self.tree = RenderTree(route.render())
 		self.initialized = False
 		self.state = "pending"
 		self.pending_action = None
 		self.queue = []
 		self.queue_timeout = None
-		self.mount_id = uuid.uuid4().hex
 		self.render_batch_id = -1
 		self.render_batch_renders = 0
 
 	def update_route(self, route_info: RouteInfo) -> None:
 		self.route.update(route_info)
-
-	def renew_mount_id(self) -> None:
-		self.mount_id = uuid.uuid4().hex
 
 	def _cancel_pending_timeout(self) -> None:
 		if self.queue_timeout is not None:
@@ -150,7 +154,7 @@ class RouteMount:
 		action = self.pending_action
 		self.pending_action = None
 		if action == "dispose":
-			self.render.dispose_mount(self.path, self)
+			self.render.dispose_view(self)
 			return
 		self.to_idle()
 
@@ -191,14 +195,14 @@ class RouteMount:
 	):
 		if self.state == "pending":
 			if self.queue is None:
-				raise RuntimeError(f"Pending mount missing queue for {self.path!r}")
+				raise RuntimeError(f"Pending view missing queue for {self.route_path!r}")
 			self.queue.append(message)
 			return
 		if self.state == "active":
 			send_message(message)
 			return
 		if self.state == "closed":
-			raise RuntimeError(f"Message sent to closed mount {self.path!r}")
+			raise RuntimeError(f"Message sent to closed view {self.route_path!r}")
 
 	def to_idle(self) -> None:
 		if self.state != "pending":
@@ -219,7 +223,7 @@ class RouteMount:
 		session = ctx.session
 
 		def _render_effect():
-			message = self.render.rerender(self, self.path, session=session)
+			message = self.render.rerender(self, session=session)
 			if message is not None:
 				self.render.send(message)
 
@@ -230,12 +234,12 @@ class RouteMount:
 					"renders": exc.renders,
 					"batch_id": exc.batch_id,
 				}
-			self.render.report_error(self.path, "render", exc, details)
+			self.render.report_error(self.id, "render", exc, details)
 
 		self.effect = Effect(
 			_render_effect,
 			immediate=False,
-			name=f"{self.path}:render",
+			name=f"{self.route_path}:render",
 			on_error=_report_render_error,
 			lazy=lazy,
 		)
@@ -257,19 +261,20 @@ class RenderSession:
 	channels: "ChannelsManager"
 	forms: "FormRegistry"
 	query_store: QueryStore
-	route_mounts: dict[str, RouteMount]
+	views: dict[str, View]
 	connected: bool
 	prerender_queue_timeout: float
 	dev_strict_mode_detach_timeout: float
 	disconnect_queue_timeout: float
 	render_loop_limit: int
+	_views_by_path: dict[str, View]
 	_server_address: str | None
 	_client_address: str | None
 	_send_message: Callable[[ServerMessage], Any] | None
 	_pending_api: dict[str, asyncio.Future[dict[str, Any]]]
 	_pending_js_results: dict[str, asyncio.Future[Any]]
 	_ref_channel: Channel | None
-	_ref_channels_by_route: dict[str, Channel]
+	_ref_channels_by_view: dict[str, Channel]
 	_global_states: dict[str, State]
 	_global_queue: list[ServerMessage]
 	_tasks: TaskRegistry
@@ -292,7 +297,8 @@ class RenderSession:
 
 		self.id = id
 		self.routes = routes
-		self.route_mounts = {}
+		self.views = {}
+		self._views_by_path = {}
 		self._server_address = server_address
 		self._client_address = client_address
 		self._send_message = None
@@ -304,7 +310,7 @@ class RenderSession:
 		self._pending_api = {}
 		self._pending_js_results = {}
 		self._ref_channel = None
-		self._ref_channels_by_route = {}
+		self._ref_channels_by_view = {}
 		self._tasks = TaskRegistry(name=f"render:{id}")
 		self._timers = TimerRegistry(tasks=self._tasks, name=f"render:{id}")
 		self.query_store = QueryStore()
@@ -327,8 +333,8 @@ class RenderSession:
 
 	def _on_effect_error(self, effect: Effect, exc: Exception):
 		details = {"effect": effect.name or "<unnamed>"}
-		for path in list(self.route_mounts.keys()):
-			self.report_error(path, "effect", exc, details)
+		for view_id in list(self.views.keys()):
+			self.report_error(view_id, "effect", exc, details)
 
 	# ---- Connection lifecycle ----
 
@@ -348,99 +354,81 @@ class RenderSession:
 		self.connected = False
 		self.channels.disconnect_all()
 
-		for mount in self.route_mounts.values():
-			if mount.state == "active":
-				mount.start_pending(self.disconnect_queue_timeout)
+		for view in self.views.values():
+			if view.state == "active":
+				view.start_pending(self.disconnect_queue_timeout)
 
 	# ---- Message routing ----
 
 	def send(self, message: ServerMessage):
-		"""Route message based on mount state."""
-		# Forced navigation is global. Route-bound navigation is dropped once
-		# its source route has unmounted.
+		"""Route message based on the owning view's state."""
+		# Forced navigation is global. View-bound navigation is dropped once its
+		# origin view has been disposed or its URL has changed since.
 		if message.get("type") == "navigate_to":
-			source_route_path = message.get("sourceRoutePath")
-			source_path = message.get("sourcePath")
-			source_mount_id = message.get("sourceMountId")
-			if isinstance(source_route_path, str) and isinstance(source_path, str):
-				mount = self.route_mounts.get(ensure_absolute_path(source_route_path))
-				source_path = ensure_absolute_path(source_path)
-				if (
-					mount is None
-					or mount.route.pathname != source_path
-					or (
-						isinstance(source_mount_id, str)
-						and mount.mount_id != source_mount_id
-					)
-				):
+			source_view = message.get("sourceView")
+			source_pathname = message.get("sourcePathname")
+			if isinstance(source_view, str):
+				view = self.views.get(source_view)
+				if view is None:
 					return
-			elif isinstance(source_path, str):
-				source_path = ensure_absolute_path(source_path)
-				with Untrack():
-					source_path_is_active = any(
-						mount.route.pathname == source_path
-						for mount in self.route_mounts.values()
-					)
-				if not source_path_is_active:
-					return
+				if isinstance(source_pathname, str):
+					with Untrack():
+						if view.route.pathname != source_pathname:
+							return
 			if self._send_message:
 				self._send_message(message)
 			else:
 				self._global_queue.append(message)
 			return
-		# Global messages (not path-specific) go directly if connected
-		path = message.get("path")
-		if path is None:
+		# Global messages (not view-specific) go directly if connected
+		view_id = message.get("view")
+		if view_id is None:
 			if self._send_message:
 				self._send_message(message)
 			else:
 				self._global_queue.append(message)
 			return
 
-		# Normalize path for lookup
-		path = ensure_absolute_path(path)
-		mount = self.route_mounts.get(path)
-		if not mount:
-			# Unknown path - send directly if connected (for js_exec, etc.)
+		view = self.views.get(view_id)
+		if not view:
+			# Unknown view - send directly if connected (client discards stale ids)
 			if self._send_message:
 				self._send_message(message)
 			return
 
 		if self._send_message:
-			mount.deliver(message, self._send_message)
+			view.deliver(message, self._send_message)
 			return
-		if mount.state == "pending":
-			mount.deliver(message, lambda _: None)
+		if view.state == "pending":
+			view.deliver(message, lambda _: None)
 		# idle: drop (effect should be paused anyway)
 
 	def report_error(
 		self,
-		path: str,
+		view_id: str | None,
 		phase: ServerErrorPhase,
 		exc: BaseException,
 		details: dict[str, Any] | None = None,
 	):
-		self.send(
-			{
-				"type": "server_error",
-				"path": path,
-				"error": {
-					"message": str(exc),
-					"stack": traceback.format_exc(),
-					"phase": phase,
-					"details": details or {},
-				},
-			}
-		)
+		message: ServerErrorMessage = {
+			"type": "server_error",
+			"error": {
+				"message": str(exc),
+				"stack": traceback.format_exc(),
+				"phase": phase,
+				"details": details or {},
+			},
+		}
+		if view_id is not None:
+			message["view"] = view_id
+		self.send(message)
 		logger.error(
-			"Error reported for path %r during %s: %s\n%s",
-			path,
+			"Error reported for view %r during %s: %s\n%s",
+			view_id,
 			phase,
 			exc,
 			traceback.format_exc(),
 		)
-
-	# ---- State transitions ----
 
 	# ---- Prerendering ----
 
@@ -449,7 +437,7 @@ class RenderSession:
 	) -> dict[str, ServerInitMessage | ServerNavigateToMessage]:
 		"""
 		Synchronous render for SSR. Returns per-path init or navigate_to messages.
-		- Creates mounts in PENDING state and starts queue
+		- Creates views in PENDING state and starts queue
 		"""
 		normalized = [ensure_absolute_path(path) for path in paths]
 
@@ -458,57 +446,56 @@ class RenderSession:
 		for path in normalized:
 			route = self.routes.find(path)
 			info = route_info or route.default_route_info()
-			mount = self.route_mounts.get(path)
+			view = self._views_by_path.get(path)
 
-			if mount is None:
-				mount = RouteMount(self, path, route, info)
-				self.route_mounts[path] = mount
-				mount.ensure_effect(lazy=True, flush=False)
+			if view is None:
+				view = View(self, path, route, info)
+				self.views[view.id] = view
+				self._views_by_path[path] = view
+				view.ensure_effect(lazy=True, flush=False)
 			else:
-				mount.update_route(info)
-				if mount.effect is None:
-					mount.ensure_effect(lazy=True, flush=False)
-				if route_info is not None and mount.state == "active":
-					mount.start_pending(self.prerender_queue_timeout)
+				view.update_route(info)
+				if view.effect is None:
+					view.ensure_effect(lazy=True, flush=False)
+				if route_info is not None and view.state == "active":
+					view.start_pending(self.prerender_queue_timeout)
 
-			if mount.state != "active" and mount.queue_timeout is None:
-				mount.start_pending(self.prerender_queue_timeout)
-			assert mount.effect is not None
-			with mount.effect.capture_deps(update_deps=True):
-				message = self.render(mount, path)
+			if view.state != "active" and view.queue_timeout is None:
+				view.start_pending(self.prerender_queue_timeout)
+			assert view.effect is not None
+			with view.effect.capture_deps(update_deps=True):
+				message = self.render(view)
 
 			results[path] = message
 			if message["type"] == "navigate_to":
-				mount.dispose()
-				del self.route_mounts[path]
+				self.dispose_view(view)
 				continue
 
 		return results
 
 	# ---- Client lifecycle ----
 
-	def attach(self, path: str, route_info: RouteInfo) -> bool:
+	def attach(self, view_id: str, route_info: RouteInfo) -> bool:
 		"""
-		Client ready to receive updates for path.
+		Client ready to receive updates for a view.
 		- PENDING: flush queue, transition to ACTIVE
 		- IDLE: request reload
 		- ACTIVE: update route_info
-		- No mount: request reload
-		Returns True when callbacks can be accepted for this path.
+		- Unknown view: request reload
+		Returns True when callbacks can be accepted for this view.
 		"""
-		path = ensure_absolute_path(path)
-		mount = self.route_mounts.get(path)
+		view = self.views.get(view_id)
 
-		if mount is None or mount.state == "idle":
+		if view is None or view.state == "idle":
 			# Initial render must come from prerender
 			self.send({"type": "reload"})
 			return False
 
-		# Update route info for active and pending mounts
-		mount.update_route(route_info)
-		if mount.state == "pending" and self._send_message:
-			mount.activate(self._send_message)
-		return mount.state == "active"
+		# Update route info for active and pending views
+		view.update_route(route_info)
+		if view.state == "pending" and self._send_message:
+			view.activate(self._send_message)
+		return view.state == "active"
 
 	def resume(
 		self,
@@ -517,12 +504,12 @@ class RenderSession:
 		channels: list[ClientResumeChannel],
 	) -> bool:
 		accepted_views: list[ServerResumeView] = []
-		accepted_paths: set[str] = set()
+		accepted_ids: set[str] = set()
 
-		for view in views:
-			path = ensure_absolute_path(view["path"])
-			mount = self.route_mounts.get(path)
-			if mount is None or mount.state in ("idle", "closed"):
+		for declared in views:
+			view_id = declared["view"]
+			view = self.views.get(view_id)
+			if view is None or view.state in ("idle", "closed"):
 				self.send(
 					ServerResumeMessage(
 						type="server_resume",
@@ -531,10 +518,10 @@ class RenderSession:
 					)
 				)
 				return False
-			mount.update_route(view["routeInfo"])
-			if mount.state == "pending" and self._send_message:
-				mount.activate(self._send_message)
-			if mount.state != "active":
+			view.update_route(declared["routeInfo"])
+			if view.state == "pending" and self._send_message:
+				view.activate(self._send_message)
+			if view.state != "active":
 				self.send(
 					ServerResumeMessage(
 						type="server_resume",
@@ -543,20 +530,20 @@ class RenderSession:
 					)
 				)
 				return False
-			accepted_paths.add(path)
-			resumed_view: ServerResumeView = {"path": path}
-			if attach_id := view.get("attachId"):
+			accepted_ids.add(view_id)
+			resumed_view: ServerResumeView = {"view": view_id}
+			if attach_id := declared.get("attachId"):
 				resumed_view["attachId"] = attach_id
 			accepted_views.append(resumed_view)
 
 		accepted_channels: list[ServerResumeChannel] = []
 		for channel in channels:
 			channel_id = str(channel.get("channel", ""))
-			path = ensure_absolute_path(str(channel.get("path", "")))
-			if path not in accepted_paths:
+			view_id = str(channel.get("view", ""))
+			if view_id not in accepted_ids:
 				continue
-			if self.channels.resume_client_channel(channel_id, path):
-				accepted_channels.append({"channel": channel_id, "path": path})
+			if self.channels.resume_client_channel(channel_id, view_id):
+				accepted_channels.append({"channel": channel_id, "view": view_id})
 
 		self.send(
 			ServerResumeMessage(
@@ -569,72 +556,69 @@ class RenderSession:
 		)
 		return True
 
-	def update_route(self, path: str, route_info: RouteInfo):
-		"""Update routing state (query params, etc.) for attached path."""
-		path = ensure_absolute_path(path)
-		mount = self.route_mounts.get(path)
-		if mount is None:
-			# No-op when mount does not exist yet.
-			# Route updates may arrive before prerender; prerender creates the mount with
-			# the authoritative RouteInfo, so replaying/stashing is unnecessary.
+	def update_route(self, view_id: str, route_info: RouteInfo):
+		"""Update routing state (query params, etc.) for an attached view."""
+		view = self.views.get(view_id)
+		if view is None:
+			# No-op when the view does not exist yet.
+			# Route updates may arrive before prerender; prerender creates the view
+			# with the authoritative RouteInfo, so replaying/stashing is unnecessary.
 			return
 		try:
-			mount.update_route(route_info)
-			if mount.state == "pending" and self._send_message:
-				mount.activate(self._send_message)
+			view.update_route(route_info)
+			if view.state == "pending" and self._send_message:
+				view.activate(self._send_message)
 		except Exception as e:
-			self.report_error(path, "navigate", e)
+			self.report_error(view.id, "navigate", e)
 
-	def dispose_mount(self, path: str, mount: RouteMount) -> None:
-		current = self.route_mounts.get(path)
-		if current is not mount:
+	def dispose_view(self, view: View) -> None:
+		current = self.views.get(view.id)
+		if current is not view:
 			return
 		try:
-			self.channels.remove_route(path)
-			self.route_mounts.pop(path, None)
-			self._ref_channels_by_route.pop(path, None)
-			mount.dispose()
+			self.channels.remove_view(view.id)
+			self.views.pop(view.id, None)
+			if self._views_by_path.get(view.route_path) is view:
+				self._views_by_path.pop(view.route_path, None)
+			self._ref_channels_by_view.pop(view.id, None)
+			view.dispose()
 		except Exception as e:
-			self.report_error(path, "unmount", e)
+			self.report_error(view.id, "unmount", e)
 
-	def detach(self, path: str):
-		"""Client route unmounted. Dispose immediately outside dev StrictMode replay."""
-		path = ensure_absolute_path(path)
-		mount = self.route_mounts.get(path)
-		if not mount:
+	def detach(self, view_id: str):
+		"""Client view unmounted. Dispose immediately outside dev StrictMode replay."""
+		view = self.views.get(view_id)
+		if not view:
 			return
-		old_mount_id = mount.mount_id
-		mount.renew_mount_id()
-		self.channels.rebind_route_mount(path, old_mount_id, mount.mount_id)
 		if self.dev_strict_mode_detach_timeout > 0:
 			# React StrictMode in development intentionally replays mount effects as
-			# attach -> detach -> attach without another prerender. Keep the mount for
-			# a very short dev-only window so that synthetic cleanup can be cancelled
-			# by the replayed attach. The mount id was renewed above before this delay,
-			# so async work from the detached generation is still route-stale and cannot
-			# navigate during the grace period.
-			mount.start_pending(self.dev_strict_mode_detach_timeout, action="dispose")
+			# attach -> detach -> attach without another prerender. Keep the view
+			# alive for a very short dev-only window so the replayed attach can
+			# cancel the disposal. The view keeps its id: the replayed attach is
+			# the same logical view.
+			view.start_pending(self.dev_strict_mode_detach_timeout, action="dispose")
 			return
-		self.dispose_mount(path, mount)
+		self.dispose_view(view)
 
-	# ---- Effect creation ----
+	# ---- Rendering ----
 
-	def _check_render_loop(self, mount: RouteMount, path: str) -> None:
+	def _check_render_loop(self, view: View) -> None:
 		batch_id = REACTIVE_CONTEXT.get().batch.flush_id
-		if mount.render_batch_id == batch_id:
-			mount.render_batch_renders += 1
+		if view.render_batch_id == batch_id:
+			view.render_batch_renders += 1
 		else:
-			mount.render_batch_id = batch_id
-			mount.render_batch_renders = 1
-		if mount.render_batch_renders > self.render_loop_limit:
-			if mount.effect:
-				mount.effect.pause()
-			raise RenderLoopError(path, mount.render_batch_renders, batch_id)
+			view.render_batch_id = batch_id
+			view.render_batch_renders = 1
+		if view.render_batch_renders > self.render_loop_limit:
+			if view.effect:
+				view.effect.pause()
+			raise RenderLoopError(
+				view.route_path, view.render_batch_renders, batch_id
+			)
 
 	def _render_with_interrupts(
 		self,
-		mount: RouteMount,
-		path: str,
+		view: View,
 		*,
 		session: Any | None = None,
 		render_fn: Callable[[], T_Render],
@@ -642,19 +626,16 @@ class RenderSession:
 		ctx = PulseContext.get()
 		render_session = ctx.session if session is None else session
 		with Untrack():
-			source_path = mount.route.pathname
-			source_route_path = mount.route.route_path
-			source_mount_id = mount.mount_id
+			source_pathname = view.route.pathname
 		with PulseContext.update(
 			session=render_session,
 			render=self,
-			route=mount.route,
-			source_route_path=source_route_path,
-			source_path=source_path,
-			source_mount_id=source_mount_id,
+			route=view.route,
+			view=view,
+			source_pathname=source_pathname,
 		):
 			try:
-				self._check_render_loop(mount, path)
+				self._check_render_loop(view)
 				return render_fn()
 			except RedirectInterrupt as r:
 				return ServerNavigateToMessage(
@@ -673,32 +654,34 @@ class RenderSession:
 				)
 
 	def render(
-		self, mount: RouteMount, path: str, *, session: Any | None = None
+		self, view: View, *, session: Any | None = None
 	) -> ServerInitMessage | ServerNavigateToMessage:
 		def _render() -> ServerInitMessage:
-			vdom = mount.tree.render()
-			mount.initialized = True
-			return ServerInitMessage(type="vdom_init", path=path, vdom=vdom)
+			vdom = view.tree.render()
+			view.initialized = True
+			return ServerInitMessage(
+				type="vdom_init",
+				view=view.id,
+				routePath=view.route_path,
+				vdom=vdom,
+			)
 
-		message = self._render_with_interrupts(
-			mount, path, session=session, render_fn=_render
-		)
-		return message
+		return self._render_with_interrupts(view, session=session, render_fn=_render)
 
 	def rerender(
-		self, mount: RouteMount, path: str, *, session: Any | None = None
+		self, view: View, *, session: Any | None = None
 	) -> ServerUpdateMessage | ServerNavigateToMessage | None:
 		def _rerender() -> ServerUpdateMessage | None:
-			if not mount.initialized:
-				raise RuntimeError(f"rerender called before init for {path!r}")
-			ops = mount.tree.rerender()
+			if not view.initialized:
+				raise RuntimeError(
+					f"rerender called before init for {view.route_path!r}"
+				)
+			ops = view.tree.rerender()
 			if ops:
-				return ServerUpdateMessage(type="vdom_update", path=path, ops=ops)
+				return ServerUpdateMessage(type="vdom_update", view=view.id, ops=ops)
 			return None
 
-		return self._render_with_interrupts(
-			mount, path, session=session, render_fn=_rerender
-		)
+		return self._render_with_interrupts(view, session=session, render_fn=_rerender)
 
 	# ---- Helpers ----
 
@@ -707,9 +690,10 @@ class RenderSession:
 		self._timers.cancel_all()
 		self.forms.dispose()
 		self._tasks.cancel_all()
-		for path, mount in list(self.route_mounts.items()):
-			self.dispose_mount(path, mount)
-		self.route_mounts.clear()
+		for view in list(self.views.values()):
+			self.dispose_view(view)
+		self.views.clear()
+		self._views_by_path.clear()
 		self.query_store.dispose_all()
 		for value in self._global_states.values():
 			value.dispose()
@@ -728,19 +712,26 @@ class RenderSession:
 				fut.cancel()
 		self._pending_js_results.clear()
 		self._ref_channel = None
-		self._ref_channels_by_route.clear()
+		self._ref_channels_by_view.clear()
 		# Close any timer that may have been scheduled during cleanup (ex: query GC)
 		self._timers.cancel_all()
 		self._global_queue = []
 		self._send_message = None
 		self.connected = False
 
-	def get_route_mount(self, path: str) -> RouteMount:
+	def get_view(self, view_id: str) -> View:
+		view = self.views.get(view_id)
+		if not view:
+			raise ValueError(f"No view with id '{view_id}'")
+		return view
+
+	def view_for_path(self, path: str) -> View:
+		"""Look up the view rendering the given route pattern path."""
 		path = ensure_absolute_path(path)
-		mount = self.route_mounts.get(path)
-		if not mount:
-			raise ValueError(f"No active route for '{path}'")
-		return mount
+		view = self._views_by_path.get(path)
+		if not view:
+			raise ValueError(f"No view for route '{path}'")
+		return view
 
 	def get_global_state(self, key: str, factory: Callable[[], Any]) -> Any:
 		"""Return a per-session singleton for the provided key."""
@@ -752,20 +743,20 @@ class RenderSession:
 
 	def get_ref_channel(self) -> Channel:
 		ctx = PulseContext.get()
-		if ctx.route is None:
+		if ctx.view is None:
 			if self._ref_channel is not None and not self._ref_channel.closed:
 				return self._ref_channel
-			self._ref_channel = self.channels.create(bind_route=False)
+			self._ref_channel = self.channels.create(bind_view=False)
 			return self._ref_channel
 
-		route_path = ctx.route.route_path
-		channel = self._ref_channels_by_route.get(route_path)
+		view_id = ctx.view.id
+		channel = self._ref_channels_by_view.get(view_id)
 		if channel is not None and channel.closed:
-			self._ref_channels_by_route.pop(route_path, None)
+			self._ref_channels_by_view.pop(view_id, None)
 			channel = None
 		if channel is None:
-			channel = self.channels.create(bind_route=True)
-			self._ref_channels_by_route[route_path] = channel
+			channel = self.channels.create(bind_view=True)
+			self._ref_channels_by_view[view_id] = channel
 		return channel
 
 	def flush(self):
@@ -794,31 +785,33 @@ class RenderSession:
 		"""Remove a timer handle from the session registry."""
 		self._timers.discard(handle)
 
-	def execute_callback(self, path: str, key: str, args: list[Any] | tuple[Any, ...]):
-		path = ensure_absolute_path(path)
-		mount = self.route_mounts.get(path)
-		if mount is None or mount.state == "closed":
-			logger.warning("Dropping callback %r for missing route %r", key, path)
+	def execute_callback(
+		self, view_id: str, key: str, args: list[Any] | tuple[Any, ...]
+	):
+		view = self.views.get(view_id)
+		if view is None or view.state == "closed":
+			logger.warning("Dropping callback %r for missing view %r", key, view_id)
 			return
-		cb = mount.tree.callbacks.get(key)
+		cb = view.tree.callbacks.get(key)
 		if cb is None:
-			logger.warning("Dropping stale callback %r for route %r", key, path)
+			logger.warning(
+				"Dropping stale callback %r for view %r", key, view.route_path
+			)
 			return
 
 		def report(e: BaseException, is_async: bool = False):
-			self.report_error(path, "callback", e, {"callback": key, "async": is_async})
+			self.report_error(
+				view.id, "callback", e, {"callback": key, "async": is_async}
+			)
 
 		try:
 			with Untrack():
-				source_path = mount.route.pathname
-				source_route_path = mount.route.route_path
-				source_mount_id = mount.mount_id
+				source_pathname = view.route.pathname
 			with PulseContext.update(
 				render=self,
-				route=mount.route,
-				source_route_path=source_route_path,
-				source_path=source_path,
-				source_mount_id=source_mount_id,
+				route=view.route,
+				view=view,
+				source_pathname=source_pathname,
 			):
 				res = cb.fn(*(args if cb.accepts_varargs else args[: cb.n_args]))
 				if iscoroutine(res):
@@ -954,16 +947,16 @@ class RenderSession:
 			)
 
 		ctx = PulseContext.get()
+		if ctx.view is None:
+			raise RuntimeError(
+				"run_js() requires an active view context (component render, callback, or effect)"
+			)
 		exec_id = next_id()
-
-		# Get route pattern path (e.g., "/users/:id") not pathname (e.g., "/users/123")
-		# This must match the path used to key views on the client side
-		path = ctx.route.pulse_route.unique_path() if ctx.route else "/"
 
 		self.send(
 			ServerJsExecMessage(
 				type="js_exec",
-				path=path,
+				view=ctx.view.id,
 				id=exec_id,
 				expr=expr.render(),
 			)

--- a/packages/pulse/python/src/pulse/state/query_param.py
+++ b/packages/pulse/python/src/pulse/state/query_param.py
@@ -489,10 +489,8 @@ class QueryParamSync(Disposable):
 			raw_params = info["queryParams"]
 			current_params = dict(cast(Mapping[str, str], raw_params))
 			pathname = info["pathname"]
-			source_route_path = self.route.route_path
-			source_path = pathname
-			mount = self.render.route_mounts.get(source_route_path)
-			source_mount_id = mount.mount_id if mount is not None else None
+			view = self.render._views_by_path.get(self.route.route_path)  # pyright: ignore[reportPrivateUsage]
+			source_view = view.id if view is not None and view.route is self.route else None
 			hash_frag = info["hash"]
 		query_params = dict(current_params)
 		for binding in self._bindings.values():
@@ -528,11 +526,10 @@ class QueryParamSync(Disposable):
 			path=path,
 			replace=True,
 			hard=False,
-			sourceRoutePath=source_route_path,
-			sourcePath=source_path,
 		)
-		if source_mount_id is not None:
-			message["sourceMountId"] = source_mount_id
+		if source_view is not None:
+			message["sourceView"] = source_view
+			message["sourcePathname"] = pathname
 		self.render.send(message)
 
 	@override

--- a/packages/pulse/python/src/pulse/state/query_param.py
+++ b/packages/pulse/python/src/pulse/state/query_param.py
@@ -490,7 +490,9 @@ class QueryParamSync(Disposable):
 			current_params = dict(cast(Mapping[str, str], raw_params))
 			pathname = info["pathname"]
 			view = self.render._views_by_path.get(self.route.route_path)  # pyright: ignore[reportPrivateUsage]
-			source_view = view.id if view is not None and view.route is self.route else None
+			source_view = (
+				view.id if view is not None and view.route is self.route else None
+			)
 			hash_frag = info["hash"]
 		query_params = dict(current_params)
 		for binding in self._bindings.values():

--- a/packages/pulse/python/tests/test_app_message_order.py
+++ b/packages/pulse/python/tests/test_app_message_order.py
@@ -43,7 +43,7 @@ async def test_socket_messages_for_render_are_serialized(
 			serialize(
 				{
 					"type": "attach",
-					"path": "/",
+					"view": "view-1",
 					"routeInfo": {
 						"pathname": "/",
 						"hash": "",
@@ -64,7 +64,7 @@ async def test_socket_messages_for_render_are_serialized(
 			serialize(
 				{
 					"type": "callback",
-					"path": "/",
+					"view": "view-1",
 					"callback": "1.onClick",
 					"args": [],
 				}
@@ -116,7 +116,7 @@ async def test_attach_sends_ack_after_route_is_attached(
 		cast(UserSession, cast(object, session)),
 		{
 			"type": "attach",
-			"path": "/",
+			"view": "view-1",
 			"routeInfo": {
 				"pathname": "/",
 				"hash": "",
@@ -129,7 +129,7 @@ async def test_attach_sends_ack_after_route_is_attached(
 		},
 	)
 
-	assert sent == [{"type": "attach_ack", "path": "/", "attachId": "attach-1"}]
+	assert sent == [{"type": "attach_ack", "view": "view-1", "attachId": "attach-1"}]
 
 
 @pytest.mark.asyncio
@@ -155,7 +155,7 @@ async def test_attach_does_not_ack_when_route_needs_reload(
 		cast(UserSession, cast(object, session)),
 		{
 			"type": "attach",
-			"path": "/",
+			"view": "view-1",
 			"routeInfo": {
 				"pathname": "/",
 				"hash": "",
@@ -192,7 +192,7 @@ async def test_socket_messages_wait_for_connect_to_finish(
 		serialize(
 			{
 				"type": "attach",
-				"path": "/",
+				"view": "view-1",
 				"routeInfo": {
 					"pathname": "/",
 					"hash": "",
@@ -209,7 +209,7 @@ async def test_socket_messages_wait_for_connect_to_finish(
 		serialize(
 			{
 				"type": "callback",
-				"path": "/",
+				"view": "view-1",
 				"callback": "1.onClick",
 				"args": [],
 			}

--- a/packages/pulse/python/tests/test_channels.py
+++ b/packages/pulse/python/tests/test_channels.py
@@ -22,9 +22,15 @@ class DummyRender:
 		self.sent.append(message)
 
 
-def connect_channel(render: RenderSession, channel: Channel, path: str = "/") -> None:
+def connect_channel(
+	render: RenderSession, channel: Channel, view_id: str | None = None
+) -> None:
 	render.channels.handle_client_connect(
-		{"type": "channel_connect", "channel": channel.id, "path": path}
+		{
+			"type": "channel_connect",
+			"channel": channel.id,
+			"view": view_id if view_id is not None else (channel.view_id or ""),
+		}
 	)
 
 
@@ -48,7 +54,9 @@ def make_route_render(
 	render.connect(lambda _: None)
 	with ps.PulseContext(app=app, session=session, render=render):
 		render.prerender([path])
-		render.attach(path, app.routes.find(path).default_route_info())
+		render.attach(
+			render.view_for_path(path).id, app.routes.find(path).default_route_info()
+		)
 	return app, render, session
 
 
@@ -59,15 +67,14 @@ def create_route_channel(
 	identifier: str,
 	path: str = "/",
 ) -> Channel:
-	mount = render.get_route_mount(path)
+	view = render.view_for_path(path)
 	with ps.PulseContext(
 		app=app,
 		session=session,
 		render=render,
-		route=mount.route,
-		source_route_path=mount.route.route_path,
-		source_path=mount.route.pathname,
-		source_mount_id=mount.mount_id,
+		route=view.route,
+		view=view,
+		source_pathname=view.route.pathname,
 	):
 		return render.channels.create(identifier)
 
@@ -102,7 +109,7 @@ async def test_channel_emit_sends_message():
 	assert message["payload"] == {"values": {"a": 1}}
 
 
-def test_route_bound_channel_emit_includes_path():
+def test_route_bound_channel_emit_includes_view():
 	app, render, session = make_route_render()
 	channel = create_route_channel(app, render, session, "route-channel")
 	connect_channel(render, channel)
@@ -114,7 +121,7 @@ def test_route_bound_channel_emit_includes_path():
 	assert len(sent) == 1
 	message = sent[0]
 	assert message["type"] == "channel_message"
-	assert message["path"] == "/"
+	assert message["view"] == render.view_for_path("/").id
 	assert message["channel"] == channel.id
 	assert message["event"] == "setValues"
 	assert message["payload"] == {"values": {"a": 1}}
@@ -128,12 +135,12 @@ def test_channel_emit_without_endpoint_raises_channel_closed():
 		channel.emit("notify", None)
 
 
-def test_connect_requires_matching_active_route_mount():
+def test_connect_requires_matching_active_view():
 	app, render, session = make_route_render()
 	channel = create_route_channel(app, render, session, "owned-channel")
 
 	render.channels.handle_client_connect(
-		{"type": "channel_connect", "channel": channel.id, "path": "/other"}
+		{"type": "channel_connect", "channel": channel.id, "view": "other-view"}
 	)
 	assert channel.connected is False
 
@@ -147,7 +154,7 @@ async def test_dev_strict_mode_detach_preserves_route_channel_until_dispose():
 	channel = create_route_channel(app, render, session, "strict-channel")
 	connect_channel(render, channel)
 
-	render.detach("/")
+	render.detach(render.view_for_path("/").id)
 
 	assert channel.closed is False
 	assert channel.connected is True
@@ -157,22 +164,26 @@ async def test_dev_strict_mode_detach_preserves_route_channel_until_dispose():
 	assert channel.closed is True
 
 
-def test_dev_strict_mode_replay_rebinds_route_channel_mount():
+def test_dev_strict_mode_replay_reconnects_route_channel():
 	app, render, session = make_route_render(dev_strict_mode_detach_timeout=10.0)
 	channel = create_route_channel(app, render, session, "replay-channel")
 	connect_channel(render, channel)
 
-	render.detach("/")
+	view = render.view_for_path("/")
+	render.detach(view.id)
 	render.channels.handle_client_disconnect(
 		{"type": "channel_disconnect", "channel": channel.id}
 	)
 	assert channel.closed is False
 	assert channel.connected is False
 
+	# The view keeps its id through the StrictMode replay, so the channel
+	# binding stays valid without any rebinding.
 	with ps.PulseContext(app=app, session=session, render=render):
-		render.attach("/", app.routes.find("/").default_route_info())
+		render.attach(view.id, app.routes.find("/").default_route_info())
 	connect_channel(render, channel)
 
+	assert channel.view_id == view.id
 	assert channel.connected is True
 
 
@@ -180,7 +191,7 @@ def test_stale_connect_during_detach_grace_is_rejected():
 	app, render, session = make_route_render(dev_strict_mode_detach_timeout=10.0)
 	channel = create_route_channel(app, render, session, "stale-channel")
 
-	render.detach("/")
+	render.detach(render.view_for_path("/").id)
 	connect_channel(render, channel)
 
 	assert channel.connected is False
@@ -195,16 +206,17 @@ def test_resume_omits_closed_channel_from_acceptance():
 	connect_channel(render, channel)
 	channel.close()
 
+	view = render.view_for_path("/")
 	ok = render.resume(
 		"resume-1",
 		[
 			{
-				"path": "/",
+				"view": view.id,
 				"routeInfo": app.routes.find("/").default_route_info(),
 				"attachId": "attach-1",
 			}
 		],
-		[{"channel": channel.id, "path": "/"}],
+		[{"channel": channel.id, "view": view.id}],
 	)
 
 	assert ok is True
@@ -212,7 +224,7 @@ def test_resume_omits_closed_channel_from_acceptance():
 		"type": "server_resume",
 		"resumeId": "resume-1",
 		"status": "ok",
-		"views": [{"path": "/", "attachId": "attach-1"}],
+		"views": [{"view": view.id, "attachId": "attach-1"}],
 		"channels": [],
 	}
 
@@ -299,7 +311,7 @@ def test_client_request_without_connected_endpoint_gets_error_response():
 			"responseTo": "client-req-1",
 			"payload": None,
 			"error": "Channel has no connected client",
-			"path": "/",
+			"view": render.view_for_path("/").id,
 		}
 	]
 
@@ -394,10 +406,11 @@ async def test_channel_lifecycle_runs_middleware_and_denial_notifies_client():
 	render.send = sent.append  # pyright: ignore[reportAttributeAccessIssue]
 	channel = create_route_channel(app, render, session, "denied-channel")
 
+	view = render.view_for_path("/")
 	await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
 		render,
 		session,
-		{"type": "channel_connect", "channel": channel.id, "path": "/"},
+		{"type": "channel_connect", "channel": channel.id, "view": view.id},
 	)
 
 	assert events == ["__connect__"]
@@ -408,7 +421,7 @@ async def test_channel_lifecycle_runs_middleware_and_denial_notifies_client():
 			"channel": channel.id,
 			"event": "__close__",
 			"payload": {"reason": "Denied"},
-			"path": "/",
+			"view": view.id,
 		}
 	]
 
@@ -435,10 +448,11 @@ async def test_channel_connect_disconnect_lifecycle_middleware_events():
 	app, render, session = make_route_render(middleware=LogMiddleware())
 	channel = create_route_channel(app, render, session, "lifecycle-channel")
 
+	view = render.view_for_path("/")
 	await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
 		render,
 		session,
-		{"type": "channel_connect", "channel": channel.id, "path": "/"},
+		{"type": "channel_connect", "channel": channel.id, "view": view.id},
 	)
 	await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
 		render,

--- a/packages/pulse/python/tests/test_codegen.py
+++ b/packages/pulse/python/tests/test_codegen.py
@@ -246,7 +246,7 @@ class TestCodegen:
 
 		layout_content = (pulse_app_dir / "_layout.tsx").read_text()
 		assert (
-			'import { deserialize, extractServerRouteInfo, PulseProvider, type PulseConfig, type PulsePrerender } from "pulse-ui-client";'
+			'import { buildRouteInfo, deserialize, PulseProvider, type PulseConfig, type PulsePrerender } from "pulse-ui-client";'
 			in layout_content
 		)
 		assert 'serverAddress: "http://localhost:8000"' in layout_content

--- a/packages/pulse/python/tests/test_query_param.py
+++ b/packages/pulse/python/tests/test_query_param.py
@@ -36,8 +36,9 @@ def make_context(route_info: RouteInfo):
 	routes = RouteTree([route])
 	session = RenderSession("test", routes)
 	app = ps.App(routes=[route])
-	session.prerender(["/"], route_info)
-	route_ctx = session.route_mounts["/"].route
+	with ps.PulseContext(app=app, render=session):
+		session.prerender(["/"], route_info)
+	route_ctx = session.view_for_path("/").route
 	return app, session, route_ctx
 
 
@@ -60,7 +61,7 @@ class TestQueryParam:
 		session.connect(messages.append)
 
 		with ps.PulseContext(app=app, render=session, route=route_ctx):
-			assert route_ctx.pathname in session.route_mounts
+			assert session.view_for_path(route_ctx.pathname).route is route_ctx
 			state = QState()
 			assert state.q == "hello"
 			flush_effects()
@@ -71,8 +72,8 @@ class TestQueryParam:
 		assert len(messages) == 1
 		msg = messages[0]
 		assert msg["type"] == "navigate_to"
-		assert msg.get("sourceRoutePath") == "/"
-		assert msg.get("sourcePath") == "/"
+		assert msg.get("sourceView") == session.view_for_path("/").id
+		assert msg.get("sourcePathname") == "/"
 		parsed = urlparse(str(msg["path"]))
 		query = parse_qs(parsed.query)
 		assert query["q"] == ["next"]

--- a/packages/pulse/python/tests/test_render_session.py
+++ b/packages/pulse/python/tests/test_render_session.py
@@ -72,9 +72,16 @@ def make_route_info(
 	}
 
 
-def transition_mount_to_idle(session: RenderSession, path: str) -> None:
-	mount = session.route_mounts[path]
-	mount.to_idle()
+def transition_view_to_idle(session: RenderSession, path: str) -> None:
+	view = session.view_for_path(path)
+	view.to_idle()
+
+
+def attach_view(
+	session: RenderSession, path: str, route_info: RouteInfo | None = None
+) -> None:
+	view = session.view_for_path(path)
+	session.attach(view.id, route_info or make_route_info(path))
 
 
 # TODO: clean this up - this was refactored using GPT-5 and is thus quite hacky
@@ -85,7 +92,9 @@ def mount_with_listener(session: RenderSession, path: str):
 		listened = set()
 		session._test_listened_paths = listened  # pyright: ignore[reportAttributeAccessIssue]
 
-	log: list[ServerMessage] | None = getattr(session, "_test_message_log", None)
+	log: list[tuple[str, ServerMessage]] | None = getattr(
+		session, "_test_message_log", None
+	)
 	if log is None:
 		log = []
 		session._test_message_log = log  # pyright: ignore[reportAttributeAccessIssue]
@@ -93,12 +102,15 @@ def mount_with_listener(session: RenderSession, path: str):
 		def on_message(msg: ServerMessage):
 			if msg.get("type") == "api_call":
 				return
-			p = msg.get("path")
-			if not isinstance(p, str):
+			view_id = msg.get("view")
+			if not isinstance(view_id, str):
+				return
+			view = session.views.get(view_id)
+			if view is None:
 				return
 			# Only record messages for paths we're currently listening to
-			if p in getattr(session, "_test_listened_paths", set()):  # pyright: ignore[reportUnknownArgumentType]
-				session._test_message_log.append(msg)  # pyright: ignore[reportAttributeAccessIssue]
+			if view.route_path in getattr(session, "_test_listened_paths", set()):  # pyright: ignore[reportUnknownArgumentType]
+				session._test_message_log.append((view.route_path, msg))  # pyright: ignore[reportAttributeAccessIssue]
 
 		session.connect(on_message)
 
@@ -107,15 +119,15 @@ def mount_with_listener(session: RenderSession, path: str):
 
 	class _PathMessages:
 		def __iter__(self):  # type: ignore[override]
-			for m in getattr(session, "_test_message_log", []):
-				if m.get("path") == path:
+			for p, m in getattr(session, "_test_message_log", []):
+				if p == path:
 					yield m
 
 	# Ensure RenderSession is present in PulseContext when attaching so the
 	# captured context for the render effect includes it
 	with ps.PulseContext.update(render=session):
 		session.prerender(sorted(listened))
-		session.attach(path, make_route_info(path))
+		attach_view(session, path)
 
 	def disconnect():
 		# Stop listening for this path; messages are still in the shared log
@@ -128,9 +140,9 @@ def mount_with_listener(session: RenderSession, path: str):
 
 def extract_count_from_ctx(session: RenderSession, path: str) -> int:
 	# Read latest VDOM by re-rendering from the RenderTree and inspecting it
-	mount = session.route_mounts[path]
-	with ps.PulseContext.update(render=session, route=mount.route):
-		vdom = mount.tree.render()
+	view = session.view_for_path(path)
+	with ps.PulseContext.update(render=session, route=view.route):
+		vdom = view.tree.render()
 	vdom_dict = cast(dict[str, Any], cast(object, vdom))
 	children = cast(list[Any], (vdom_dict.get("children", []) or []))
 	span = cast(dict[str, Any], children[0])
@@ -140,7 +152,7 @@ def extract_count_from_ctx(session: RenderSession, path: str) -> int:
 
 
 def first_callback_key(session: RenderSession, path: str) -> str:
-	return next(iter(session.route_mounts[path].tree.callbacks))
+	return next(iter(session.view_for_path(path).tree.callbacks))
 
 
 @pytest.mark.asyncio
@@ -150,27 +162,24 @@ async def test_pulse_context_update_can_clear_route_source():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 
-	route = session.route_mounts["/a"].route
+	view = session.view_for_path("/a")
 	with ps.PulseContext.update(
 		render=session,
-		route=route,
-		source_route_path=route.route_path,
-		source_path=route.pathname,
-		source_mount_id=session.route_mounts["/a"].mount_id,
+		route=view.route,
+		view=view,
+		source_pathname=view.route.pathname,
 	):
 		with ps.PulseContext.update(
 			route=None,
-			source_route_path=None,
-			source_path=None,
-			source_mount_id=None,
+			view=None,
+			source_pathname=None,
 		):
 			ctx = ps.PulseContext.get()
 			assert ctx.route is None
-			assert ctx.source_route_path is None
-			assert ctx.source_path is None
-			assert ctx.source_mount_id is None
+			assert ctx.view is None
+			assert ctx.source_pathname is None
 
 	session.close()
 
@@ -194,7 +203,7 @@ async def test_two_sessions_two_routes_are_isolated():
 	assert extract_count_from_ctx(s2, "/b") == 0
 
 	# Click a button in session 1 route a (button is second child, index 1)
-	s1.execute_callback("/a", "1.onClick", [])
+	s1.execute_callback(s1.view_for_path("/a").id, "1.onClick", [])
 	s1.flush()
 	s2.flush()
 
@@ -211,7 +220,7 @@ async def test_two_sessions_two_routes_are_isolated():
 	assert len([m for m in msgs_s2_b if m["type"] == "vdom_update"]) == 0
 
 	# Click a button in session 2 route a (button is second child, index 1)
-	s2.execute_callback("/a", "1.onClick", [])
+	s2.execute_callback(s2.view_for_path("/a").id, "1.onClick", [])
 	s1.flush()
 	s2.flush()
 
@@ -263,9 +272,9 @@ def make_global_routes() -> RouteTree:
 
 
 def extract_global_count(session: RenderSession, path: str) -> int:
-	mount = session.route_mounts[path]
-	with ps.PulseContext.update(render=session, route=mount.route):
-		vdom = mount.tree.render()
+	view = session.view_for_path(path)
+	with ps.PulseContext.update(render=session, route=view.route):
+		vdom = view.tree.render()
 	vdom_dict = cast(dict[str, Any], cast(object, vdom))
 	children = cast(list[Any], (vdom_dict.get("children", []) or []))
 	span = cast(dict[str, Any], children[0])
@@ -293,7 +302,7 @@ async def test_global_state_shared_within_session_and_isolated_across_sessions()
 	assert extract_global_count(s2, "/b") == 0
 
 	# Increment in s1 on route a
-	s1.execute_callback("/a", "1.onClick", [])
+	s1.execute_callback(s1.view_for_path("/a").id, "1.onClick", [])
 	s1.flush()
 	s2.flush()
 
@@ -312,7 +321,7 @@ async def test_global_state_shared_within_session_and_isolated_across_sessions()
 	assert len([m for m in msgs_s2_b if m["type"] == "vdom_update"]) == 0
 
 	# Increment in s2 on route b
-	s2.execute_callback("/b", "1.onClick", [])
+	s2.execute_callback(s2.view_for_path("/b").id, "1.onClick", [])
 	s1.flush()
 	s2.flush()
 
@@ -363,7 +372,7 @@ def test_dummy_placeholder_to_keep_line_numbers_stable():
 	assert True
 
 
-def test_global_navigate_to_bypasses_pending_mount_queue():
+def test_global_navigate_to_bypasses_pending_view_queue():
 	routes = RouteTree(
 		[
 			Route("a", simple_component),
@@ -377,13 +386,13 @@ def test_global_navigate_to_bypasses_pending_mount_queue():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a", "/a/b"])
-		session.attach("/a", make_route_info("/a"))
-		session.attach("/a/b", make_route_info("/a/b"))
+		attach_view(session, "/a")
+		attach_view(session, "/a/b")
 
-	mount = session.route_mounts["/a/b"]
-	mount.start_pending(10)
-	assert mount.state == "pending"
-	assert mount.queue == []
+	view = session.view_for_path("/a/b")
+	view.start_pending(10)
+	assert view.state == "pending"
+	assert view.queue == []
 
 	session.send(
 		{
@@ -396,7 +405,7 @@ def test_global_navigate_to_bypasses_pending_mount_queue():
 
 	assert len(messages) == 1
 	assert messages[0]["type"] == "navigate_to"
-	assert mount.queue == []
+	assert view.queue == []
 
 	session.close()
 
@@ -410,7 +419,7 @@ def test_navigate_to_queued_as_global_on_disconnect():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 
 	session.disconnect()
 	session.send(
@@ -444,8 +453,8 @@ def simple_component():
 
 
 @pytest.mark.asyncio
-async def test_attach_without_prerender_requests_reload():
-	"""Test that attaching without prerender requests a reload."""
+async def test_attach_unknown_view_requests_reload():
+	"""Test that attaching with an unknown view id requests a reload."""
 	routes = RouteTree([Route("a", simple_component)])
 	session = RenderSession("test-id", routes)
 
@@ -453,9 +462,9 @@ async def test_attach_without_prerender_requests_reload():
 	session.connect(lambda msg: messages.append(msg))
 
 	with ps.PulseContext.update(render=session):
-		session.attach("/a", make_route_info("/a"))
+		session.attach("missing-view", make_route_info("/a"))
 
-	assert "/a" not in session.route_mounts
+	assert session.views == {}
 	assert len(messages) == 1
 	assert messages[0]["type"] == "reload"
 
@@ -485,11 +494,12 @@ async def test_async_callback_navigation_after_detach_is_ignored_by_default():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 
-	session.execute_callback("/a", first_callback_key(session, "/a"), [])
+	view = session.view_for_path("/a")
+	session.execute_callback(view.id, first_callback_key(session, "/a"), [])
 	await started.wait()
-	session.detach("/a")
+	session.detach(view.id)
 	release.set()
 	await asyncio.wait_for(completed.wait(), timeout=0.2)
 	await asyncio.sleep(0)
@@ -521,11 +531,12 @@ async def test_async_callback_force_navigation_after_detach_still_navigates():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 
-	session.execute_callback("/a", first_callback_key(session, "/a"), [])
+	view = session.view_for_path("/a")
+	session.execute_callback(view.id, first_callback_key(session, "/a"), [])
 	await started.wait()
-	session.detach("/a")
+	session.detach(view.id)
 	release.set()
 	await wait_for(lambda: any(msg["type"] == "navigate_to" for msg in messages))
 
@@ -549,10 +560,11 @@ def test_route_bound_navigation_uses_current_path_for_dynamic_routes():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/items/:id"], route_info)
-		session.attach("/items/:id", route_info)
+		attach_view(session, "/items/:id", route_info)
 
+	view = session.view_for_path("/items/:id")
 	session.execute_callback(
-		"/items/:id",
+		view.id,
 		first_callback_key(session, "/items/:id"),
 		[],
 	)
@@ -560,14 +572,13 @@ def test_route_bound_navigation_uses_current_path_for_dynamic_routes():
 	navigations = [msg for msg in messages if msg["type"] == "navigate_to"]
 	assert len(navigations) == 1
 	assert navigations[0]["path"] == "/after"
-	assert navigations[0].get("sourceRoutePath") == "/items/:id"
-	assert navigations[0].get("sourcePath") == "/items/123"
-	assert isinstance(navigations[0].get("sourceMountId"), str)
+	assert navigations[0].get("sourceView") == view.id
+	assert navigations[0].get("sourcePathname") == "/items/123"
 
 	session.close()
 
 
-def test_route_bound_navigation_validates_source_route_identity():
+def test_route_bound_navigation_validates_source_view_identity():
 	routes = RouteTree([Route("a", simple_component), Route("b", simple_component)])
 	session = RenderSession("test-id", routes)
 	messages: list[ServerMessage] = []
@@ -576,21 +587,23 @@ def test_route_bound_navigation_validates_source_route_identity():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"], route_info)
-		session.attach("/a", route_info)
+		attach_view(session, "/a", route_info)
 		session.prerender(["/b"], route_info)
-		session.attach("/b", route_info)
+		attach_view(session, "/b", route_info)
 
-	mount = session.route_mounts["/a"]
+	view = session.view_for_path("/a")
 	with ps.PulseContext.update(
 		render=session,
-		route=mount.route,
-		source_route_path=mount.route.route_path,
-		source_path=mount.route.pathname,
+		route=view.route,
+		view=view,
+		source_pathname=view.route.pathname,
 	):
-		session.detach("/a")
+		session.detach(view.id)
 		ps.navigate("/after")
 
-	assert "/b" in session.route_mounts
+	# /b is still mounted at the same pathname, but the navigation came from the
+	# disposed /a view, so it must be dropped.
+	assert session.view_for_path("/b") is not None
 	assert not [msg for msg in messages if msg["type"] == "navigate_to"]
 
 	session.close()
@@ -619,15 +632,19 @@ async def test_async_callback_navigation_after_same_url_remount_is_ignored():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 
-	session.execute_callback("/a", first_callback_key(session, "/a"), [])
+	view = session.view_for_path("/a")
+	session.execute_callback(view.id, first_callback_key(session, "/a"), [])
 	await started.wait()
-	session.detach("/a")
+	session.detach(view.id)
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
+
+	# A fresh view was created for the same path; the old id is gone.
+	assert session.view_for_path("/a").id != view.id
 
 	release.set()
 	await asyncio.wait_for(completed.wait(), timeout=0.2)
@@ -664,13 +681,12 @@ async def test_async_callback_navigation_after_route_update_is_ignored_by_defaul
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/items/:id"], first_info)
-		session.attach("/items/:id", first_info)
+		attach_view(session, "/items/:id", first_info)
 
-	session.execute_callback(
-		"/items/:id", first_callback_key(session, "/items/:id"), []
-	)
+	view = session.view_for_path("/items/:id")
+	session.execute_callback(view.id, first_callback_key(session, "/items/:id"), [])
 	await started.wait()
-	session.attach("/items/:id", next_info)
+	session.attach(view.id, next_info)
 	release.set()
 	await asyncio.wait_for(completed.wait(), timeout=0.2)
 	await asyncio.sleep(0)
@@ -689,19 +705,19 @@ def test_queued_route_bound_navigation_is_revalidated_on_reconnect():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 
 	session.disconnect()
-	mount = session.route_mounts["/a"]
+	view = session.view_for_path("/a")
 	with ps.PulseContext.update(
 		render=session,
-		route=mount.route,
-		source_route_path=mount.route.route_path,
-		source_path=mount.route.pathname,
+		route=view.route,
+		view=view,
+		source_pathname=view.route.pathname,
 	):
 		ps.navigate("/after")
 
-	session.detach("/a")
+	session.detach(view.id)
 	session.connect(messages.append)
 
 	assert not [msg for msg in messages if msg["type"] == "navigate_to"]
@@ -731,10 +747,11 @@ async def test_later_callback_runs_after_detach_but_route_navigation_is_ignored(
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 
-	session.execute_callback("/a", first_callback_key(session, "/a"), [])
-	session.detach("/a")
+	view = session.view_for_path("/a")
+	session.execute_callback(view.id, first_callback_key(session, "/a"), [])
+	session.detach(view.id)
 
 	await asyncio.wait_for(fired.wait(), timeout=0.2)
 	await asyncio.sleep(0)
@@ -756,18 +773,18 @@ async def test_disconnect_pauses_render_effects():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 
-	mount = session.route_mounts["/a"]
-	assert mount.effect is not None
-	assert mount.effect.paused is False
+	view = session.view_for_path("/a")
+	assert view.effect is not None
+	assert view.effect.paused is False
 
 	# Disconnect should pause the effect (after queue timeout)
 	session.disconnect()
 
 	assert session.connected is False
 	# Note: now effects transition to PENDING first, not immediately paused
-	assert mount.state == "pending"
+	assert view.state == "pending"
 
 	session.close()
 
@@ -784,14 +801,14 @@ async def test_reconnect_flushes_queue_when_pending():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 
 	assert len(messages1) == 0
 
 	# Disconnect - state becomes PENDING
 	session.disconnect()
-	mount = session.route_mounts["/a"]
-	assert mount.state == "pending"
+	view = session.view_for_path("/a")
+	assert view.state == "pending"
 
 	# Reconnect
 	messages2: list[ServerMessage] = []
@@ -799,16 +816,16 @@ async def test_reconnect_flushes_queue_when_pending():
 
 	# Attach again (simulating client reconnection)
 	with ps.PulseContext.update(render=session):
-		session.attach("/a", make_route_info("/a"))
+		session.attach(view.id, make_route_info("/a"))
 
 	# Queue was empty, so no messages sent. State is now ACTIVE.
 	assert len(messages2) == 0
-	assert mount.state == "active"
+	assert view.state == "active"
 
 	session.close()
 
 
-def test_resume_missing_mount_requests_reload():
+def test_resume_missing_view_requests_reload():
 	routes = RouteTree([Route("a", simple_component)])
 	session = RenderSession("test-id", routes)
 	messages: list[ServerMessage] = []
@@ -819,7 +836,7 @@ def test_resume_missing_mount_requests_reload():
 			"resume-1",
 			[
 				{
-					"path": "/a",
+					"view": "missing-view",
 					"routeInfo": make_route_info("/a"),
 					"attachId": "attach-1",
 				}
@@ -835,7 +852,7 @@ def test_resume_missing_mount_requests_reload():
 	session.close()
 
 
-def test_resume_accepts_pending_mount_and_flushes_queue_after_snapshot():
+def test_resume_accepts_pending_view_and_flushes_queue_after_snapshot():
 	routes = RouteTree([Route("a", StatefulCounter)])
 	session = RenderSession("test-id", routes)
 	messages: list[ServerMessage] = []
@@ -843,14 +860,14 @@ def test_resume_accepts_pending_mount_and_flushes_queue_after_snapshot():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"], make_route_info("/a"))
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 
 	session.disconnect()
-	mount = session.route_mounts["/a"]
-	session.execute_callback("/a", first_callback_key(session, "/a"), [])
+	view = session.view_for_path("/a")
+	session.execute_callback(view.id, first_callback_key(session, "/a"), [])
 	session.flush()
-	assert mount.queue is not None
-	assert len(mount.queue) == 1
+	assert view.queue is not None
+	assert len(view.queue) == 1
 
 	resume_messages: list[ServerMessage] = []
 	session.connect(resume_messages.append)
@@ -859,7 +876,7 @@ def test_resume_accepts_pending_mount_and_flushes_queue_after_snapshot():
 			"resume-1",
 			[
 				{
-					"path": "/a",
+					"view": view.id,
 					"routeInfo": make_route_info("/a"),
 					"attachId": "attach-1",
 				}
@@ -876,7 +893,7 @@ def test_resume_accepts_pending_mount_and_flushes_queue_after_snapshot():
 		"type": "server_resume",
 		"resumeId": "resume-1",
 		"status": "ok",
-		"views": [{"path": "/a", "attachId": "attach-1"}],
+		"views": [{"view": view.id, "attachId": "attach-1"}],
 		"channels": [],
 	}
 
@@ -891,20 +908,21 @@ def test_prerender_of_active_path_queues_updates_until_route_sync():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 
 	messages.clear()
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"], make_route_info("/a"))
 
-	session.execute_callback("/a", first_callback_key(session, "/a"), [])
+	view = session.view_for_path("/a")
+	session.execute_callback(view.id, first_callback_key(session, "/a"), [])
 	session.flush()
 
 	assert messages == []
 
 	with ps.PulseContext.update(render=session):
-		session.update_route("/a", make_route_info("/a"))
+		session.update_route(view.id, make_route_info("/a"))
 
 	updates = [message for message in messages if message["type"] == "vdom_update"]
 	assert len(updates) == 1
@@ -923,14 +941,16 @@ async def test_messages_dropped_while_disconnected():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 	messages.clear()
+
+	view = session.view_for_path("/a")
 
 	# Disconnect
 	session.disconnect()
 
 	# Try to send a message while disconnected
-	session.send({"type": "vdom_update", "path": "/a", "ops": []})  # type: ignore[typeddict-item]
+	session.send({"type": "vdom_update", "view": view.id, "ops": []})
 
 	# Reconnect
 	messages2: list[ServerMessage] = []
@@ -961,10 +981,10 @@ async def test_route_info_updated_on_reconnect():
 	}
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"], route_info1)
-		session.attach("/a", route_info1)
+		attach_view(session, "/a", route_info1)
 
-	mount = session.route_mounts["/a"]
-	assert mount.route.query == "foo=bar"
+	view = session.view_for_path("/a")
+	assert view.route.query == "foo=bar"
 
 	# Disconnect
 	session.disconnect()
@@ -981,10 +1001,10 @@ async def test_route_info_updated_on_reconnect():
 		"catchall": [],
 	}
 	with ps.PulseContext.update(render=session):
-		session.attach("/a", route_info2)
+		session.attach(view.id, route_info2)
 
 	# Route info should be updated
-	assert mount.route.query == "baz=qux"
+	assert view.route.query == "baz=qux"
 
 	session.close()
 
@@ -1015,14 +1035,16 @@ async def test_state_preserved_across_reconnect():
 
 	with ps.PulseContext.update(render=session):
 		result = session.prerender(["/a"], make_route_info("/a"))["/a"]
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 
 	# Should have initial vdom_init with count 0
 	assert result["type"] == "vdom_init"
 	assert "0" in str(result["vdom"])
 
+	view = session.view_for_path("/a")
+
 	# Execute the increment callback
-	session.execute_callback("/a", "1.onClick", [])
+	session.execute_callback(view.id, "1.onClick", [])
 	session.flush()
 
 	# Should have vdom_update
@@ -1031,31 +1053,30 @@ async def test_state_preserved_across_reconnect():
 
 	# Disconnect - state goes to PENDING
 	session.disconnect()
-	mount = session.route_mounts["/a"]
-	assert mount.state == "pending"
+	assert view.state == "pending"
 
 	# Execute another increment while disconnected (will be queued)
-	session.execute_callback("/a", "1.onClick", [])
+	session.execute_callback(view.id, "1.onClick", [])
 	session.flush()
 
 	# The update should be queued
-	assert mount.queue is not None
-	assert len(mount.queue) == 1
-	assert mount.queue[0]["type"] == "vdom_update"
+	assert view.queue is not None
+	assert len(view.queue) == 1
+	assert view.queue[0]["type"] == "vdom_update"
 
 	# Reconnect
 	messages2: list[ServerMessage] = []
 	session.connect(lambda msg: messages2.append(msg))
 
 	with ps.PulseContext.update(render=session):
-		session.attach("/a", make_route_info("/a"))
+		session.attach(view.id, make_route_info("/a"))
 
 	# Queue should be flushed - should get the queued vdom_update
 	assert len(messages2) == 1
 	assert messages2[0]["type"] == "vdom_update"
 
 	# Verify the count is now 2 (two increments)
-	vdom = mount.tree.render()
+	vdom = view.tree.render()
 	assert "2" in str(vdom)
 
 	session.close()
@@ -1063,7 +1084,7 @@ async def test_state_preserved_across_reconnect():
 
 @pytest.mark.asyncio
 async def test_effect_paused_in_idle_state():
-	"""Test that effects are paused when mount transitions to IDLE state."""
+	"""Test that effects are paused when view transitions to IDLE state."""
 	routes = make_routes()
 	session = RenderSession("test-id", routes)
 
@@ -1072,25 +1093,25 @@ async def test_effect_paused_in_idle_state():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 
-	mount = session.route_mounts["/a"]
-	assert mount.effect is not None
-	assert mount.effect.paused is False
-	assert mount.state == "active"
+	view = session.view_for_path("/a")
+	assert view.effect is not None
+	assert view.effect.paused is False
+	assert view.state == "active"
 
-	# Disconnect puts mount in PENDING state (not paused)
+	# Disconnect puts view in PENDING state (not paused)
 	session.disconnect()
-	assert mount.state == "pending"
-	assert mount.effect.paused is False  # Still running in PENDING
+	assert view.state == "pending"
+	assert view.effect.paused is False  # Still running in PENDING
 
 	# Manually trigger transition to IDLE (simulating timeout)
-	transition_mount_to_idle(session, "/a")
+	transition_view_to_idle(session, "/a")
 
 	# Now the effect should be paused
-	assert mount.state == "idle"
-	assert mount.effect.paused is True
-	assert mount.effect.batch is None
+	assert view.state == "idle"
+	assert view.effect.paused is True
+	assert view.effect.batch is None
 
 	session.close()
 
@@ -1107,39 +1128,39 @@ async def test_multiple_routes_idle_attach_requests_reload():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a", "/b"])
-		session.attach("/a", make_route_info("/a"))
-		session.attach("/b", make_route_info("/b"))
+		attach_view(session, "/a")
+		attach_view(session, "/b")
 
 	assert len(messages1) == 0
 
 	# Disconnect - goes to PENDING
 	session.disconnect()
-	mount_a = session.route_mounts["/a"]
-	mount_b = session.route_mounts["/b"]
-	assert mount_a.state == "pending"
-	assert mount_b.state == "pending"
+	view_a = session.view_for_path("/a")
+	view_b = session.view_for_path("/b")
+	assert view_a.state == "pending"
+	assert view_b.state == "pending"
 
 	# Manually transition to IDLE (simulating timeout)
-	transition_mount_to_idle(session, "/a")
-	transition_mount_to_idle(session, "/b")
+	transition_view_to_idle(session, "/a")
+	transition_view_to_idle(session, "/b")
 
 	# Both effects should now be paused
-	effect_a = mount_a.effect
-	effect_b = mount_b.effect
+	effect_a = view_a.effect
+	effect_b = view_b.effect
 	assert effect_a is not None
 	assert effect_b is not None
 	assert effect_a.paused is True
 	assert effect_b.paused is True
-	assert mount_a.state == "idle"
-	assert mount_b.state == "idle"
+	assert view_a.state == "idle"
+	assert view_b.state == "idle"
 
 	# Reconnect
 	messages2: list[ServerMessage] = []
 	session.connect(lambda msg: messages2.append(msg))
 
 	with ps.PulseContext.update(render=session):
-		session.attach("/a", make_route_info("/a"))
-		session.attach("/b", make_route_info("/b"))
+		session.attach(view_a.id, make_route_info("/a"))
+		session.attach(view_b.id, make_route_info("/b"))
 
 	# Should request reload for each idle attach
 	reload_messages = [m for m in messages2 if m["type"] == "reload"]
@@ -1148,8 +1169,8 @@ async def test_multiple_routes_idle_attach_requests_reload():
 	# Both effects should remain paused
 	assert effect_a.paused is True
 	assert effect_b.paused is True
-	assert mount_a.state == "idle"
-	assert mount_b.state == "idle"
+	assert view_a.state == "idle"
+	assert view_b.state == "idle"
 
 	session.close()
 
@@ -1170,7 +1191,7 @@ async def test_call_api_timeout():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 
 	# Call API with a very short timeout - no response will arrive
 	with pytest.raises(asyncio.TimeoutError):
@@ -1193,7 +1214,7 @@ async def test_call_api_success_before_timeout():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 
 	# Start the API call
 	api_task = asyncio.create_task(session.call_api("/test", timeout=1.0))
@@ -1238,10 +1259,12 @@ async def test_run_js_timeout():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
+
+	view = session.view_for_path("/a")
 
 	# Run JS with result=True and short timeout
-	with ps.PulseContext.update(render=session, route=session.route_mounts["/a"].route):
+	with ps.PulseContext.update(render=session, route=view.route, view=view):
 		future = session.run_js(get_answer(), result=True, timeout=0.05)
 
 	assert future is not None
@@ -1267,10 +1290,12 @@ async def test_run_js_success_before_timeout():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
+
+	view = session.view_for_path("/a")
 
 	# Run JS with result=True
-	with ps.PulseContext.update(render=session, route=session.route_mounts["/a"].route):
+	with ps.PulseContext.update(render=session, route=view.route, view=view):
 		future = session.run_js(get_answer(), result=True, timeout=1.0)
 
 	assert future is not None
@@ -1301,7 +1326,7 @@ async def test_session_close_cancels_pending_api():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 
 	# Create a pending API future manually (simulating an in-flight request)
 	loop = asyncio.get_running_loop()
@@ -1327,7 +1352,7 @@ async def test_session_close_cancels_pending_js():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 
 	# Create a pending JS future manually
 	loop = asyncio.get_running_loop()
@@ -1397,12 +1422,13 @@ async def test_session_close_ignores_cancelled_callback_tasks():
 	try:
 		with ps.PulseContext.update(render=session):
 			session.prerender(["/a"])
-			session.attach("/a", make_route_info("/a"))
+			attach_view(session, "/a")
 
-		callbacks = session.route_mounts["/a"].tree.callbacks
+		view = session.view_for_path("/a")
+		callbacks = view.tree.callbacks
 		assert len(callbacks) == 1
 		key = next(iter(callbacks))
-		session.execute_callback("/a", key, [])
+		session.execute_callback(view.id, key, [])
 		assert await wait_for(lambda: started.is_set(), timeout=0.2)
 
 		session.close()
@@ -1466,7 +1492,7 @@ async def test_session_close_cancels_cleanup_timers():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 
 	assert state_box
 	session.close()
@@ -1538,8 +1564,8 @@ def not_found_component():
 
 
 @pytest.mark.asyncio
-async def test_prerender_redirect_removes_mount():
-	"""Test that RedirectInterrupt during first prerender removes mount from route_mounts."""
+async def test_prerender_redirect_removes_view():
+	"""Test that RedirectInterrupt during first prerender removes the view."""
 	routes = RouteTree([Route("redirect", redirecting_component)])
 	session = RenderSession("test-id", routes)
 
@@ -1551,15 +1577,17 @@ async def test_prerender_redirect_removes_mount():
 	assert result["path"] == "/other"
 	assert result["replace"] is True
 
-	# Mount should NOT be in route_mounts (was removed after interrupt)
-	assert "/redirect" not in session.route_mounts
+	# View should have been disposed after the interrupt
+	assert session.views == {}
+	with pytest.raises(ValueError):
+		session.view_for_path("/redirect")
 
 	session.close()
 
 
 @pytest.mark.asyncio
-async def test_prerender_not_found_removes_mount():
-	"""Test that NotFoundInterrupt during first prerender removes mount from route_mounts."""
+async def test_prerender_not_found_removes_view():
+	"""Test that NotFoundInterrupt during first prerender removes the view."""
 	routes = RouteTree([Route("missing", not_found_component)])
 	session = RenderSession("test-id", routes)
 
@@ -1570,8 +1598,10 @@ async def test_prerender_not_found_removes_mount():
 	assert result["type"] == "navigate_to"
 	assert result["replace"] is True
 
-	# Mount should NOT be in route_mounts
-	assert "/missing" not in session.route_mounts
+	# View should have been disposed
+	assert session.views == {}
+	with pytest.raises(ValueError):
+		session.view_for_path("/missing")
 
 	session.close()
 
@@ -1587,21 +1617,22 @@ async def test_prerender_then_attach_works():
 		result = session.prerender(["/a"], None)["/a"]
 
 	assert result["type"] == "vdom_init"
-	assert "/a" in session.route_mounts
-	mount = session.route_mounts["/a"]
-	assert mount.state == "pending"
-	assert mount.effect is not None  # Effect created during prerender
+	view = session.view_for_path("/a")
+	assert result["view"] == view.id
+	assert result["routePath"] == "/a"
+	assert view.state == "pending"
+	assert view.effect is not None  # Effect created during prerender
 
 	# Now attach
 	messages: list[ServerMessage] = []
 	session.connect(lambda msg: messages.append(msg))
 
 	with ps.PulseContext.update(render=session):
-		session.attach("/a", make_route_info("/a"))
+		session.attach(view.id, make_route_info("/a"))
 
 	# Should transition to active, queue flushed (empty)
-	assert mount.state == "active"
-	assert mount.queue is None
+	assert view.state == "active"
+	assert view.queue is None
 	assert len(messages) == 0  # No new messages, VDOM already sent during prerender
 
 	session.close()
@@ -1634,14 +1665,14 @@ async def test_prerender_seeds_effect_deps_for_updates():
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"], None)
 
-	mount = session.route_mounts["/a"]
-	assert mount.effect is not None
-	assert mount.effect.runs == 0
+	view = session.view_for_path("/a")
+	assert view.effect is not None
+	assert view.effect.runs == 0
 
 	with ps.PulseContext.update(render=session):
-		session.attach("/a", make_route_info("/a"))
+		session.attach(view.id, make_route_info("/a"))
 
-	session.execute_callback("/a", "1.onClick", [])
+	session.execute_callback(view.id, "1.onClick", [])
 	session.flush()
 
 	assert len([m for m in messages if m["type"] == "vdom_update"]) == 1
@@ -1650,8 +1681,8 @@ async def test_prerender_seeds_effect_deps_for_updates():
 
 
 @pytest.mark.asyncio
-async def test_prerender_keeps_mounts_for_unrendered_paths():
-	"""Test that prerender preserves mounts that are not part of the new paths."""
+async def test_prerender_keeps_views_for_unrendered_paths():
+	"""Test that prerender preserves views that are not part of the new paths."""
 	routes = make_routes()
 	session = RenderSession("test-id", routes)
 
@@ -1660,17 +1691,17 @@ async def test_prerender_keeps_mounts_for_unrendered_paths():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a", "/b"])
-		session.attach("/a", make_route_info("/a"))
-		session.attach("/b", make_route_info("/b"))
+		attach_view(session, "/a")
+		attach_view(session, "/b")
 
-	mount_a = session.route_mounts["/a"]
-	mount_b = session.route_mounts["/b"]
-	effect_a = mount_a.effect
-	effect_b = mount_b.effect
+	view_a = session.view_for_path("/a")
+	view_b = session.view_for_path("/b")
+	effect_a = view_a.effect
+	effect_b = view_b.effect
 	assert effect_a is not None
 	assert effect_b is not None
-	assert mount_a.state == "active"
-	assert mount_b.state == "active"
+	assert view_a.state == "active"
+	assert view_b.state == "active"
 
 	nav_info = make_route_info("/a")
 	nav_info["query"] = "page=2"
@@ -1680,17 +1711,17 @@ async def test_prerender_keeps_mounts_for_unrendered_paths():
 		result = session.prerender(["/a"], nav_info)["/a"]
 
 	assert result["type"] == "vdom_init"
-	assert session.route_mounts["/a"] is mount_a
-	assert mount_a.effect is effect_a
-	assert mount_a.state == "pending"
-	assert mount_a.route.query == "page=2"
-	assert session.route_mounts["/b"] is mount_b
-	assert mount_b.effect is effect_b
+	assert session.view_for_path("/a") is view_a
+	assert view_a.effect is effect_a
+	assert view_a.state == "pending"
+	assert view_a.route.query == "page=2"
+	assert session.view_for_path("/b") is view_b
+	assert view_b.effect is effect_b
 
 	messages.clear()
-	session.update_route("/a", nav_info)
-	assert mount_a.state == "active"
-	session.execute_callback("/a", "1.onClick", [])
+	session.update_route(view_a.id, nav_info)
+	assert view_a.state == "active"
+	session.execute_callback(view_a.id, "1.onClick", [])
 	session.flush()
 
 	assert len([m for m in messages if m["type"] == "vdom_update"]) == 1
@@ -1714,22 +1745,22 @@ async def test_attach_after_redirect_prerender_requests_reload():
 	routes = RouteTree([Route("cond", conditional_redirect)])
 	session = RenderSession("test-id", routes)
 
-	# First prerender - redirects
+	# First prerender - redirects, the view is disposed
 	with ps.PulseContext.update(render=session):
 		result = session.prerender(["/cond"], None)["/cond"]
 
 	assert result["type"] == "navigate_to"
-	assert "/cond" not in session.route_mounts
+	assert session.views == {}
 
-	# Now attach directly (simulating user navigating back)
+	# Now attach with the stale id (simulating user navigating back)
 	messages: list[ServerMessage] = []
 	session.connect(lambda msg: messages.append(msg))
 
 	with ps.PulseContext.update(render=session):
-		session.attach("/cond", make_route_info("/cond"))
+		session.attach("stale-view", make_route_info("/cond"))
 
-	# Should request reload and not create a mount
-	assert "/cond" not in session.route_mounts
+	# Should request reload and not create a view
+	assert session.views == {}
 	assert len(messages) == 1
 	assert messages[0]["type"] == "reload"
 
@@ -1756,8 +1787,8 @@ async def test_re_prerender_returns_fresh_vdom():
 
 
 @pytest.mark.asyncio
-async def test_detach_immediate_removes_mount_and_disposes_effect():
-	"""Test that detach immediately removes the mount and disposes its effect."""
+async def test_detach_immediate_removes_view_and_disposes_effect():
+	"""Test that detach immediately removes the view and disposes its effect."""
 	routes = RouteTree([Route("a", simple_component)])
 	session = RenderSession("test-id", routes)
 
@@ -1766,22 +1797,30 @@ async def test_detach_immediate_removes_mount_and_disposes_effect():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 
-	mount = session.route_mounts["/a"]
-	effect = mount.effect
+	view = session.view_for_path("/a")
+	effect = view.effect
 	assert effect is not None
 
-	session.detach("/a")
+	session.detach(view.id)
 
-	assert "/a" not in session.route_mounts
+	assert view.id not in session.views
+	with pytest.raises(ValueError):
+		session.view_for_path("/a")
 	assert len(effect.deps) == 0
 	assert effect.parent is None
+
+	# Attaching the disposed view id again must trigger a reload
+	with ps.PulseContext.update(render=session):
+		session.attach(view.id, make_route_info("/a"))
+
+	assert messages == [{"type": "reload"}]
 
 	session.close()
 
 
-def test_dev_strict_mode_detach_replay_reuses_mount_without_reload():
+def test_dev_strict_mode_detach_replay_reuses_view_without_reload():
 	routes = RouteTree([Route("a", simple_component)])
 	session = RenderSession("test-id", routes, dev_strict_mode_detach_timeout=10.0)
 	messages: list[ServerMessage] = []
@@ -1789,23 +1828,25 @@ def test_dev_strict_mode_detach_replay_reuses_mount_without_reload():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 
-	mount = session.route_mounts["/a"]
-	first_mount_id = mount.mount_id
+	view = session.view_for_path("/a")
+	first_view_id = view.id
 
-	session.detach("/a")
+	session.detach(view.id)
 
-	assert session.route_mounts["/a"] is mount
-	assert mount.state == "pending"
-	assert mount.pending_action == "dispose"
-	assert mount.mount_id != first_mount_id
+	# The view keeps its id through the dev StrictMode detach grace window
+	assert session.view_for_path("/a") is view
+	assert session.views[first_view_id] is view
+	assert view.state == "pending"
+	assert view.pending_action == "dispose"
+	assert view.id == first_view_id
 
 	with ps.PulseContext.update(render=session):
-		session.attach("/a", make_route_info("/a"))
+		session.attach(view.id, make_route_info("/a"))
 
-	assert session.route_mounts["/a"] is mount
-	assert mount.state == "active"
+	assert session.view_for_path("/a") is view
+	assert view.state == "active"
 	assert not [msg for msg in messages if msg["type"] == "reload"]
 
 	session.close()
@@ -1818,29 +1859,30 @@ async def test_dev_strict_mode_detach_disposes_after_timeout():
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 
-	session.detach("/a")
+	view = session.view_for_path("/a")
+	session.detach(view.id)
 
-	await wait_for(lambda: "/a" not in session.route_mounts)
+	await wait_for(lambda: view.id not in session.views)
 
 	session.close()
 
 
-def test_detach_nonexistent_path_is_noop():
-	"""Test that detaching a path that doesn't exist is a no-op."""
+def test_detach_nonexistent_view_is_noop():
+	"""Test that detaching a view id that doesn't exist is a no-op."""
 	routes = RouteTree([Route("a", simple_component)])
 	session = RenderSession("test-id", routes)
 
 	# Should not raise
-	session.detach("/nonexistent")
+	session.detach("nonexistent-view")
 
 	session.close()
 
 
 @pytest.mark.asyncio
 async def test_update_route_updates_route_context():
-	"""Test that update_route updates the route context for an attached path."""
+	"""Test that update_route updates the route context for an attached view."""
 	routes = RouteTree([Route("a", simple_component)])
 	session = RenderSession("test-id", routes)
 
@@ -1857,10 +1899,10 @@ async def test_update_route_updates_route_context():
 	}
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"], initial_info)
-		session.attach("/a", initial_info)
+		attach_view(session, "/a", initial_info)
 
-	mount = session.route_mounts["/a"]
-	assert mount.route.query == "x=1"
+	view = session.view_for_path("/a")
+	assert view.route.query == "x=1"
 
 	# Update route
 	updated_info: RouteInfo = {
@@ -1871,15 +1913,15 @@ async def test_update_route_updates_route_context():
 		"pathParams": {},
 		"catchall": [],
 	}
-	session.update_route("/a", updated_info)
+	session.update_route(view.id, updated_info)
 
-	assert mount.route.query == "y=2"
-	assert mount.route.hash == "section"
+	assert view.route.query == "y=2"
+	assert view.route.hash == "section"
 
 	session.close()
 
 
-def test_update_route_missing_mount_is_noop(monkeypatch: pytest.MonkeyPatch):
+def test_update_route_missing_view_is_noop(monkeypatch: pytest.MonkeyPatch):
 	routes = RouteTree([Route("a", simple_component)])
 	session = RenderSession("test-id", routes)
 	reported: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
@@ -1889,14 +1931,14 @@ def test_update_route_missing_mount_is_noop(monkeypatch: pytest.MonkeyPatch):
 
 	monkeypatch.setattr(session, "report_error", report_error)
 
-	session.update_route("/missing", make_route_info("/missing"))
+	session.update_route("missing-view", make_route_info("/missing"))
 
 	assert reported == []
 
 	session.close()
 
 
-def test_execute_callback_missing_mount_is_noop(monkeypatch: pytest.MonkeyPatch):
+def test_execute_callback_missing_view_is_noop(monkeypatch: pytest.MonkeyPatch):
 	routes = RouteTree([Route("a", simple_component)])
 	session = RenderSession("test-id", routes)
 	reported: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
@@ -1906,7 +1948,7 @@ def test_execute_callback_missing_mount_is_noop(monkeypatch: pytest.MonkeyPatch)
 
 	monkeypatch.setattr(session, "report_error", report_error)
 
-	session.execute_callback("/missing", "1.onClick", [])
+	session.execute_callback("missing-view", "1.onClick", [])
 
 	assert reported == []
 
@@ -1925,9 +1967,9 @@ def test_execute_callback_stale_key_is_noop(monkeypatch: pytest.MonkeyPatch):
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
-		session.attach("/a", make_route_info("/a"))
+		attach_view(session, "/a")
 
-	session.execute_callback("/a", "missing.onClick", [])
+	session.execute_callback(session.view_for_path("/a").id, "missing.onClick", [])
 
 	assert reported == []
 
@@ -1944,23 +1986,23 @@ async def test_prerender_queue_timeout_transitions_to_idle():
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
 
-	mount = session.route_mounts["/a"]
-	assert mount.state == "pending"
-	assert mount.effect is not None
-	assert mount.effect.paused is False
+	view = session.view_for_path("/a")
+	assert view.state == "pending"
+	assert view.effect is not None
+	assert view.effect.paused is False
 
 	# Manually trigger the timeout (simulating time passing)
-	transition_mount_to_idle(session, "/a")
+	transition_view_to_idle(session, "/a")
 
-	assert mount.state == "idle"
-	assert mount.effect.paused is True
+	assert view.state == "idle"
+	assert view.effect.paused is True
 
 	session.close()
 
 
 @pytest.mark.asyncio
 async def test_attach_from_idle_requests_reload():
-	"""Test that attaching to an idle mount requests a reload."""
+	"""Test that attaching to an idle view requests a reload."""
 	routes = RouteTree([Route("a", simple_component)])
 	session = RenderSession("test-id", routes)
 
@@ -1968,22 +2010,22 @@ async def test_attach_from_idle_requests_reload():
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
 
-	mount = session.route_mounts["/a"]
-	transition_mount_to_idle(session, "/a")
-	assert mount.state == "idle"
-	assert mount.effect is not None
-	assert mount.effect.paused is True
+	view = session.view_for_path("/a")
+	transition_view_to_idle(session, "/a")
+	assert view.state == "idle"
+	assert view.effect is not None
+	assert view.effect.paused is True
 
 	# Now attach
 	messages: list[ServerMessage] = []
 	session.connect(lambda msg: messages.append(msg))
 
 	with ps.PulseContext.update(render=session):
-		session.attach("/a", make_route_info("/a"))
+		session.attach(view.id, make_route_info("/a"))
 
-	# Should request reload and leave mount idle
-	assert mount.state == "idle"
-	assert mount.effect.paused is True
+	# Should request reload and leave the view idle
+	assert view.state == "idle"
+	assert view.effect.paused is True
 	assert len(messages) == 1
 	assert messages[0]["type"] == "reload"
 

--- a/packages/pulse/python/tests/test_renderer.py
+++ b/packages/pulse/python/tests/test_renderer.py
@@ -1285,11 +1285,12 @@ async def test_ref_on_mount_uses_route_context():
 	render.connect(lambda _: None)
 	with ps.PulseContext(app=app, session=session, render=render):
 		render.prerender(["/"])
-		render.attach("/", app.routes.find("/").default_route_info())
+		view = render.view_for_path("/")
+		render.attach(view.id, app.routes.find("/").default_route_info())
 
 	assert handle is not None
 	render.channels.handle_client_connect(
-		{"type": "channel_connect", "channel": handle.channel_id, "path": "/"}
+		{"type": "channel_connect", "channel": handle.channel_id, "view": view.id}
 	)
 	render.channels.handle_client_event(
 		render=render,

--- a/specs/custom-framework-redesign.md
+++ b/specs/custom-framework-redesign.md
@@ -1,0 +1,162 @@
+# Pulse custom framework redesign
+
+Status: in progress (June 2026). This spec drives the rebuild of Pulse's
+client/server foundation: removing React Router, making routing and navigation
+Python-native, anchoring every rendered view to a unique ID, fine-grained
+rendering, and client-side prefetching.
+
+## Goals
+
+1. **Custom React framework.** Replace React Router (framework mode, loaders,
+   SSR pipeline) with a small purpose-built router + SSR setup. React Router is
+   retrofitted into an unusual use case today; we only need route matching,
+   history management, outlets, links, and code splitting.
+2. **Python-native routing & navigation.** The Python route tree is the single
+   source of truth. Navigation flows through the Pulse protocol (WebSocket)
+   instead of React Router client loaders + HTTP prerender fetches.
+3. **View identity.** Rename backend "mount" to **view**. Every view has a
+   unique server-generated ID. All view-scoped protocol messages carry the view
+   ID instead of a route path, eliminating the (path, mount_id) workarounds.
+4. **Fine-grained rendering.** Each server component gets its own reactive
+   render effect; state changes re-render only the affected component subtree,
+   not the whole route. VDOM + expressions stay seamlessly interwoven in the
+   wire format.
+5. **Prefetching.** Links can prefetch both the route's JS chunks and the
+   server-rendered VDOM (on hover/viewport), making navigation instant.
+
+## Prior art in this repo
+
+- `origin/minimal-react`: complete React Router removal experiment (Jan 2026,
+  on a stale base). Source for the router (`js/src/router/`), SSR entries,
+  codegen templates. Ported, not merged.
+- `origin/minimal-pulse-router`: POC + `code-review.md` documenting issues to
+  fix (initial module load, nav races, popstate unknown routes,
+  protocol-relative URLs, error surfacing).
+- `origin/fine-grained-rerender`: plan doc for per-component render effects.
+- split/02..09 PR stack (merged into this branch): renderable serialization,
+  channel lifecycle + hooks, reconnect resume, route-local hydration,
+  notification payload cleanup.
+
+## Architecture
+
+### View identity (server)
+
+- `View` replaces `RouteMount` (`render_session.py`). A view = one rendered
+  route/layout instance for one client, identified by `View.id` (uuid hex),
+  created at prerender/navigation time.
+- `RenderSession.views: dict[str, View]` keyed by view ID. Path remains an
+  attribute (`view.route_path` pattern + `view.route` runtime info).
+- View lifecycle states stay: `pending → active → idle/closed`, with pending
+  queues + TTL (reused for prefetch).
+- Channels bind to `view.id` (replaces `(route_path, mount_id)` pair from
+  split/04). Detach/remount produces a new view ID, so stale actors are
+  rejected naturally.
+- Resume handshake declares views by ID.
+
+### Protocol
+
+All view-scoped messages carry `view` (the ID):
+
+- server → client: `vdom_init {view, vdom}`, `vdom_update {view, ops}`,
+  `js_exec {view, ...}`, `server_error {view?, ...}`, `attach_ack {view}`.
+- client → server: `attach {view, routeInfo}`, `callback {view, key, args}`,
+  `update {view, routeInfo}`, `detach {view}`.
+- Channel messages carry `view` when route-bound (replaces `path`).
+- `navigate_to` (server-initiated) carries the origin `view` for staleness
+  checks.
+
+### Navigation (WS-native)
+
+- Client router matches locally (mirror matcher) to know which JS chunks to
+  load, then sends `navigate {nav, url, routeInfo, keep: [viewIds]}` over the
+  socket. `nav` is a client sequence number; stale responses are dropped.
+- Server: matches the URL against the Python route tree, runs redirect
+  middleware, computes the view set (reusing `keep` views whose route pattern
+  still matches — layouts persist across sibling navigation), renders new
+  views, and replies `server_navigate {nav, location, views: [{id, routePath,
+  vdom?}]}`. Removed views are disposed server-side; the client detaches them
+  implicitly.
+- Because everything flows on one socket, updates to surviving views and the
+  navigation response are naturally ordered (the old HTTP prerender + WS
+  update combination had no ordering guarantee).
+- First load stays HTTP: SSR fetches `/_pulse/prerender`, which returns the
+  same view-set payload + directives; the client attaches by view ID after
+  connecting.
+- Server-initiated `navigate_to` is handled by the client router exactly like
+  a link click.
+
+### Custom router (client)
+
+`packages/pulse/js/src/router/`, adapted from minimal-react with the POC
+review fixes:
+
+- `match.ts` — mirrors Python matching: static > dynamic `:x` > optional
+  `:x?` > splat `*`; layouts are pathless nodes; deepest static-preferred
+  match wins.
+- `context.tsx` — `PulseRouterProvider`: location state machine, popstate
+  handling, navigation sequencing (token per navigation, out-of-order
+  completions dropped), error surfacing.
+- `link.tsx` — `Link` with `prefetch` prop (`intent` | `viewport` | `render` |
+  `none`).
+- `outlet.tsx`, `scroll.ts` (restoration), `hash.ts`, navigation progress UI.
+- Fixes from POC review: initial modules loaded before first render (no blank
+  page), popstate to unknown route → hard navigation, `//host` treated as
+  external, navigation errors surface in UI + revert.
+
+### Codegen
+
+`web/app/pulse/` now contains:
+
+- `routes.ts` — `pulseRouteTree` (serializable data) + `routeLoaders`
+  (`{ [routeId]: () => import("./routes/...") }`) as code-splitting points.
+- Per-route modules — default-export components rendering `<PulseView>` with
+  their registry (unchanged in spirit).
+- `app.tsx` — `PulseApp` shell composing `PulseRouterProvider` →
+  `PulseProvider` → `PulseRoutes`.
+- No `_layout.tsx` loaders, no `@react-router/dev` route config.
+
+### SSR + dev server
+
+- `web/` gets `index.html`, `src/entry-client.tsx`, `src/entry-server.tsx`,
+  `server/ssr.ts` (Bun), plain Vite config (no react-router plugin).
+- Dev (`pulse run`): Python server + Bun SSR server with Vite middleware mode
+  (HMR preserved for user components). Python proxies page requests to SSR.
+- Prod (`pulse build` / `pulse start`): Vite client + SSR builds; Python
+  serves static assets, Bun SSR renders HTML from the manifest. Fixes the
+  minimal-react prod 404 (`/src/entry-client.tsx`) by emitting hashed bundle
+  references from the manifest.
+
+### Fine-grained rendering (server)
+
+Per the fine-grained plan doc:
+
+- `RenderEffect(Effect)` per `PulseNode`, created on first render, immediate
+  on creation, batched on schedule.
+- Batch flush dedupe: a scheduled render effect is skipped when an ancestor
+  render effect is also scheduled (the parent re-render covers it).
+- Component runtime: stable `path`, `hooks`, `effect`; reconciliation moves
+  rebase paths and callback registry keys (prefix pruning).
+- Ops from component effects accumulate on the owning `View` and flush as one
+  `vdom_update` per reactive batch.
+- The wire format (VDOM + exprs + callbacks + render props interwoven) is
+  unchanged; ops just get more precise paths.
+
+### Prefetching
+
+- Chunks: `Link` warms `routeLoaders` imports on intent/viewport.
+- VDOM: `prefetch {url, routeInfo}` over WS → server creates **pending** views
+  (TTL'd, queueing updates) and returns the same payload shape as
+  `server_navigate`, minus the location commit. The client caches it keyed by
+  URL (short TTL). A subsequent navigation consumes the cache and attaches,
+  which activates the pending views and flushes whatever queued.
+- Races: prefetch responses are keyed by URL, never alter location; a
+  navigation always re-validates against the live route tree server-side.
+
+## Implementation order
+
+1. View identity rename + protocol (server, client, channels, resume).
+2. Custom router + codegen + SSR/dev-server (React Router removed).
+3. WS-native navigation.
+4. Prefetching.
+5. Fine-grained rendering.
+6. Examples, docs, browser-verified QA at each step.


### PR DESCRIPTION
2/6 of the custom-framework merge train (stacked on #97).

Renames mount → view and anchors every view to a unique id for its lifetime. Protocol messages between server and client are scoped to this id, so stale actors (callbacks, channels, navigations from disposed views) are rejected structurally instead of via path + generation counters. Also lands the new dependency-free client router (`js/src/router/`: matching, Link, history, scroll restoration) as library code with its own tests — it gets wired in by the router-swap PR (4/6).

**Green-up fixes added on top of the original commit** (each found by live-boot smoke testing, not visible to `make all`):
- Generated React Router apps kept working: the codegen template now builds its route-info payload via `buildRouteInfo` (the old `extractServerRouteInfo` export was renamed in this change), and `PulseProvider`/`PulseView` stay on react-router hooks until the swap.
- `react-router` stays a peer dependency until the swap: dropping it here made tsdown bundle a private react-router copy into dist, splitting the Router context between library and app (`useNavigate` threw outside `<Router>`).

**Validated**: `make all` green; example app boots, counter increments over the socket, client-side navigation works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)