### PR TITLE
Fine-grained rendering: per-component effects with subtree-scoped ops

### DIFF
--- a/docs/content/docs/(core)/concepts/state.mdx
+++ b/docs/content/docs/(core)/concepts/state.mdx
@@ -40,6 +40,8 @@ def CounterDemo():
 
 Without `ps.init()`, a new `Counter` instance would be created on every render, resetting the count to 0 each time.
 
+States created inside `ps.init()` live as long as the component: when it unmounts (or the init block re-runs because its `key` changed), Pulse disposes them automatically, stopping their effects and running `on_dispose()`.
+
 ## How tracking works
 
 When you render a component that displays `state.count`, Pulse remembers that the component depends on `count`. Later, when `count` changes, Pulse rerenders only the components that need it.

--- a/packages/pulse-mantine/python/src/pulse_mantine/form/form.py
+++ b/packages/pulse-mantine/python/src/pulse_mantine/form/form.py
@@ -1,4 +1,3 @@
-import json
 from collections.abc import Iterator, Mapping, Sequence
 from datetime import datetime
 from typing import (
@@ -14,7 +13,6 @@ import pulse as ps
 from pulse.helpers import call_flexible, maybe_await
 from pulse.reactive_extensions import ReactiveDict
 from pulse.scheduling import create_task
-from pulse.serializer import deserialize
 
 from .internal import FormInternal, FormMode
 from .validators import (
@@ -122,19 +120,18 @@ class MantineForm(ps.State, Generic[TForm]):
 			self._create_channel()
 
 	async def _handle_form_data(self, data: ps.FormData):
-		# Expect one JSON-serialized entry under "__data__" with v3 serializer
-		# and remaining entries are files keyed by their dot/bracket paths.
-		raw = data.get("__data__")
+		# Pulse's form endpoint already deserialized the "__data__" entry and
+		# merged its values into `data` (see FormRegistry.handle_submit), so by
+		# the time we get here the dict holds the form values (files stripped
+		# client-side) plus UploadFile entries keyed by their dot/bracket paths.
 		base: dict[str, Any] = {}
-		if isinstance(raw, str) and raw:
-			try:
-				payload = json.loads(raw)
-				base = deserialize(payload)
-			except Exception:
-				base = {}
-
+		files: dict[str, Any] = {}
+		for key, value in data.items():
+			if _is_file_entry(value):
+				files[key] = value
+			else:
+				base[key] = value
 		# Merge file entries back into the nested structure
-		files: dict[str, Any] = {k: v for k, v in data.items() if k != "__data__"}
 		result = _merge_files_into_structure(base, files)
 
 		# Run server-side validation for ALL rules before forwarding to user's onSubmit.
@@ -532,6 +529,16 @@ def _check_for_reserved_keys(obj: Any, path: str = "") -> None:
 	elif isinstance(obj, list):
 		for idx, v in enumerate(cast(list[Any], obj)):
 			_check_for_reserved_keys(v, f"{path}[{idx}]")
+
+
+def _is_file_entry(value: Any) -> bool:
+	"""True for UploadFile entries (or lists of them) posted alongside __data__."""
+	if isinstance(value, ps.UploadFile):
+		return True
+	if isinstance(value, list):
+		values = cast(list[Any], value)
+		return len(values) > 0 and all(isinstance(v, ps.UploadFile) for v in values)
+	return False
 
 
 def _merge_files_into_structure(base: Any, files: dict[str, Any]) -> Any:

--- a/packages/pulse-mantine/python/tests/test_form.py
+++ b/packages/pulse-mantine/python/tests/test_form.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -7,7 +6,6 @@ import pulse as ps
 import pytest
 from pulse.messages import ClientChannelRequestMessage
 from pulse.routing import Route, RouteInfo, RouteTree
-from pulse.serializer import serialize
 from pulse.user_session import UserSession
 from pulse_mantine import MantineForm
 
@@ -200,9 +198,11 @@ async def test_submit_state_resets_after_successful_submit():
 		form.render(onSubmit=handle_submit)
 
 	form._form._start_submit()  # pyright: ignore[reportPrivateUsage]
+	# The registry deserializes __data__ and merges it before invoking the
+	# handler, so the handler receives plain values.
 	task = asyncio.create_task(
 		form._form.registration.on_submit(  # pyright: ignore[reportPrivateUsage]
-			{"__data__": json.dumps(serialize({"name": "Ada"}))}
+			{"name": "Ada"}
 		)
 	)
 	await asyncio.wait_for(started.wait(), timeout=1)
@@ -263,9 +263,11 @@ async def test_submit_state_resets_after_failed_submit():
 		form.render(onSubmit=handle_submit)
 
 	form._form._start_submit()  # pyright: ignore[reportPrivateUsage]
+	# The registry deserializes __data__ and merges it before invoking the
+	# handler, so the handler receives plain values.
 	task = asyncio.create_task(
 		form._form.registration.on_submit(  # pyright: ignore[reportPrivateUsage]
-			{"__data__": json.dumps(serialize({"name": "Ada"}))}
+			{"name": "Ada"}
 		)
 	)
 	await asyncio.wait_for(started.wait(), timeout=1)
@@ -277,3 +279,56 @@ async def test_submit_state_resets_after_failed_submit():
 		await task
 
 	assert not form.is_submitting
+
+
+@pytest.mark.asyncio
+async def test_submit_merges_files_without_placeholder_leftovers():
+	"""The form endpoint pre-merges __data__ values (with None placeholders
+	where files were stripped) into the data dict; file entries arrive under
+	dotted paths. The merge must replace the placeholders, not append."""
+	from starlette.datastructures import Headers, UploadFile
+
+	app, _render, session, real_render, view = build_context()
+	received: list[dict[str, Any]] = []
+
+	async def handle_submit(values: dict[str, Any]):
+		received.append(values)
+
+	with ps.PulseContext(
+		app=app,
+		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
+		render=real_render,
+		route=view.route,
+		view=view,
+	):
+		form = MantineForm()
+		form.render(onSubmit=handle_submit)
+
+	def make_file(name: str) -> UploadFile:
+		import io
+
+		return UploadFile(
+			io.BytesIO(b"data"),
+			filename=name,
+			headers=Headers({"content-type": "application/octet-stream"}),
+		)
+
+	resume = make_file("resume.pdf")
+	shot1 = make_file("shot1.png")
+	shot2 = make_file("shot2.png")
+
+	# Mirrors FormRegistry.handle_submit output: __data__ values merged in
+	# (files stripped to None client-side), files keyed by dotted paths.
+	await form._form.registration.on_submit(  # pyright: ignore[reportPrivateUsage]
+		{
+			"portfolio": [None, None],
+			"resume": resume,
+			"portfolio.0": shot1,
+			"portfolio.1": shot2,
+		}
+	)
+
+	assert len(received) == 1
+	values = received[0]
+	assert values["resume"] is resume
+	assert values["portfolio"] == [shot1, shot2]

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -278,6 +278,7 @@ class App:
 	session_timeout: float
 	connection_status: ConnectionStatusConfig
 	render_loop_limit: int
+	unowned_reactives: Literal["error", "warn", "ignore"]
 	prerender_queue_timeout: float
 	disconnect_queue_timeout: float
 
@@ -303,6 +304,7 @@ class App:
 		disconnect_queue_timeout: float = 300.0,
 		connection_status: ConnectionStatusConfig | None = None,
 		render_loop_limit: int = 50,
+		unowned_reactives: Literal["error", "warn", "ignore"] = "error",
 	):
 		# Resolve mode from environment and expose on the app instance
 		self.env = envvars.pulse_env
@@ -361,6 +363,9 @@ class App:
 		self.disconnect_queue_timeout = disconnect_queue_timeout
 		self.connection_status = connection_status or ConnectionStatusConfig()
 		self.render_loop_limit = render_loop_limit
+		# Policy for Effects/States constructed during a component render
+		# without an owner (ps.init / ps.setup / ps.state / a State).
+		self.unowned_reactives = unowned_reactives
 
 		self.codegen = Codegen(
 			self.routes,

--- a/packages/pulse/python/src/pulse/decorators.py
+++ b/packages/pulse/python/src/pulse/decorators.py
@@ -4,7 +4,7 @@ import inspect
 from collections.abc import Awaitable, Callable
 from typing import Any, ParamSpec, Protocol, TypeVar, cast, overload
 
-from pulse.hooks.core import HOOK_CONTEXT
+from pulse.hooks.core import HOOK_CONTEXT, INIT_SCOPE_ACTIVE
 from pulse.hooks.effects import effect_state
 from pulse.hooks.state import collect_component_identity
 from pulse.reactive import (
@@ -309,8 +309,10 @@ def effect(
 				interval=interval,
 			)
 
-		if ctx is None:
-			# Not in component - create standalone effect (current behavior)
+		if ctx is None or INIT_SCOPE_ACTIVE.get():
+			# Outside a component render, or inside a one-time initializer
+			# (ps.setup / ps.init) whose scope captures and owns the effect:
+			# create a standalone effect.
 			return create_effect()
 
 		# In component render - use inline caching

--- a/packages/pulse/python/src/pulse/helpers.py
+++ b/packages/pulse/python/src/pulse/helpers.py
@@ -163,6 +163,27 @@ class Disposable(ABC):
 			cls.dispose = wrapped_dispose
 
 
+def dispose_owned_collection(owner: str, items: "list[Disposable]") -> None:
+	"""Dispose a collection owned by a single owner, surfacing foreign disposals.
+
+	Items already disposed when this is called were disposed by something
+	that does not own them - a bug worth surfacing in dev. Items disposed
+	mid-loop by an earlier sibling's cascade (a parent state disposing a
+	child it holds as an attribute) are legitimate and skipped silently.
+	"""
+	stale = [item for item in items if item.__disposed__]
+	for item in items:
+		if not item.__disposed__:
+			item.dispose()
+	if stale and env.pulse_env == "dev":
+		names = ", ".join(repr(item) for item in stale)
+		raise RuntimeError(
+			f"Reactive objects owned by {owner} were already disposed when it "
+			+ f"released them: {names}. Something else disposed objects it "
+			+ "does not own. This is likely a bug."
+		)
+
+
 def get_client_address(request: Request) -> str | None:
 	"""Best-effort client origin/address from an HTTP request.
 

--- a/packages/pulse/python/src/pulse/hooks/core.py
+++ b/packages/pulse/python/src/pulse/hooks/core.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any, Generic, Literal, TypeVar, override
 
 from pulse.helpers import Disposable, call_flexible
+from pulse.reactive import Untrack
 
 logger = logging.getLogger(__name__)
 
@@ -194,10 +195,15 @@ class HookNamespace(Generic[T]):
 		normalized = self._normalize_key(key)
 		state = self.states.get(normalized)
 		if state is None:
-			created = call_flexible(
-				self.hook.factory,
-				HookInit(definition=self.hook, render_cycle=ctx.render_cycle, key=key),
-			)
+			# Shield the factory from the ambient scope: the hook state owns
+			# whatever reactives it creates and disposes them itself.
+			with Untrack():
+				created = call_flexible(
+					self.hook.factory,
+					HookInit(
+						definition=self.hook, render_cycle=ctx.render_cycle, key=key
+					),
+				)
 			if inspect.isawaitable(created):
 				raise HookError(
 					f"Hook factory '{self.hook.name}' returned an awaitable; "
@@ -280,6 +286,15 @@ class HookContext:
 
 HOOK_CONTEXT: ContextVar[HookContext | None] = ContextVar(
 	"pulse_hook_context", default=None
+)
+
+# True while a one-time initializer (ps.setup init function or a ps.init()
+# block) is running. Effects created there are captured and owned by that
+# initializer's scope, so @ps.effect must create standalone effects instead
+# of registering them in the inline-effects hook (which would double-own
+# them and dispose mount-only effects on the next render).
+INIT_SCOPE_ACTIVE: ContextVar[bool] = ContextVar(
+	"pulse_init_scope_active", default=False
 )
 
 
@@ -446,6 +461,7 @@ __all__ = [
 	"HookState",
 	"HookAlreadyRegisteredError",
 	"HOOK_CONTEXT",
+	"INIT_SCOPE_ACTIVE",
 	"HookRegistry",
 	"hooks",
 	"MISSING",

--- a/packages/pulse/python/src/pulse/hooks/init.py
+++ b/packages/pulse/python/src/pulse/hooks/init.py
@@ -7,10 +7,13 @@ import inspect
 import textwrap
 import types
 from collections.abc import Callable, Sequence
+from contextvars import Token
+from dataclasses import dataclass, field
 from typing import Any, Literal, cast, override
 
-from pulse.helpers import getsourcecode
-from pulse.hooks.core import HookState, hooks
+from pulse.helpers import Disposable, dispose_owned_collection, getsourcecode
+from pulse.hooks.core import INIT_SCOPE_ACTIVE, HookState, hooks
+from pulse.reactive import Effect, Scope
 from pulse.transpiler.errors import TranspileError
 
 # Storage keyed by (code object, lineno) of the `with ps.init()` call site.
@@ -76,6 +79,8 @@ class InitContext:
 	pre_keys: set[str]
 	saved: dict[str, Any]
 	key: str | None
+	_scope: Scope | None
+	_flag_token: Token[bool] | None
 
 	def __init__(self, *, key: str | None = None):
 		self.callsite = None
@@ -84,6 +89,8 @@ class InitContext:
 		self.pre_keys = set()
 		self.saved = {}
 		self.key = key
+		self._scope = None
+		self._flag_token = None
 
 	def __enter__(self):
 		self.frame = previous_frame()
@@ -93,12 +100,22 @@ class InitContext:
 
 		storage = _init_hook().storage
 		entry = storage.get(self.callsite)
-		if entry is None or entry.get("key") != self.key:
+		if entry is None or entry.key != self.key:
+			if entry is not None:
+				# The key changed: the block re-runs, so everything the
+				# previous run created is replaced and must be disposed.
+				entry.dispose_owned()
+				del storage[self.callsite]
 			self.first_render = True
 			self.saved = {}
+			# Capture effects/states created by the block so the hook owns
+			# them; INIT_SCOPE_ACTIVE makes @ps.effect skip the inline cache.
+			self._scope = Scope()
+			self._scope.__enter__()
+			self._flag_token = INIT_SCOPE_ACTIVE.set(True)
 		else:
 			self.first_render = False
-			self.saved = entry["vars"]
+			self.saved = entry.vars
 		return self
 
 	def restore_variables(self):
@@ -112,7 +129,7 @@ class InitContext:
 		self.saved = values
 		assert self.callsite is not None, "callsite is None"
 		storage = _init_hook().storage
-		storage[self.callsite] = {"vars": values, "key": self.key}
+		storage[self.callsite] = InitEntry(vars=values, key=self.key)
 
 	def _capture_new_locals(self) -> dict[str, Any]:
 		frame = self.frame
@@ -132,11 +149,27 @@ class InitContext:
 		exc_value: BaseException | None,
 		exc_tb: Any,
 	) -> Literal[False]:
+		scope = self._scope
+		if scope is not None:
+			assert self._flag_token is not None
+			INIT_SCOPE_ACTIVE.reset(self._flag_token)
+			self._flag_token = None
+			scope.__exit__(exc_type, exc_value, exc_tb)
+			self._scope = None
 		if exc_type is None:
-			captured = self._capture_new_locals()
-			assert self.callsite is not None, "callsite  None"
-			storage = _init_hook().storage
-			storage[self.callsite] = {"vars": captured, "key": self.key}
+			if self.first_render:
+				captured = self._capture_new_locals()
+				assert self.callsite is not None, "callsite is None"
+				entry = InitEntry(vars=captured, key=self.key)
+				if scope is not None:
+					entry.effects = list(scope.effects)
+					entry.states = list(scope.states)
+				_init_hook().storage[self.callsite] = entry
+		elif scope is not None:
+			# The block raised partway through: dispose whatever it created.
+			InitEntry(
+				vars={}, key=self.key, effects=scope.effects, states=scope.states
+			).dispose_owned()
 		self.frame = None
 		return False
 
@@ -674,10 +707,28 @@ def _resolve_init_bindings(func: Callable[..., Any]) -> tuple[set[str], set[str]
 	return init_names, init_modules
 
 
+@dataclass(slots=True)
+class InitEntry:
+	"""Saved variables plus the effects/states a `ps.init()` block created."""
+
+	vars: dict[str, Any]
+	key: str | None
+	effects: list[Effect] = field(default_factory=list)
+	states: list[Disposable] = field(default_factory=list)
+
+	def dispose_owned(self) -> None:
+		owned: list[Disposable] = [*self.effects, *self.states]
+		self.effects = []
+		self.states = []
+		dispose_owned_collection("a ps.init() block", owned)
+
+
 class InitState(HookState):
 	def __init__(self) -> None:
-		self.storage: dict[tuple[Any, int], dict[str, Any]] = {}
+		self.storage: dict[tuple[Any, int], InitEntry] = {}
 
 	@override
 	def dispose(self) -> None:
+		for entry in self.storage.values():
+			entry.dispose_owned()
 		self.storage.clear()

--- a/packages/pulse/python/src/pulse/hooks/runtime.py
+++ b/packages/pulse/python/src/pulse/hooks/runtime.py
@@ -13,6 +13,7 @@ from typing import (
 from pulse.context import PulseContext
 from pulse.hooks.core import HOOK_CONTEXT
 from pulse.messages import ServerNavigateToMessage
+from pulse.reactive import Untrack
 from pulse.reactive_extensions import ReactiveDict
 from pulse.routing import Layout, Route, RouteInfo
 from pulse.state.state import State
@@ -458,7 +459,11 @@ def global_state(
 			shared_key = f"{base_key}|{id}"
 			inst = cast(S | None, GLOBAL_STATES.get(shared_key))
 			if inst is None:
-				inst = mk(*args, **kwargs)
+				# Shield creation from the ambient scope: shared instances
+				# must not be owned (and later disposed) by whichever
+				# component or ps.init block first accessed them.
+				with Untrack():
+					inst = mk(*args, **kwargs)
 				GLOBAL_STATES[shared_key] = inst
 			return inst
 

--- a/packages/pulse/python/src/pulse/hooks/setup.py
+++ b/packages/pulse/python/src/pulse/hooks/setup.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, ParamSpec, TypeVar, cast, override
 
-from pulse.hooks.core import HookMetadata, HookState, hooks
+from pulse.helpers import Disposable, dispose_owned_collection
+from pulse.hooks.core import INIT_SCOPE_ACTIVE, HookMetadata, HookState, hooks
 from pulse.reactive import Effect, Scope, Signal
 
 P = ParamSpec("P")
@@ -31,6 +32,7 @@ class SetupState(HookState):
 		"args",
 		"kwargs",
 		"effects",
+		"states",
 		"key",
 		"_called",
 		"_pending_key",
@@ -45,6 +47,7 @@ class SetupState(HookState):
 		self.args: list[Signal[Any]] = []
 		self.kwargs: dict[str, Signal[Any]] = {}
 		self.effects: list[Effect] = []
+		self.states: list[Disposable] = []
 		self.key: str | None = None
 		self._called = False
 		self._pending_key: str | None = None
@@ -62,10 +65,18 @@ class SetupState(HookState):
 		kwargs: dict[str, Any],
 		key: str | None,
 	) -> Any:
-		self.dispose_effects()
-		with Scope() as scope:
-			self.value = init_func(*args, **kwargs)
-			self.effects = list(scope.effects)
+		self.dispose_owned()
+		# Effects and states created by the init function belong to this hook
+		# alone: INIT_SCOPE_ACTIVE makes @ps.effect skip the inline-effects
+		# cache so nothing ends up with two owners.
+		token = INIT_SCOPE_ACTIVE.set(True)
+		try:
+			with Scope() as scope:
+				self.value = init_func(*args, **kwargs)
+		finally:
+			INIT_SCOPE_ACTIVE.reset(token)
+		self.effects = list(scope.effects)
+		self.states = list(scope.states)
 		self.args = [Signal(arg) for arg in args]
 		self.kwargs = {name: Signal(value) for name, value in kwargs.items()}
 		self.initialized = True
@@ -103,14 +114,16 @@ class SetupState(HookState):
 		for name, value in kwargs.items():
 			self.kwargs[name].write(value)
 
-	def dispose_effects(self) -> None:
-		for effect in self.effects:
-			effect.dispose()
+	def dispose_owned(self) -> None:
+		"""Dispose the effects and states created by the last init run."""
+		owned: list[Disposable] = [*self.effects, *self.states]
 		self.effects = []
+		self.states = []
+		dispose_owned_collection("a ps.setup initializer", owned)
 
 	@override
 	def dispose(self) -> None:
-		self.dispose_effects()
+		self.dispose_owned()
 		self.args = []
 		self.kwargs = {}
 		self.value = None

--- a/packages/pulse/python/src/pulse/hooks/state.py
+++ b/packages/pulse/python/src/pulse/hooks/state.py
@@ -5,6 +5,7 @@ from typing import Any, TypeVar, override
 
 from pulse.component import is_component_code
 from pulse.hooks.core import HookMetadata, HookState, hooks
+from pulse.reactive import REACTIVE_CONTEXT, Untrack
 from pulse.state.state import State
 
 S = TypeVar("S", bound=State)
@@ -42,6 +43,15 @@ class StateHookState(HookState):
 		key: str | None,
 		arg: State | Callable[[], State],
 	) -> State:
+		if isinstance(arg, State):
+			# The hook claims instances passed directly (adopting or disposing
+			# them), so the ambient scope must not own them too.
+			scope = REACTIVE_CONTEXT.get().scope
+			if scope is not None:
+				for index, candidate in enumerate(scope.states):
+					if candidate is arg:
+						del scope.states[index]
+						break
 		full_identity = self._make_key(identity, key)
 		if full_identity in self.called_keys:
 			if key is None:
@@ -81,17 +91,23 @@ class StateHookState(HookState):
 	@override
 	def dispose(self) -> None:
 		for instance in self.instances.values():
-			try:
-				if not instance.__disposed__:
-					instance.dispose()
-			except RuntimeError:
-				# Already disposed, ignore
-				pass
+			# No already-disposed guard: this hook owns its instances
+			# exclusively, so anything else disposing them first is an
+			# ownership bug. In dev the Disposable wrapper raises (surfaced
+			# by HookNamespace.dispose's error log); prod skips silently.
+			instance.dispose()
 		self.instances.clear()
 
 
 def _instantiate_state(arg: State | Callable[[], State]) -> State:
-	instance = arg() if callable(arg) else arg
+	if callable(arg):
+		# Shield the factory from the ambient scope: this hook owns the
+		# instance, so a surrounding ps.init/ps.setup scope must not capture
+		# (and later dispose) it too.
+		with Untrack():
+			instance = arg()
+	else:
+		instance = arg
 	if not isinstance(instance, State):
 		raise TypeError(
 			"`pulse.state` expects a State instance or a callable returning a State instance"

--- a/packages/pulse/python/src/pulse/queries/query.py
+++ b/packages/pulse/python/src/pulse/queries/query.py
@@ -1006,8 +1006,7 @@ class KeyedQueryResult(Generic[T], Disposable):
 	@override
 	def dispose(self):
 		"""Clean up the result and its observe effect."""
-		if not self._observe_effect.__disposed__:
-			self._observe_effect.dispose()
+		self._observe_effect.dispose()
 
 
 class QueryProperty(Generic[T, TState], InitializableProperty):

--- a/packages/pulse/python/src/pulse/reactive.py
+++ b/packages/pulse/python/src/pulse/reactive.py
@@ -464,8 +464,10 @@ class Effect(Disposable):
 			child.dispose()
 		if self.cleanup_fn:
 			self.cleanup_fn()
+			self.cleanup_fn = None
 		for dep in self.deps:
 			dep.obs.remove(self)
+		self.deps = {}
 		if self.parent and self in self.parent.children:
 			self.parent.children.remove(self)
 
@@ -699,10 +701,12 @@ class Effect(Disposable):
 
 	@contextmanager
 	def capture_deps(self, update_deps: bool | None = None):
+		"""Capture dependencies for this effect; yields the tracking Scope so
+		callers can inspect what else (effects, states) was created within."""
 		scope = Scope()
 		try:
 			with scope:
-				yield
+				yield scope
 		finally:
 			self.set_deps(scope.deps, update_deps=update_deps)
 
@@ -888,10 +892,48 @@ class AsyncEffect(Effect):
 			child.dispose()
 		if self.cleanup_fn:
 			self.cleanup_fn()
+			self.cleanup_fn = None  # pyright: ignore[reportUnannotatedClassAttribute]
 		for dep in self.deps:
 			dep.obs.remove(self)
+		self.deps = {}  # pyright: ignore[reportUnannotatedClassAttribute]
 		if self.parent and self in self.parent.children:
 			self.parent.children.remove(self)
+
+
+class RenderEffect(Effect):
+	"""Effect that re-renders a single component subtree.
+
+	The renderer attaches the component's runtime (duck-typed: anything with a
+	`path` attribute) so batches can order render effects parents-first.
+
+	Dependencies are managed exclusively by the renderer via `capture_deps`
+	around each render pass, so executing the effect does not open a tracking
+	scope of its own (the render pass shields itself with Untrack anyway).
+	"""
+
+	runtime: Any = None
+
+	@property
+	def depth(self) -> int:
+		path = getattr(self.runtime, "path", "")
+		if not path:
+			return 0
+		return path.count(".") + 1
+
+	@override
+	def _execute(self) -> None:
+		execution_epoch = epoch()
+		# Clear batch *before* running as the render may update a signal that
+		# causes this effect to be rescheduled.
+		self.batch = None  # pyright: ignore[reportUnannotatedClassAttribute]
+		try:
+			self.cleanup_fn = self.fn()  # pyright: ignore[reportUnannotatedClassAttribute]
+		except Exception as e:
+			self.handle_error(e)
+		self.runs += 1  # pyright: ignore[reportUnannotatedClassAttribute]
+		self.last_run = execution_epoch  # pyright: ignore[reportUnannotatedClassAttribute]
+		if self._interval is not None and self._interval_handle is None:
+			self._schedule_interval()
 
 
 class Batch:
@@ -961,8 +1003,22 @@ class Batch:
 			current_effects = self.effects
 			self.effects = []
 
+			# Clear batch references upfront so that cancelling or rescheduling an
+			# effect from within another effect's run targets the new queue.
 			for effect in current_effects:
 				effect.batch = None
+			# Run render effects after other effects, parents before children: a
+			# parent re-render refreshes its children's dependency snapshots, so
+			# their queued runs become no-ops instead of duplicate renders.
+			current_effects.sort(
+				key=lambda e: (1, e.depth) if isinstance(e, RenderEffect) else (0, 0)
+			)
+
+			for effect in current_effects:
+				# An earlier effect in this flush may have disposed or paused
+				# this one (e.g. a parent re-render unmounting a child).
+				if effect.__disposed__ or effect.paused:
+					continue
 				if not effect.should_run():
 					continue
 				try:
@@ -1049,6 +1105,7 @@ class Scope:
 	Attributes:
 		deps: Tracked dependencies mapping Signal/Computed to last_change epoch.
 		effects: Effects created in this scope.
+		states: State instances created in this scope.
 
 	Example:
 
@@ -1065,11 +1122,16 @@ class Scope:
 		# Dict preserves insertion order. Maps dependency -> last_change
 		self.deps: dict[Signal[Any] | Computed[Any], int] = {}
 		self.effects: list[Effect] = []
+		self.states: list[Any] = []
 		self._token: "Token[ReactiveContext] | None" = None
 
 	def register_effect(self, effect: "Effect"):
 		if effect not in self.effects:
 			self.effects.append(effect)
+
+	def register_state(self, state: Any):
+		# Each State registers exactly once (at construction), so no dedupe.
+		self.states.append(state)
 
 	def register_dep(self, value: "Signal[Any] | Computed[Any]"):
 		self.deps[value] = value.last_change

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -108,7 +108,7 @@ class View:
 	route_path: str
 	route: RouteContext
 	tree: RenderTree
-	effect: Effect | None
+	session: Any
 	initialized: bool
 	state: ViewState
 	pending_action: PendingAction | None
@@ -128,8 +128,9 @@ class View:
 		self.render = render
 		self.route_path = ensure_absolute_path(route_path)
 		self.route = RouteContext(route_info, route, render, self.route_path)
-		self.effect = None
+		self.session = PulseContext.get().session
 		self.tree = RenderTree(route.render())
+		self.tree.dispatch = self._dispatch_render
 		self.initialized = False
 		self.state = "pending"
 		self.pending_action = None
@@ -137,6 +138,19 @@ class View:
 		self.queue_timeout = None
 		self.render_batch_id = -1
 		self.render_batch_renders = 0
+
+	def _dispatch_render(self, runtime: Any) -> None:
+		"""Run one component re-render pass and ship its operations."""
+		try:
+			message = self.render.render_component_pass(self, runtime)
+		except Exception as exc:
+			details: dict[str, Any] | None = None
+			if isinstance(exc, RenderLoopError):
+				details = {"renders": exc.renders, "batch_id": exc.batch_id}
+			self.render.report_error(self.id, "render", exc, details)
+			return
+		if message is not None:
+			self.render.send(message)
 
 	def update_route(self, route_info: RouteInfo) -> None:
 		self.route.update(route_info)
@@ -171,8 +185,8 @@ class View:
 			)
 			return
 		self._cancel_pending_timeout()
-		if self.state == "idle" and self.effect:
-			self.effect.resume()
+		if self.state == "idle":
+			self.tree.resume_effects()
 		self.state = "pending"
 		self.queue = []
 		self.pending_action = action
@@ -212,49 +226,13 @@ class View:
 		self.state = "idle"
 		self.queue = None
 		self._cancel_pending_timeout()
-		if self.effect:
-			self.effect.pause()
-
-	def ensure_effect(self, *, lazy: bool = False, flush: bool = True) -> None:
-		if self.effect is not None:
-			if flush:
-				self.effect.flush()
-			return
-
-		ctx = PulseContext.get()
-		session = ctx.session
-
-		def _render_effect():
-			message = self.render.rerender(self, session=session)
-			if message is not None:
-				self.render.send(message)
-
-		def _report_render_error(exc: Exception) -> None:
-			details: dict[str, Any] | None = None
-			if isinstance(exc, RenderLoopError):
-				details = {
-					"renders": exc.renders,
-					"batch_id": exc.batch_id,
-				}
-			self.render.report_error(self.id, "render", exc, details)
-
-		self.effect = Effect(
-			_render_effect,
-			immediate=False,
-			name=f"{self.route_path}:render",
-			on_error=_report_render_error,
-			lazy=lazy,
-		)
-		if flush:
-			self.effect.flush()
+		self.tree.pause_effects()
 
 	def dispose(self) -> None:
 		self._cancel_pending_timeout()
 		self.state = "closed"
 		self.queue = None
 		self.tree.unmount()
-		if self.effect:
-			self.effect.dispose()
 
 
 class RenderSession:
@@ -454,19 +432,19 @@ class RenderSession:
 				view = View(self, path, route, info)
 				self.views[view.id] = view
 				self._views_by_path[path] = view
-				view.ensure_effect(lazy=True, flush=False)
 			else:
 				view.update_route(info)
-				if view.effect is None:
-					view.ensure_effect(lazy=True, flush=False)
 				if route_info is not None and view.state == "active":
 					view.start_pending(self.prerender_queue_timeout)
 
 			if view.state != "active" and view.queue_timeout is None:
 				view.start_pending(self.prerender_queue_timeout)
-			assert view.effect is not None
-			with view.effect.capture_deps(update_deps=True):
-				message = self.render(view)
+			if view.state == "pending":
+				# The full re-render below supersedes anything queued; ops
+				# computed against the previous tree must not flush onto the
+				# client's freshly initialized one.
+				view.queue = []
+			message = self.render(view)
 
 			results[path] = message
 			if message["type"] == "navigate_to":
@@ -612,8 +590,7 @@ class RenderSession:
 			view.render_batch_id = batch_id
 			view.render_batch_renders = 1
 		if view.render_batch_renders > self.render_loop_limit:
-			if view.effect:
-				view.effect.pause()
+			view.tree.pause_effects()
 			raise RenderLoopError(view.route_path, view.render_batch_renders, batch_id)
 
 	def _render_with_interrupts(
@@ -668,20 +645,22 @@ class RenderSession:
 
 		return self._render_with_interrupts(view, session=session, render_fn=_render)
 
-	def rerender(
-		self, view: View, *, session: Any | None = None
+	def render_component_pass(
+		self, view: View, runtime: Any
 	) -> ServerUpdateMessage | ServerNavigateToMessage | None:
-		def _rerender() -> ServerUpdateMessage | None:
+		"""Re-render one component subtree within the view's Pulse context."""
+
+		def _pass() -> ServerUpdateMessage | None:
 			if not view.initialized:
 				raise RuntimeError(
-					f"rerender called before init for {view.route_path!r}"
+					f"component render before init for {view.route_path!r}"
 				)
-			ops = view.tree.rerender()
+			ops = view.tree.run_component_pass(runtime)
 			if ops:
 				return ServerUpdateMessage(type="vdom_update", view=view.id, ops=ops)
 			return None
 
-		return self._render_with_interrupts(view, session=session, render_fn=_rerender)
+		return self._render_with_interrupts(view, session=view.session, render_fn=_pass)
 
 	# ---- Helpers ----
 
@@ -737,7 +716,11 @@ class RenderSession:
 		"""Return a per-session singleton for the provided key."""
 		inst = self._global_states.get(key)
 		if inst is None:
-			inst = factory()
+			# Shield creation from the ambient scope: this session owns the
+			# instance, not whatever component (or ps.init block) first
+			# happened to access it.
+			with Untrack():
+				inst = factory()
 			self._global_states[key] = inst
 		return inst
 

--- a/packages/pulse/python/src/pulse/renderer.py
+++ b/packages/pulse/python/src/pulse/renderer.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Callable, Iterable
+import logging
+from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 from types import NoneType
 from typing import Any, NamedTuple, TypeAlias, cast
 from typing import Literal as TypingLiteral
 
+from pulse.context import PulseContext
 from pulse.debounce import Debounced
 from pulse.helpers import values_equal
 from pulse.hooks.core import HookContext
+from pulse.reactive import RenderEffect, Scope, Untrack
 from pulse.refs import RefHandle
 from pulse.transpiler import Import
 from pulse.transpiler.function import Constant, JsFunction, JsxFunction
@@ -42,6 +45,44 @@ FRAGMENT_TAG = ""
 MOUNT_PREFIX = "$$"
 CALLBACK_PLACEHOLDER = "$cb"
 
+logger = logging.getLogger(__name__)
+
+
+def enforce_scope_ownership(scope: Scope, component: PulseNode) -> None:
+	"""Flag Effects/States constructed during a render pass without an owner.
+
+	Everything with a designated owner is shielded from (or removed from) the
+	component's tracking scope: inline @ps.effect (inline-effects hook),
+	ps.init/ps.setup creations (their own capture scopes), ps.state factories,
+	hook-state factories, and shared/global states (Untrack). Whatever is left
+	would never be disposed, so it leaks past unmount. Policy comes from
+	App(unowned_reactives=...): "error" (default), "warn", or "ignore".
+	"""
+	if not scope.effects and not scope.states:
+		return
+	policy = PulseContext.get().app.unowned_reactives
+	if policy == "ignore":
+		return
+	component_name = component.name or getattr(component.fn, "__name__", "component")
+	created = [f"Effect '{effect.name or 'unnamed'}'" for effect in scope.effects]
+	created += [type(state).__name__ for state in scope.states]
+	message = (
+		f"Component '{component_name}' created reactive objects during render "
+		f"with no owner to dispose them: {', '.join(created)}. Create states in "
+		"`with ps.init():` or via `ps.state(...)`, and effects with `@ps.effect` "
+		"or inside a State. Configure this check with App(unowned_reactives=...)."
+	)
+	if policy == "warn":
+		logger.warning(message)
+		return
+	for effect in scope.effects:
+		if not effect.__disposed__:
+			effect.dispose()
+	for state in scope.states:
+		if not state.__disposed__:
+			state.dispose()
+	raise RuntimeError(message)
+
 
 class Callback(NamedTuple):
 	fn: Callable[..., Any]
@@ -69,52 +110,160 @@ class RenderPropTask(NamedTuple):
 	path: str
 
 
+class ComponentRuntime:
+	"""Persistent render state for one component instance.
+
+	Lives on the first PulseNode instance rendered for the component and moves
+	to each new instance during reconciliation. The render effect re-renders
+	only this component's subtree when its dependencies change.
+	"""
+
+	__slots__ = ("node", "path", "tree", "effect")  # pyright: ignore[reportUnannotatedClassAttribute]
+
+	node: PulseNode
+	path: str
+	tree: "RenderTree"
+	effect: RenderEffect | None
+
+	def __init__(self, node: PulseNode, path: str, tree: "RenderTree") -> None:
+		self.node = node
+		self.path = path
+		self.tree = tree
+		self.effect = None
+
+
 class RenderTree:
+	"""Persistent render state for a view.
+
+	Holds the normalized node tree and the callback registry, and dispatches
+	fine-grained component re-renders. The owning View installs `dispatch` to
+	wrap passes with Pulse context and ship the resulting operations to the
+	client; without a dispatcher (tests, standalone trees), operations
+	accumulate in `pending_ops`.
+	"""
+
 	element: Node
 	callbacks: Callbacks
 	rendered: bool
+	dispatch: Callable[[ComponentRuntime], None] | None
+	pending_ops: list[VDOMOperation]
 
 	def __init__(self, element: Node) -> None:
 		self.element = element
 		self.callbacks = {}
 		self.rendered = False
+		self.dispatch = None
+		self.pending_ops = []
 
 	def render(self) -> VDOM:
-		"""First render. Returns VDOM."""
-		renderer = Renderer()
+		"""First render (or full re-render for a fresh prerender). Returns VDOM."""
+		renderer = Renderer(tree=self)
 		vdom, self.element = renderer.render_tree(self.element)
-		self.callbacks = renderer.callbacks
+		renderer.finish_pass()
 		self.rendered = True
 		return vdom
 
 	def rerender(self, new_element: Node | None = None) -> list[VDOMOperation]:
-		"""Re-render and return update operations.
+		"""Reconcile the whole tree from the root and return update operations.
 
 		If new_element is provided, reconciles against it (for testing).
-		Otherwise, reconciles against the current element (production use).
+		Otherwise, reconciles against the current element.
 		"""
 		if not self.rendered:
 			raise RuntimeError("render() must be called before rerender()")
 		target = new_element if new_element is not None else self.element
-		renderer = Renderer()
+		renderer = Renderer(tree=self)
 		self.element = renderer.reconcile_tree(self.element, target, path="")
-		self.callbacks = renderer.callbacks
+		renderer.finish_pass()
 		return renderer.operations
+
+	def run_component_pass(self, runtime: ComponentRuntime) -> list[VDOMOperation]:
+		"""Re-render a single component subtree, returning its operations."""
+		renderer = Renderer(tree=self, pass_root=runtime.path)
+		renderer.rerender_component(runtime)
+		renderer.finish_pass()
+		return renderer.operations
+
+	def _dispatch(self, runtime: ComponentRuntime) -> None:
+		if self.dispatch is not None:
+			self.dispatch(runtime)
+			return
+		self.pending_ops.extend(self.run_component_pass(runtime))
+
+	def take_ops(self) -> list[VDOMOperation]:
+		"""Drain operations accumulated without a dispatcher."""
+		ops = self.pending_ops
+		self.pending_ops = []
+		return ops
+
+	def iter_runtimes(self) -> "Iterator[ComponentRuntime]":
+		yield from iter_component_runtimes(self.element)
+
+	def pause_effects(self) -> None:
+		for runtime in self.iter_runtimes():
+			if runtime.effect is not None:
+				runtime.effect.pause()
+
+	def resume_effects(self) -> None:
+		for runtime in self.iter_runtimes():
+			if runtime.effect is not None:
+				runtime.effect.resume()
+
+	def flush_effects(self) -> None:
+		for runtime in self.iter_runtimes():
+			if runtime.effect is not None:
+				runtime.effect.flush()
 
 	def unmount(self) -> None:
 		if self.rendered:
 			unmount_element(self.element)
 			self.rendered = False
 		self.callbacks.clear()
+		self.pending_ops = []
 
 
 class Renderer:
+	"""Single render/reconcile pass over (part of) a tree.
+
+	Persistent mode requires a RenderTree: callbacks are registered into the
+	tree's persistent registry, and callbacks under `pass_root` that are not
+	re-registered during the pass are swept when it finishes. Snapshot mode
+	renders one-shot VDOM with callbacks/refs stripped.
+	"""
+
 	def __init__(
-		self, *, mode: TypingLiteral["persistent", "snapshot"] = "persistent"
+		self,
+		*,
+		tree: RenderTree | None = None,
+		pass_root: str = "",
+		mode: TypingLiteral["persistent", "snapshot"] = "persistent",
 	) -> None:
 		self.mode: TypingLiteral["persistent", "snapshot"] = mode
-		self.callbacks: Callbacks = {}
+		self.tree: RenderTree | None = tree
+		self.pass_root: str = pass_root
+		self.callbacks: Callbacks = tree.callbacks if tree is not None else {}
 		self.operations: list[VDOMOperation] = []
+		self._stale_callbacks: set[str] = set()
+		if tree is not None:
+			if pass_root:
+				prefix = pass_root + "."
+				self._stale_callbacks = {
+					key
+					for key in self.callbacks
+					if key == pass_root or key.startswith(prefix)
+				}
+			else:
+				self._stale_callbacks = set(self.callbacks)
+
+	def register_callback(self, path: str, fn: Callable[..., Any]) -> None:
+		register_callback(self.callbacks, path, fn)
+		self._stale_callbacks.discard(path)
+
+	def finish_pass(self) -> None:
+		"""Drop callbacks under the pass root that were not re-registered."""
+		for key in self._stale_callbacks:
+			self.callbacks.pop(key, None)
+		self._stale_callbacks = set()
 
 	# ------------------------------------------------------------------
 	# Rendering helpers
@@ -135,11 +284,53 @@ class Renderer:
 	def render_component(
 		self, component: PulseNode, path: str
 	) -> tuple[VDOM, PulseNode]:
+		if self.mode == "snapshot":
+			if component.hooks is None:
+				component.hooks = HookContext()
+			with component.hooks:
+				rendered = component.fn(*component.args, **component.kwargs)
+			vdom, normalized_child = self.render_tree(rendered, path)
+			component.contents = normalized_child
+			return vdom, component
+
+		tree = self.tree
+		if tree is None:
+			raise RuntimeError(
+				"Rendering components persistently requires a RenderTree"
+			)
+		runtime = component.runtime
+		if runtime is None:
+			runtime = ComponentRuntime(component, path, tree)
+			component.runtime = runtime
+		else:
+			# Full re-render of an already-rendered component (fresh prerender):
+			# tear down the old subtree so stale effects don't stay subscribed.
+			runtime.node = component
+			runtime.path = path
+			if component.contents is not None:
+				unmount_element(component.contents)
+				component.contents = None
+		if runtime.effect is None:
+			# Untrack: the runtime owns its render effect; it must not register
+			# into the enclosing (parent) component's tracking scope.
+			with Untrack():
+				runtime.effect = RenderEffect(
+					_make_component_effect(tree, runtime),
+					lazy=True,
+					name=f"render:{component.name or getattr(component.fn, '__name__', 'component')}",
+				)
+			runtime.effect.runtime = runtime
 		if component.hooks is None:
 			component.hooks = HookContext()
-		with component.hooks:
-			rendered = component.fn(*component.args, **component.kwargs)
-		vdom, normalized_child = self.render_tree(rendered, path)
+		# Untrack shields the enclosing component's scope: this component's
+		# reads (and its effect) must not become dependencies of its parent.
+		with Untrack():
+			with runtime.effect.capture_deps(update_deps=True) as scope:
+				with component.hooks:
+					rendered = component.fn(*component.args, **component.kwargs)
+				vdom, normalized_child = self.render_tree(rendered, path)
+			enforce_scope_ownership(scope, component)
+		runtime.effect.runs += 1
 		component.contents = normalized_child
 		return vdom, component
 
@@ -216,23 +407,93 @@ class Renderer:
 	) -> PulseNode:
 		current.hooks = previous.hooks
 		current.contents = previous.contents
-
 		if current.hooks is None:
 			current.hooks = HookContext()
 
-		with current.hooks:
-			rendered = current.fn(*current.args, **current.kwargs)
+		if self.mode == "snapshot":
+			with current.hooks:
+				rendered = current.fn(*current.args, **current.kwargs)
+			if current.contents is None:
+				new_vdom, normalized = self.render_tree(rendered, path)
+				current.contents = normalized
+				self.operations.append(
+					ReplaceOperation(type="replace", path=path, data=new_vdom)
+				)
+			else:
+				current.contents = self.reconcile_tree(current.contents, rendered, path)
+			return current
 
-		if current.contents is None:
-			new_vdom, normalized = self.render_tree(rendered, path)
-			current.contents = normalized
-			self.operations.append(
-				ReplaceOperation(type="replace", path=path, data=new_vdom)
+		tree = self.tree
+		if tree is None:
+			raise RuntimeError(
+				"Rendering components persistently requires a RenderTree"
 			)
+		runtime = previous.runtime
+		if runtime is None:
+			runtime = ComponentRuntime(current, path, tree)
+		current.runtime = runtime
+		if previous is not current:
+			previous.runtime = None
+		runtime.node = current
+		runtime.path = path
+		if runtime.effect is None:
+			# Untrack: the runtime owns its render effect; it must not register
+			# into the enclosing (parent) component's tracking scope.
+			with Untrack():
+				runtime.effect = RenderEffect(
+					_make_component_effect(tree, runtime),
+					lazy=True,
+					name=f"render:{current.name or getattr(current.fn, '__name__', 'component')}",
+				)
+			runtime.effect.runtime = runtime
 		else:
-			current.contents = self.reconcile_tree(current.contents, rendered, path)
+			# This pass re-renders the component now; a queued standalone run
+			# would be redundant.
+			runtime.effect.cancel(cancel_interval=False)
+
+		with Untrack():
+			with runtime.effect.capture_deps(update_deps=True) as scope:
+				with current.hooks:
+					rendered = current.fn(*current.args, **current.kwargs)
+
+				if current.contents is None:
+					new_vdom, normalized = self.render_tree(rendered, path)
+					current.contents = normalized
+					self.operations.append(
+						ReplaceOperation(type="replace", path=path, data=new_vdom)
+					)
+				else:
+					current.contents = self.reconcile_tree(
+						current.contents, rendered, path
+					)
+			enforce_scope_ownership(scope, current)
+		runtime.effect.runs += 1
 
 		return current
+
+	def rerender_component(self, runtime: ComponentRuntime) -> None:
+		"""Standalone re-render of one component, triggered by its effect."""
+		component = runtime.node
+		path = runtime.path
+		assert runtime.effect is not None
+		if component.hooks is None:
+			component.hooks = HookContext()
+		with Untrack():
+			with runtime.effect.capture_deps(update_deps=True) as scope:
+				with component.hooks:
+					rendered = component.fn(*component.args, **component.kwargs)
+				if component.contents is None:
+					new_vdom, normalized = self.render_tree(rendered, path)
+					component.contents = normalized
+					self.operations.append(
+						ReplaceOperation(type="replace", path=path, data=new_vdom)
+					)
+				else:
+					component.contents = self.reconcile_tree(
+						component.contents, rendered, path
+					)
+			enforce_scope_ownership(scope, component)
+		runtime.effect.runs += 1
 
 	def reconcile_element(
 		self,
@@ -457,7 +718,7 @@ class Renderer:
 				if normalized is None:
 					normalized = current.copy()
 				normalized[key] = value
-				register_callback(self.callbacks, prop_path, value.fn)
+				self.register_callback(prop_path, value.fn)
 				prev_delay = (
 					old_value.delay_ms if isinstance(old_value, Debounced) else None
 				)
@@ -477,7 +738,7 @@ class Renderer:
 				if normalized is None:
 					normalized = current.copy()
 				normalized[key] = value
-				register_callback(self.callbacks, prop_path, value)
+				self.register_callback(prop_path, value)
 				if not callable(old_value) or isinstance(old_value, Debounced):
 					updated[key] = CALLBACK_PLACEHOLDER
 				continue
@@ -529,6 +790,13 @@ class Renderer:
 
 	def unmount_subtree(self, node: Node) -> None:
 		unmount_element(node)
+
+
+def _make_component_effect(tree: RenderTree, runtime: ComponentRuntime):
+	def run() -> None:
+		tree._dispatch(runtime)  # pyright: ignore[reportPrivateUsage]
+
+	return run
 
 
 # ----------------------------------------------------------------------
@@ -651,8 +919,31 @@ def key_value(node: Node | Node) -> str | None:
 	return cast(str | None, key)
 
 
+def iter_component_runtimes(node: Node) -> "Iterator[ComponentRuntime]":
+	"""Yield every ComponentRuntime in a normalized subtree."""
+	if isinstance(node, PulseNode):
+		if node.runtime is not None:
+			yield node.runtime
+		if node.contents is not None:
+			yield from iter_component_runtimes(node.contents)
+		return
+	if isinstance(node, Element):
+		if isinstance(node.props, dict):
+			for value in node.props.values():
+				if isinstance(value, (Element, PulseNode)):
+					yield from iter_component_runtimes(value)
+		for child in normalize_children(node.children):
+			yield from iter_component_runtimes(child)
+
+
 def unmount_element(element: Node) -> None:
 	if isinstance(element, PulseNode):
+		runtime = element.runtime
+		if runtime is not None:
+			if runtime.effect is not None:
+				runtime.effect.dispose()
+				runtime.effect = None
+			element.runtime = None
 		if element.contents is not None:
 			unmount_element(element.contents)
 			element.contents = None

--- a/packages/pulse/python/src/pulse/serializer.py
+++ b/packages/pulse/python/src/pulse/serializer.py
@@ -38,7 +38,7 @@ import types
 from dataclasses import fields, is_dataclass
 from typing import Any, TypeAlias
 
-from pulse.renderer import Renderer
+from pulse.renderer import Renderer, unmount_element
 from pulse.transpiler.nodes import Element, Expr, PulseNode, Value, clone_renderable
 
 Primitive = int | float | str | bool | None
@@ -132,10 +132,14 @@ def serialize(data: Any) -> Serialized:
 			raise TypeError(f"Unsupported value in serialization: {type(value)!r}")
 
 		pulse_payload = None
-		if isinstance(value, Element):
-			pulse_payload = clone_renderable(value).render(Renderer(mode="snapshot"))
-		elif isinstance(value, PulseNode):
-			pulse_payload = clone_renderable(value).render(Renderer(mode="snapshot"))
+		if isinstance(value, (Element, PulseNode)):
+			# Snapshot-render a clone, then unmount it: hooks (and any effects
+			# created during the render) must not outlive the one-shot VDOM.
+			clone = clone_renderable(value)
+			try:
+				pulse_payload = clone.render(Renderer(mode="snapshot"))
+			finally:
+				unmount_element(clone)
 		elif isinstance(value, Expr):
 			pulse_payload = value.render()
 

--- a/packages/pulse/python/src/pulse/state/state.py
+++ b/packages/pulse/python/src/pulse/state/state.py
@@ -13,7 +13,7 @@ from types import SimpleNamespace
 from typing import Any, get_type_hints, override
 
 from pulse.helpers import Disposable
-from pulse.reactive import Computed, Effect, Scope, Signal
+from pulse.reactive import REACTIVE_CONTEXT, Computed, Effect, Scope, Signal
 from pulse.reactive_extensions import ReactiveProperty
 from pulse.state.property import (
 	ComputedProperty,
@@ -145,6 +145,11 @@ class StateMeta(ABCMeta):
 		except AttributeError:
 			return instance
 		initializer()
+		# Let the ambient scope track this instance so owners that capture a
+		# scope (ps.setup / ps.init) can dispose states created within it.
+		rc = REACTIVE_CONTEXT.get()
+		if rc.scope is not None:
+			rc.scope.register_state(instance)
 		return instance
 
 
@@ -353,8 +358,10 @@ class State(Disposable, metaclass=StateMeta):
 		"""
 		# Call user-defined cleanup hook first
 		self.on_dispose()
+		# Skip values another owner (or a previous loop iteration through an
+		# alias) already disposed.
 		for value in self.__dict__.values():
-			if isinstance(value, Disposable):
+			if isinstance(value, Disposable) and not value.__disposed__:
 				value.dispose()
 
 		undisposed_effects = [e for e in self._scope.effects if not e.__disposed__]

--- a/packages/pulse/python/src/pulse/transpiler/nodes.py
+++ b/packages/pulse/python/src/pulse/transpiler/nodes.py
@@ -780,6 +780,7 @@ class PulseNode:
 	# Renderer state (mutable, set during render)
 	hooks: Any = None  # HookContext
 	contents: Node | None = None
+	runtime: Any = None  # ComponentRuntime (persistent render state)
 
 	def emit(self, out: list[str]) -> None:
 		fn_name = getattr(self.fn, "__name__", "unknown")

--- a/packages/pulse/python/tests/test_fine_grained_rendering.py
+++ b/packages/pulse/python/tests/test_fine_grained_rendering.py
@@ -1,0 +1,338 @@
+"""Fine-grained rendering: per-component render effects.
+
+State changes re-render only the component that read the state, not the whole
+tree. These tests exercise the RenderTree dispatch machinery directly (no
+View/RenderSession), accumulating ops via tree.take_ops().
+"""
+
+from typing import cast
+
+import pulse as ps
+from pulse.reactive import Signal, flush_effects
+from pulse.renderer import RenderTree
+from pulse.transpiler.vdom import VDOMElement
+
+
+def test_leaf_state_change_rerenders_only_leaf():
+	leaf_signal = Signal(0)
+	renders = {"parent": 0, "leaf": 0, "sibling": 0}
+
+	@ps.component
+	def Leaf():
+		renders["leaf"] += 1
+		return ps.span(f"count: {leaf_signal()}")
+
+	@ps.component
+	def Sibling():
+		renders["sibling"] += 1
+		return ps.span("static")
+
+	@ps.component
+	def Parent():
+		renders["parent"] += 1
+		return ps.div(Leaf(), Sibling())
+
+	tree = RenderTree(Parent())
+	vdom = cast(VDOMElement, tree.render())
+	assert renders == {"parent": 1, "leaf": 1, "sibling": 1}
+	assert vdom == {
+		"tag": "div",
+		"children": [
+			{"tag": "span", "children": ["count: 0"]},
+			{"tag": "span", "children": ["static"]},
+		],
+	}
+
+	leaf_signal.write(1)
+	flush_effects()
+
+	assert renders == {"parent": 1, "leaf": 2, "sibling": 1}
+	ops = tree.take_ops()
+	assert ops == [
+		{
+			"type": "reconciliation",
+			"path": "0",
+			"N": 1,
+			"new": ([0], ["count: 1"]),
+			"reuse": ([], []),
+		}
+	]
+
+
+def test_parent_state_change_rerenders_subtree_once():
+	parent_signal = Signal("a")
+	child_signal = Signal(0)
+	renders = {"parent": 0, "child": 0}
+
+	@ps.component
+	def Child():
+		renders["child"] += 1
+		return ps.span(f"child: {child_signal()}")
+
+	@ps.component
+	def Parent():
+		renders["parent"] += 1
+		return ps.div(parent_signal(), Child())
+
+	tree = RenderTree(Parent())
+	tree.render()
+	assert renders == {"parent": 1, "child": 1}
+
+	# Parent and child deps change in the same batch: the parent re-renders
+	# first and refreshes the child, whose queued run then becomes a no-op.
+	parent_signal.write("b")
+	child_signal.write(1)
+	flush_effects()
+
+	assert renders == {"parent": 2, "child": 2}
+
+
+def test_child_state_change_does_not_rerun_parent():
+	child_signal = Signal(0)
+	renders = {"parent": 0, "child": 0}
+
+	@ps.component
+	def Child():
+		renders["child"] += 1
+		return ps.span(child_signal())
+
+	@ps.component
+	def Parent():
+		renders["parent"] += 1
+		return ps.div(Child())
+
+	tree = RenderTree(Parent())
+	tree.render()
+
+	for i in range(1, 4):
+		child_signal.write(i)
+		flush_effects()
+		assert renders["child"] == 1 + i
+		assert renders["parent"] == 1
+
+
+def test_unmounted_component_effect_is_disposed():
+	show = Signal(True)
+	leaf_signal = Signal(0)
+	renders = {"leaf": 0}
+
+	@ps.component
+	def Leaf():
+		renders["leaf"] += 1
+		return ps.span(leaf_signal())
+
+	@ps.component
+	def Parent():
+		if show():
+			return ps.div(Leaf())
+		return ps.div(ps.span("empty"))
+
+	tree = RenderTree(Parent())
+	tree.render()
+	assert renders["leaf"] == 1
+	runtimes = list(tree.iter_runtimes())
+	assert len(runtimes) == 2  # Parent + Leaf
+
+	show.write(False)
+	flush_effects()
+	tree.take_ops()
+
+	# The leaf is unmounted: its effect must no longer react to its state.
+	leaf_signal.write(1)
+	flush_effects()
+	assert renders["leaf"] == 1
+	assert tree.take_ops() == []
+	assert len(list(tree.iter_runtimes())) == 1
+
+
+def test_nested_component_ops_use_absolute_paths():
+	inner_signal = Signal("x")
+
+	@ps.component
+	def Inner():
+		return ps.span(inner_signal())
+
+	@ps.component
+	def Middle():
+		return ps.section(ps.p("intro"), Inner())
+
+	@ps.component
+	def Outer():
+		return ps.div(ps.h1("title"), Middle())
+
+	tree = RenderTree(Outer())
+	vdom = cast(VDOMElement, tree.render())
+	middle = cast(VDOMElement, vdom.get("children", [])[1])
+	assert middle.get("children", [])[1] == {"tag": "span", "children": ["x"]}
+
+	inner_signal.write("y")
+	flush_effects()
+	ops = tree.take_ops()
+	assert ops == [
+		{
+			"type": "reconciliation",
+			"path": "1.1",
+			"N": 1,
+			"new": ([0], ["y"]),
+			"reuse": ([], []),
+		}
+	]
+
+
+def test_callbacks_swept_per_component_pass():
+	toggle = Signal(True)
+	other_clicked: list[str] = []
+
+	@ps.component
+	def WithButton():
+		if toggle():
+			return ps.button("on", onClick=lambda: None)
+		return ps.span("off")
+
+	@ps.component
+	def OtherButton():
+		return ps.button("other", onClick=lambda: other_clicked.append("hit"))
+
+	@ps.component
+	def Root():
+		return ps.div(WithButton(), OtherButton())
+
+	tree = RenderTree(Root())
+	tree.render()
+	assert set(tree.callbacks) == {"0.onClick", "1.onClick"}
+
+	toggle.write(False)
+	flush_effects()
+	tree.take_ops()
+
+	# WithButton's callback is gone; OtherButton's untouched (it never re-ran).
+	assert set(tree.callbacks) == {"1.onClick"}
+	tree.callbacks["1.onClick"].fn()
+	assert other_clicked == ["hit"]
+
+
+def test_keyed_reorder_rebinds_component_paths():
+	order = Signal(["a", "b"])
+	signals = {"a": Signal(0), "b": Signal(0)}
+
+	@ps.component
+	def Item(name: str, key: str | None = None):
+		return ps.li(f"{name}:{signals[name]()}")
+
+	@ps.component
+	def Root():
+		return ps.ul(*[Item(name, key=name) for name in order()])
+
+	tree = RenderTree(Root())
+	vdom = cast(VDOMElement, tree.render())
+	items = [cast(VDOMElement, c) for c in vdom.get("children", [])]
+	assert [c.get("children", [])[0] for c in items] == ["a:0", "b:0"]
+
+	order.write(["b", "a"])
+	flush_effects()
+	tree.take_ops()
+
+	# After the reorder, item "a" lives at index 1; its update must target it.
+	signals["a"].write(7)
+	flush_effects()
+	ops = tree.take_ops()
+	assert ops == [
+		{
+			"type": "reconciliation",
+			"path": "1",
+			"N": 1,
+			"new": ([0], ["a:7"]),
+			"reuse": ([], []),
+		}
+	]
+
+
+def test_pause_and_resume_effects():
+	leaf_signal = Signal(0)
+	renders = {"leaf": 0}
+
+	@ps.component
+	def Leaf():
+		renders["leaf"] += 1
+		return ps.span(leaf_signal())
+
+	tree = RenderTree(Leaf())
+	tree.render()
+
+	tree.pause_effects()
+	leaf_signal.write(1)
+	flush_effects()
+	assert renders["leaf"] == 1
+
+	tree.resume_effects()
+	flush_effects()
+	assert renders["leaf"] == 2
+	ops = tree.take_ops()
+	assert ops == [
+		{
+			"type": "reconciliation",
+			"path": "",
+			"N": 1,
+			"new": ([0], [1]),
+			"reuse": ([], []),
+		}
+	]
+
+
+def test_sibling_updates_in_one_batch_emit_separate_precise_ops():
+	left = Signal(0)
+	right = Signal(0)
+
+	@ps.component
+	def Left():
+		return ps.span(f"L{left()}")
+
+	@ps.component
+	def Right():
+		return ps.span(f"R{right()}")
+
+	@ps.component
+	def Root():
+		return ps.div(Left(), Right())
+
+	tree = RenderTree(Root())
+	tree.render()
+
+	left.write(1)
+	right.write(2)
+	flush_effects()
+	ops = tree.take_ops()
+	assert sorted(op["path"] for op in ops) == ["0", "1"]
+	assert all(op["type"] == "reconciliation" for op in ops)
+
+
+def test_parent_unmounting_child_in_same_batch_skips_child_effect():
+	"""Parent and child both read the same signal; the parent's re-render
+	unmounts the child, whose queued effect must not run afterwards."""
+	show = Signal(True)
+	renders = {"parent": 0, "child": 0}
+
+	@ps.component
+	def Child():
+		renders["child"] += 1
+		return ps.span(f"child sees {show()}")
+
+	@ps.component
+	def Parent():
+		renders["parent"] += 1
+		if show():
+			return ps.div(Child())
+		return ps.div(ps.span("empty"))
+
+	tree = RenderTree(Parent())
+	tree.render()
+	assert renders == {"parent": 1, "child": 1}
+
+	show.write(False)
+	flush_effects()
+
+	# The child was unmounted by the parent's pass; its queued run is skipped.
+	assert renders == {"parent": 2, "child": 1}
+	ops = tree.take_ops()
+	assert ops and all(op["path"].startswith("") for op in ops)
+	assert len(list(tree.iter_runtimes())) == 1

--- a/packages/pulse/python/tests/test_hooks.py
+++ b/packages/pulse/python/tests/test_hooks.py
@@ -1,4 +1,4 @@
-from typing import override
+from typing import Any, override
 
 import pulse as ps
 import pytest
@@ -396,3 +396,167 @@ def test_pulse_route_returns_definition():
 	with ps.PulseContext(app=app, render=session, route=route_ctx):
 		definition = ps.pulse_route()
 		assert definition is route
+
+
+class TestSetupOwnership:
+	"""Effects/states created in a setup init function are owned by the setup
+	hook alone: never inline-cached, survive re-renders, disposed exactly once."""
+
+	def test_setup_effect_not_inline_cached_and_disposed_once(self):
+		from pulse.reactive import Signal, flush_effects
+		from pulse.renderer import RenderTree
+
+		sig = Signal(0)
+		events: list[str] = []
+
+		@ps.component
+		def Leaf():
+			def _init() -> dict[str, Any]:
+				@ps.effect
+				def on_mount():  # pyright: ignore[reportUnusedFunction]
+					events.append("mount")
+					return lambda: events.append("unmount")
+
+				return {}
+
+			ps.setup(_init)
+			return ps.div(f"{sig()}")
+
+		tree = RenderTree(Leaf())
+		tree.render()
+		flush_effects()
+		assert events == ["mount"]
+
+		# Re-render: the mount effect must survive (it used to be GC'd by the
+		# inline-effects hook because its callsite is unseen after render 1).
+		sig.write(1)
+		flush_effects()
+		assert events == ["mount"]
+
+		# Unmount disposes it exactly once (no dev-mode double-dispose error).
+		tree.unmount()
+		assert events == ["mount", "unmount"]
+
+	def test_setup_states_disposed_on_unmount(self):
+		from pulse.reactive import flush_effects
+		from pulse.renderer import RenderTree
+
+		instances: list[DummyState] = []
+
+		@ps.component
+		def Comp():
+			def _init():
+				st = DummyState()
+				instances.append(st)
+				return st
+
+			ps.setup(_init)
+			return ps.div()
+
+		tree = RenderTree(Comp())
+		tree.render()
+		flush_effects()
+		assert len(instances) == 1
+
+		tree.unmount()
+		assert instances[0].__disposed__
+		assert instances[0].dispose_calls == 1
+
+	def test_setup_key_change_disposes_previous_owned(self):
+		ctx = HookContext()
+		events: list[str] = []
+		instances: list[DummyState] = []
+
+		def _init(label: str):
+			st = DummyState()
+			instances.append(st)
+
+			@ps.effect
+			def eff():  # pyright: ignore[reportUnusedFunction]
+				events.append(f"run:{label}")
+				return lambda: events.append(f"cleanup:{label}")
+
+			return st
+
+		with ctx:
+			setup_key("a")
+			setup(_init, "a")
+		from pulse.reactive import flush_effects
+
+		flush_effects()
+		assert events == ["run:a"]
+
+		with ctx:
+			setup_key("b")
+			setup(_init, "b")
+		flush_effects()
+		assert instances[0].__disposed__
+		assert not instances[1].__disposed__
+		assert "cleanup:a" in events
+		assert "run:b" in events
+
+
+def test_externally_disposed_hook_state_is_surfaced_on_unmount(
+	caplog: pytest.LogCaptureFixture,
+):
+	"""ps.state owns its instances exclusively; if something else disposed one,
+	unmount must surface the double dispose instead of skipping silently."""
+	import logging
+
+	from pulse.renderer import RenderTree
+
+	captured: list[DummyState] = []
+
+	@ps.component
+	def Comp():
+		st = state(lambda: DummyState())
+		captured.append(st)
+		return ps.div()
+
+	tree = RenderTree(Comp())
+	tree.render()
+
+	# Forbidden: disposing a state returned by ps.state.
+	captured[0].dispose()
+
+	with caplog.at_level(logging.ERROR, logger="pulse.hooks.core"):
+		tree.unmount()
+
+	assert any(
+		"Error disposing hook 'pulse:core.state'" in record.getMessage()
+		for record in caplog.records
+	)
+
+
+def test_setup_owned_state_disposed_elsewhere_is_surfaced(
+	caplog: pytest.LogCaptureFixture,
+):
+	import logging
+
+	from pulse.renderer import RenderTree
+
+	captured: list[DummyState] = []
+
+	@ps.component
+	def Comp():
+		def _init():
+			st = DummyState()
+			captured.append(st)
+			return st
+
+		ps.setup(_init)
+		return ps.div()
+
+	tree = RenderTree(Comp())
+	tree.render()
+
+	# Forbidden: the setup initializer owns this state.
+	captured[0].dispose()
+
+	with caplog.at_level(logging.ERROR, logger="pulse.hooks.core"):
+		tree.unmount()
+
+	assert any(
+		"Error disposing hook 'pulse:core.setup'" in record.getMessage()
+		for record in caplog.records
+	)

--- a/packages/pulse/python/tests/test_init_hook.py
+++ b/packages/pulse/python/tests/test_init_hook.py
@@ -378,3 +378,212 @@ def test_init_exception_does_not_save_partial_locals() -> None:
 		assert calls["count"] == 1
 		assert cast(int, cast(object, example.fn())) == 1
 		assert calls["count"] == 2
+
+
+def test_init_disposes_states_and_effects_on_unmount() -> None:
+	from pulse.reactive import flush_effects
+	from pulse.renderer import RenderTree
+
+	events: list[str] = []
+
+	class S(ps.State):
+		count: int = 0
+
+		@ps.effect
+		def watch(self):
+			events.append(f"state:{self.count}")
+
+	captured: dict[str, Any] = {}
+
+	@ps.component
+	def Comp():
+		with ps.init():
+			st = S()
+
+			@ps.effect
+			def mount_only():  # pyright: ignore[reportUnusedFunction]
+				events.append("mount")
+				return lambda: events.append("unmount")
+
+		captured["st"] = st
+		return ps.div(f"{st.count}")
+
+	tree = RenderTree(Comp())
+	tree.render()
+	flush_effects()
+	assert events == ["state:0", "mount"]
+
+	# Re-render: the init block is skipped, its effects must survive.
+	st = captured["st"]
+	st.count = 1
+	flush_effects()
+	assert "unmount" not in events
+
+	tree.unmount()
+	assert st.__disposed__
+	assert events.count("unmount") == 1
+
+	# The state's effect is dead: further writes don't run it.
+	before = list(events)
+	st.count = 2
+	flush_effects()
+	assert events == before
+
+
+def test_init_effects_are_not_inline_cached() -> None:
+	"""Effects created in a ps.init block bypass the inline-effects hook, so
+	the inline GC for unseen callsites can't dispose them on re-renders."""
+	from pulse.hooks.effects import effect_state
+	from pulse.renderer import RenderTree
+
+	inline_counts: list[int] = []
+
+	@ps.component
+	def Comp():
+		with ps.init():
+
+			@ps.effect
+			def mount_only():  # pyright: ignore[reportUnusedFunction]
+				pass
+
+		inline_counts.append(len(effect_state().effects))
+		return ps.div()
+
+	tree = RenderTree(Comp())
+	tree.render()
+	assert inline_counts == [0]
+	tree.unmount()
+
+
+def test_init_key_change_disposes_previous_states() -> None:
+	from pulse.reactive import Signal, flush_effects
+	from pulse.renderer import RenderTree
+
+	class S(ps.State):
+		label: str = ""
+
+		def __init__(self, label: str):
+			self.label = label
+
+	key_sig = Signal("a")
+	instances: list[Any] = []
+
+	@ps.component
+	def Comp():
+		current = key_sig()
+		with ps.init(key=current):
+			st = S(current)
+		if st not in instances:
+			instances.append(st)
+		return ps.div(st.label)
+
+	tree = RenderTree(Comp())
+	tree.render()
+	flush_effects()
+	assert len(instances) == 1
+
+	key_sig.write("b")
+	flush_effects()
+	assert len(instances) == 2
+	assert instances[0].__disposed__
+	assert not instances[1].__disposed__
+
+	tree.unmount()
+	assert instances[1].__disposed__
+
+
+def test_init_does_not_own_shared_states() -> None:
+	"""States obtained through ps.state or ps.global_state inside a ps.init
+	block belong to their own stores, not to the init entry, so unmounting
+	one component must not dispose them."""
+	from pulse.reactive import flush_effects
+	from pulse.renderer import RenderTree
+
+	class Shared(ps.State):
+		value: int = 0
+
+	shared = ps.global_state(Shared, key="test-init-shared")
+	seen: list[Any] = []
+
+	@ps.component
+	def Comp():
+		with ps.init():
+			inst = shared(id="x")
+		seen.append(inst)
+		return ps.div(f"{inst.value}")
+
+	tree = RenderTree(Comp())
+	tree.render()
+	flush_effects()
+	tree.unmount()
+
+	assert not seen[0].__disposed__
+	# Cleanup the process-wide registry for test isolation.
+	from pulse.hooks.runtime import GLOBAL_STATES
+
+	GLOBAL_STATES.pop("test-init-shared|x", None)
+	seen[0].dispose()
+
+
+def test_init_parent_child_state_composition_disposes_cleanly() -> None:
+	"""A parent state disposing a child it holds as an attribute must not be
+	flagged: both are captured by the init scope, and whichever the entry
+	disposes first cascades into the other."""
+	from pulse.renderer import RenderTree
+
+	class Child(ps.State):
+		value: int = 0
+
+	class Parent(ps.State):
+		def __init__(self, child: Child):
+			self._child: Child = child
+
+	created: list[Any] = []
+
+	@ps.component
+	def Comp():
+		with ps.init():
+			child = Child()
+			parent = Parent(child)
+		created.append((child, parent))
+		return ps.div()
+
+	tree = RenderTree(Comp())
+	tree.render()
+	tree.unmount()
+	child, parent = created[0]
+	assert child.__disposed__ and parent.__disposed__
+
+
+def test_init_owned_state_disposed_elsewhere_is_surfaced(
+	caplog: pytest.LogCaptureFixture,
+) -> None:
+	import logging
+
+	from pulse.renderer import RenderTree
+
+	class S(ps.State):
+		value: int = 0
+
+	created: list[Any] = []
+
+	@ps.component
+	def Comp():
+		with ps.init():
+			st = S()
+		created.append(st)
+		return ps.div()
+
+	tree = RenderTree(Comp())
+	tree.render()
+
+	# Forbidden: the init block owns this state.
+	created[0].dispose()
+
+	with caplog.at_level(logging.ERROR, logger="pulse.hooks.core"):
+		tree.unmount()
+
+	assert any(
+		"Error disposing hook 'init_storage'" in record.getMessage()
+		for record in caplog.records
+	)

--- a/packages/pulse/python/tests/test_render_session.py
+++ b/packages/pulse/python/tests/test_render_session.py
@@ -14,6 +14,7 @@ import pytest
 from pulse import javascript
 from pulse.hooks.runtime import NotFoundInterrupt, RedirectInterrupt
 from pulse.messages import ServerMessage
+from pulse.reactive import RenderEffect
 from pulse.render_session import RenderSession
 from pulse.routing import Route, RouteInfo, RouteTree
 from pulse.test_helpers import wait_for
@@ -85,6 +86,13 @@ def attach_view(
 
 
 # TODO: clean this up - this was refactored using GPT-5 and is thus quite hacky
+def root_effect(view: Any) -> RenderEffect:
+	"""The render effect of the view's root component."""
+	runtime = next(iter(view.tree.iter_runtimes()))
+	assert runtime.effect is not None
+	return runtime.effect
+
+
 def mount_with_listener(session: RenderSession, path: str):
 	# Maintain a session-level set of listened paths and a shared message log
 	listened: set[str] | None = getattr(session, "_test_listened_paths", None)
@@ -776,8 +784,8 @@ async def test_disconnect_pauses_render_effects():
 		attach_view(session, "/a")
 
 	view = session.view_for_path("/a")
-	assert view.effect is not None
-	assert view.effect.paused is False
+	assert root_effect(view) is not None
+	assert root_effect(view).paused is False
 
 	# Disconnect should pause the effect (after queue timeout)
 	session.disconnect()
@@ -1096,22 +1104,22 @@ async def test_effect_paused_in_idle_state():
 		attach_view(session, "/a")
 
 	view = session.view_for_path("/a")
-	assert view.effect is not None
-	assert view.effect.paused is False
+	assert root_effect(view) is not None
+	assert root_effect(view).paused is False
 	assert view.state == "active"
 
 	# Disconnect puts view in PENDING state (not paused)
 	session.disconnect()
 	assert view.state == "pending"
-	assert view.effect.paused is False  # Still running in PENDING
+	assert root_effect(view).paused is False  # Still running in PENDING
 
 	# Manually trigger transition to IDLE (simulating timeout)
 	transition_view_to_idle(session, "/a")
 
 	# Now the effect should be paused
 	assert view.state == "idle"
-	assert view.effect.paused is True
-	assert view.effect.batch is None
+	assert root_effect(view).paused is True
+	assert root_effect(view).batch is None
 
 	session.close()
 
@@ -1145,8 +1153,8 @@ async def test_multiple_routes_idle_attach_requests_reload():
 	transition_view_to_idle(session, "/b")
 
 	# Both effects should now be paused
-	effect_a = view_a.effect
-	effect_b = view_b.effect
+	effect_a = root_effect(view_a)
+	effect_b = root_effect(view_b)
 	assert effect_a is not None
 	assert effect_b is not None
 	assert effect_a.paused is True
@@ -1621,7 +1629,7 @@ async def test_prerender_then_attach_works():
 	assert result["view"] == view.id
 	assert result["routePath"] == "/a"
 	assert view.state == "pending"
-	assert view.effect is not None  # Effect created during prerender
+	assert root_effect(view) is not None  # Effect created during prerender
 
 	# Now attach
 	messages: list[ServerMessage] = []
@@ -1666,8 +1674,9 @@ async def test_prerender_seeds_effect_deps_for_updates():
 		session.prerender(["/a"], None)
 
 	view = session.view_for_path("/a")
-	assert view.effect is not None
-	assert view.effect.runs == 0
+	assert root_effect(view) is not None
+	# The initial render ran inside the effect's dependency capture
+	assert root_effect(view).runs == 1
 
 	with ps.PulseContext.update(render=session):
 		session.attach(view.id, make_route_info("/a"))
@@ -1696,8 +1705,8 @@ async def test_prerender_keeps_views_for_unrendered_paths():
 
 	view_a = session.view_for_path("/a")
 	view_b = session.view_for_path("/b")
-	effect_a = view_a.effect
-	effect_b = view_b.effect
+	effect_a = root_effect(view_a)
+	effect_b = root_effect(view_b)
 	assert effect_a is not None
 	assert effect_b is not None
 	assert view_a.state == "active"
@@ -1712,11 +1721,11 @@ async def test_prerender_keeps_views_for_unrendered_paths():
 
 	assert result["type"] == "vdom_init"
 	assert session.view_for_path("/a") is view_a
-	assert view_a.effect is effect_a
+	assert root_effect(view_a) is effect_a
 	assert view_a.state == "pending"
 	assert view_a.route.query == "page=2"
 	assert session.view_for_path("/b") is view_b
-	assert view_b.effect is effect_b
+	assert root_effect(view_b) is effect_b
 
 	messages.clear()
 	session.update_route(view_a.id, nav_info)
@@ -1800,7 +1809,7 @@ async def test_detach_immediate_removes_view_and_disposes_effect():
 		attach_view(session, "/a")
 
 	view = session.view_for_path("/a")
-	effect = view.effect
+	effect = root_effect(view)
 	assert effect is not None
 
 	session.detach(view.id)
@@ -1988,14 +1997,14 @@ async def test_prerender_queue_timeout_transitions_to_idle():
 
 	view = session.view_for_path("/a")
 	assert view.state == "pending"
-	assert view.effect is not None
-	assert view.effect.paused is False
+	assert root_effect(view) is not None
+	assert root_effect(view).paused is False
 
 	# Manually trigger the timeout (simulating time passing)
 	transition_view_to_idle(session, "/a")
 
 	assert view.state == "idle"
-	assert view.effect.paused is True
+	assert root_effect(view).paused is True
 
 	session.close()
 
@@ -2013,8 +2022,8 @@ async def test_attach_from_idle_requests_reload():
 	view = session.view_for_path("/a")
 	transition_view_to_idle(session, "/a")
 	assert view.state == "idle"
-	assert view.effect is not None
-	assert view.effect.paused is True
+	assert root_effect(view) is not None
+	assert root_effect(view).paused is True
 
 	# Now attach
 	messages: list[ServerMessage] = []
@@ -2025,7 +2034,7 @@ async def test_attach_from_idle_requests_reload():
 
 	# Should request reload and leave the view idle
 	assert view.state == "idle"
-	assert view.effect.paused is True
+	assert root_effect(view).paused is True
 	assert len(messages) == 1
 	assert messages[0]["type"] == "reload"
 

--- a/packages/pulse/python/tests/test_renderer.py
+++ b/packages/pulse/python/tests/test_renderer.py
@@ -785,8 +785,8 @@ def test_keyed_parent_node_move_preserves_child_state():
 	assert hasattr(stored_hook_state, "storage")
 	# Find the captured counter in the storage
 	for entry in stored_hook_state.storage.values():
-		if "counter" in entry["vars"]:
-			stored_counter = entry["vars"]["counter"]
+		if "counter" in entry.vars:
+			stored_counter = entry.vars["counter"]
 			assert isinstance(stored_counter, Counter)
 			assert stored_counter.label == "A"
 			assert stored_counter.count == 1

--- a/packages/pulse/python/tests/test_serializer.py
+++ b/packages/pulse/python/tests/test_serializer.py
@@ -284,3 +284,28 @@ def test_js_exec_expr_can_include_element_payload():
 			"Done",
 		],
 	}
+
+
+def test_snapshot_render_disposes_inline_effects():
+	"""Serializing a renderable must not leak effects created during the
+	one-shot snapshot render."""
+	from pulse.reactive import Signal, flush_effects
+
+	sig = Signal(0)
+	runs: list[int] = []
+
+	@ps.component
+	def Toast():
+		@ps.effect(immediate=True)
+		def track():  # pyright: ignore[reportUnusedFunction]
+			runs.append(sig())
+
+		return ps.div(f"value: {sig()}")
+
+	serialize(Toast())
+	flush_effects()
+	assert runs == [0]
+
+	sig.write(1)
+	flush_effects()
+	assert runs == [0]

--- a/packages/pulse/python/tests/test_unowned_reactives.py
+++ b/packages/pulse/python/tests/test_unowned_reactives.py
@@ -1,0 +1,139 @@
+# pyright: reportUnusedFunction=false
+"""App(unowned_reactives=...): Effects/States constructed during a component
+render without an owner are flagged (error by default) instead of leaking."""
+
+import logging
+from typing import override
+
+import pulse as ps
+import pytest
+from pulse.app import App
+from pulse.reactive import Effect, Signal, flush_effects
+from pulse.renderer import RenderTree
+
+
+class Plain(ps.State):
+	count: int = 0
+
+
+class _HookOwnedState(ps.hooks.State):
+	owned: Plain
+
+	def __init__(self) -> None:
+		super().__init__()
+		self.owned = Plain()
+
+	@override
+	def dispose(self) -> None:
+		self.owned.dispose()
+
+
+def test_raw_effect_in_component_body_errors():
+	@ps.component
+	def Comp():
+		Effect(lambda: None, name="orphan")
+		return ps.div()
+
+	tree = RenderTree(Comp())
+	with pytest.raises(RuntimeError, match="orphan"):
+		tree.render()
+
+
+def test_raw_state_in_component_body_errors():
+	created: list[Plain] = []
+
+	@ps.component
+	def Comp():
+		state = Plain()
+		created.append(state)
+		return ps.div(f"{state.count}")
+
+	tree = RenderTree(Comp())
+	with pytest.raises(RuntimeError, match="Plain"):
+		tree.render()
+	# The orphan is disposed before raising so it cannot leak.
+	assert created[0].__disposed__
+
+
+def test_warn_policy_logs_and_renders(caplog: pytest.LogCaptureFixture):
+	@ps.component
+	def Comp():
+		Plain()
+		return ps.div("ok")
+
+	with ps.PulseContext(app=App(unowned_reactives="warn")):
+		tree = RenderTree(Comp())
+		with caplog.at_level(logging.WARNING, logger="pulse.renderer"):
+			vdom = tree.render()
+		tree.unmount()
+	assert vdom == {"tag": "div", "children": ["ok"]}
+	assert any("Plain" in record.message for record in caplog.records)
+
+
+def test_ignore_policy_renders_silently(caplog: pytest.LogCaptureFixture):
+	@ps.component
+	def Comp():
+		Plain()
+		return ps.div("ok")
+
+	with ps.PulseContext(app=App(unowned_reactives="ignore")):
+		tree = RenderTree(Comp())
+		with caplog.at_level(logging.WARNING, logger="pulse.renderer"):
+			tree.render()
+		tree.unmount()
+	assert not caplog.records
+
+
+# Registered at import time: some suites lock the hook registry mid-run.
+custom_hook = ps.hooks.create(
+	"test:unowned.owned-by-hook", factory=lambda: _HookOwnedState()
+)
+
+
+def test_owned_patterns_do_not_trigger():
+	sig = Signal(0)
+
+	class WithEffect(ps.State):
+		count: int = 0
+
+		@ps.effect
+		def watch(self):
+			_ = self.count
+
+	@ps.component
+	def Comp():
+		with ps.init():
+			a = WithEffect()
+		b = ps.state(lambda: Plain())
+		c = custom_hook()
+
+		@ps.effect
+		def inline():
+			_ = sig()
+
+		return ps.div(f"{a.count}{b.count}{c.render_cycle}")
+
+	tree = RenderTree(Comp())
+	tree.render()
+	flush_effects()
+	# Re-render must stay clean too.
+	sig.write(1)
+	flush_effects()
+	tree.unmount()
+
+
+def test_state_instance_passed_to_ps_state_is_adopted():
+	"""ps.state(SomeState()) constructs the instance in the component body;
+	the hook adopts it, so the check must not flag it."""
+
+	@ps.component
+	def Comp():
+		state = ps.state(Plain())
+		return ps.div(f"{state.count}")
+
+	tree = RenderTree(Comp())
+	tree.render()
+	# Re-render: the freshly constructed instance is disposed by the hook in
+	# favor of the cached one - still not a violation.
+	tree.rerender()
+	tree.unmount()


### PR DESCRIPTION
3/6 of the custom-framework merge train (stacked on #98).

Every server component owns a `RenderEffect`; state changes re-render only the components that read them, emitting one subtree-scoped `vdom_update` per component pass. Batches order render effects parents-first so a parent re-render absorbs queued child runs. Unmounts dispose component effects; idle views pause every component effect.

Ownership/disposal semantics ship with it: `ps.init`/`ps.setup` own the effects and states created inside them (disposed exactly once), foreign disposals are surfaced, and reactives created during render with no owner trip the new `App(unowned_reactives=...)` policy (`error`/`warn`/`ignore`).

**Review notes**
- All post-hoc fixes from the original branch are pre-folded (effect ownership, double/foreign dispose surfacing, snapshot-clone disposal, effect flush) — you review the corrected code once.
- This level intentionally runs fine-grained rendering against the **old React Router client** — a state that never existed historically. Validated live: counter, second counter, and layout-level shared state all update independently over the socket; `make all` green (includes the new `test_fine_grained_rendering`, `test_unowned_reactives`, `test_init_hook` suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)