### PR TITLE
WebSocket-native navigation with view reuse and VDOM prefetching

### DIFF
--- a/packages/pulse/js/src/client.tsx
+++ b/packages/pulse/js/src/client.tsx
@@ -13,6 +13,7 @@ import type {
 	ServerError,
 	ServerJsExecMessage,
 	ServerMessage,
+	ServerNavigateResultMessage,
 	ServerResumeMessage,
 } from "./messages";
 import type { PulsePrerenderView } from "./pulse";
@@ -93,6 +94,15 @@ export class PulseSocketIOClient {
 	#pendingResumeId: string | null = null;
 	#resumeSnapshotViews: Set<string> = new Set();
 	#resumeSnapshotChannels: Set<string> = new Set();
+	#nextNavId = 0;
+	#pendingNavigations: Map<
+		string,
+		{
+			resolve: (result: ServerNavigateResultMessage) => void;
+			reject: (error: Error) => void;
+			timer: ReturnType<typeof setTimeout>;
+		}
+	> = new Map();
 
 	constructor(
 		url: string,
@@ -239,7 +249,8 @@ export class PulseSocketIOClient {
 					}
 					if (
 						payload.type === "channel_connect" ||
-						payload.type === "channel_disconnect"
+						payload.type === "channel_disconnect" ||
+						payload.type === "navigate"
 					) {
 						continue;
 					}
@@ -472,6 +483,10 @@ export class PulseSocketIOClient {
 				this.#handleServerResume(message);
 				break;
 			}
+			case "navigate_result": {
+				this.#handleNavigateResult(message);
+				break;
+			}
 			case "attach_ack": {
 				this.#handleAttachAck(message.view, message.attachId);
 				break;
@@ -556,6 +571,49 @@ export class PulseSocketIOClient {
 		this.#queueCallback(message);
 	}
 
+	/**
+	 * Ask the server to render the views for a navigation (or prefetch them).
+	 * Rejects when the socket is down — callers fall back to HTTP prerender.
+	 */
+	public navigateViews(
+		routeInfo: RouteInfo,
+		options: { prefetch?: boolean; timeoutMs?: number } = {},
+	): Promise<ServerNavigateResultMessage> {
+		if (!this.isConnected() || this.#resumePending) {
+			return Promise.reject(new Error("Pulse socket is not connected"));
+		}
+		const nav = `nav-${++this.#nextNavId}`;
+		const promise = new Promise<ServerNavigateResultMessage>((resolve, reject) => {
+			const timer = setTimeout(() => {
+				this.#pendingNavigations.delete(nav);
+				reject(new Error("Navigation request timed out"));
+			}, options.timeoutMs ?? 15_000);
+			this.#pendingNavigations.set(nav, { resolve, reject, timer });
+		});
+		this.sendMessage({
+			type: "navigate",
+			nav,
+			routeInfo,
+			...(options.prefetch ? { prefetch: true } : {}),
+		});
+		return promise;
+	}
+
+	#handleNavigateResult(message: ServerNavigateResultMessage): void {
+		const pending = this.#pendingNavigations.get(message.nav);
+		if (!pending) return;
+		this.#pendingNavigations.delete(message.nav);
+		clearTimeout(pending.timer);
+		pending.resolve(message);
+	}
+
+	#rejectPendingNavigations(reason: string): void {
+		for (const pending of this.#pendingNavigations.values()) {
+			clearTimeout(pending.timer);
+			pending.reject(new Error(reason));
+		}
+		this.#pendingNavigations.clear();
+	}
 
 	#handleJsExec(message: ServerJsExecMessage) {
 		const view = this.#activeViews.get(message.view);
@@ -617,6 +675,7 @@ export class PulseSocketIOClient {
 		this.#ackedAttachIds.clear();
 		this.#resumePending = false;
 		this.#pendingResumeId = null;
+		this.#rejectPendingNavigations("Connection lost");
 		for (const entry of this.#channels.values()) {
 			entry.bridge.handleDisconnect(new PulseChannelResetError("Connection lost"));
 		}
@@ -738,6 +797,7 @@ export class PulseSocketIOClient {
 		if (
 			payload.type === "attach" ||
 			payload.type === "update" ||
+			payload.type === "navigate" ||
 			payload.type === "channel_connect" ||
 			payload.type === "client_resume"
 		) {

--- a/packages/pulse/js/src/messages.ts
+++ b/packages/pulse/js/src/messages.ts
@@ -101,6 +101,15 @@ export interface ServerResumeMessage {
 	channels?: ServerResumeChannel[];
 }
 
+export interface ServerNavigateResultMessage {
+	type: "navigate_result";
+	nav: string;
+	status: "ok" | "redirect" | "notFound" | "error";
+	redirect?: string;
+	// Route pattern path -> fresh init message, or null to keep the live view
+	views?: Record<string, ServerInitMessage | null>;
+}
+
 export interface ServerAttachAckMessage {
 	type: "attach_ack";
 	view: string;
@@ -122,6 +131,7 @@ export type ServerMessage =
 	| ServerNavigateToMessage
 	| ServerReloadMessage
 	| ServerResumeMessage
+	| ServerNavigateResultMessage
 	| ServerAttachAckMessage
 	| ServerChannelRequestMessage
 	| ServerChannelResponseMessage
@@ -148,6 +158,13 @@ export interface ClientUpdateMessage {
 export interface ClientDetachMessage {
 	type: "detach";
 	view: string;
+}
+
+export interface ClientNavigateMessage {
+	type: "navigate";
+	nav: string;
+	routeInfo: RouteInfo;
+	prefetch?: boolean;
 }
 
 export interface ClientResumeView {
@@ -222,6 +239,7 @@ export type ClientMessage =
 	| ClientCallbackMessage
 	| ClientUpdateMessage
 	| ClientDetachMessage
+	| ClientNavigateMessage
 	| ClientResumeMessage
 	| ClientApiResultMessage
 	| ClientChannelRequestMessage

--- a/packages/pulse/js/src/pulse.tsx
+++ b/packages/pulse/js/src/pulse.tsx
@@ -17,7 +17,7 @@ import {
 import { type ConnectionStatus, type Directives, PulseSocketIOClient } from "./client";
 import { buildRouteInfo, type RouteInfo } from "./helpers";
 import { replayPreHydrationInputs } from "./hydration";
-import type { ServerError, ServerInitMessage } from "./messages";
+import type { ServerError, ServerInitMessage, ServerNavigateResultMessage } from "./messages";
 import { VDOMRenderer } from "./renderer";
 import {
 	type NavigationTarget,
@@ -374,6 +374,10 @@ export interface PulseAppProps {
 }
 
 const DIRECTIVES_KEY = "__PULSE_DIRECTIVES";
+// Client-side cache lifetime for prefetched views. Must stay below the
+// server's pending-view TTL (60s) so a consumed prefetch always attaches to a
+// live view.
+const PREFETCH_TTL_MS = 30_000;
 
 function readStoredDirectives(): Directives {
 	if (!inBrowser || typeof sessionStorage === "undefined") {
@@ -472,9 +476,10 @@ function PulseFrameworkNavigationBinder({ client }: { client: PulseSocketIOClien
 /**
  * The Pulse application shell: router + socket client + route views.
  *
- * Navigation is server-driven: link clicks fetch the target's views from the
- * Python server via HTTP prerender, and the result commits atomically with
- * the location change.
+ * Navigation is server-driven: link clicks ask the Python server for the
+ * target's views over the WebSocket (falling back to HTTP prerender when the
+ * socket is down), and hovering a link prefetches both the route's JS chunks
+ * and its server-rendered views.
  */
 export function PulseApp({ routes, routeLoaders, config, prerender, url }: PulseAppProps) {
 	const [current, setCurrent] = useState(prerender);
@@ -499,6 +504,10 @@ export function PulseApp({ routes, routeLoaders, config, prerender, url }: Pulse
 		[config.serverAddress, config.connectionStatus],
 	);
 
+	const prefetches = useRef(
+		new Map<string, { at: number; promise: Promise<ServerNavigateResultMessage> }>(),
+	);
+
 	const requestViews = useCallback(
 		async (target: NavigationTarget): Promise<NavigationViews> => {
 			const routeInfo = buildRouteInfo(
@@ -506,15 +515,38 @@ export function PulseApp({ routes, routeLoaders, config, prerender, url }: Pulse
 				target.match.params,
 				target.match.catchall,
 			);
+			if (client.isConnected()) {
+				try {
+					return await client.navigateViews(routeInfo);
+				} catch {
+					// Socket unusable (resume in flight, dropped mid-request,
+					// timeout) - fall through to the HTTP prerender.
+				}
+			}
 			const paths = target.match.matches.map((route) => route.id);
 			return fetchPrerenderViews(config, paths, routeInfo);
 		},
-		[config],
+		[client, config],
 	);
 
 	const handleNavigate = useCallback(
 		async (target: NavigationTarget) => {
-			let result = await requestViews(target);
+			const key = target.location.pathname + target.location.search;
+			let result: NavigationViews | null = null;
+			const cached = prefetches.current.get(key);
+			if (cached) {
+				prefetches.current.delete(key);
+				if (Date.now() - cached.at < PREFETCH_TTL_MS) {
+					try {
+						result = await cached.promise;
+					} catch {
+						result = null;
+					}
+				}
+			}
+			if (result === null || result.status === "error") {
+				result = await requestViews(target);
+			}
 			if (result.status === "redirect") {
 				if (inBrowser) {
 					window.location.assign(result.redirect || "/");
@@ -553,6 +585,35 @@ export function PulseApp({ routes, routeLoaders, config, prerender, url }: Pulse
 		[requestViews],
 	);
 
+	const handlePrefetch = useCallback(
+		(target: NavigationTarget) => {
+			if (!client.isConnected()) {
+				return;
+			}
+			const now = Date.now();
+			for (const [staleKey, entry] of prefetches.current) {
+				if (now - entry.at >= PREFETCH_TTL_MS) {
+					prefetches.current.delete(staleKey);
+				}
+			}
+			const key = target.location.pathname + target.location.search;
+			const existing = prefetches.current.get(key);
+			if (existing && now - existing.at < PREFETCH_TTL_MS) {
+				return;
+			}
+			const routeInfo = buildRouteInfo(
+				target.location,
+				target.match.params,
+				target.match.catchall,
+			);
+			const promise = client.navigateViews(routeInfo, { prefetch: true });
+			promise.catch(() => {
+				prefetches.current.delete(key);
+			});
+			prefetches.current.set(key, { at: Date.now(), promise });
+		},
+		[client],
+	);
 
 	return (
 		<PulseRouterProvider
@@ -560,6 +621,7 @@ export function PulseApp({ routes, routeLoaders, config, prerender, url }: Pulse
 			routeLoaders={routeLoaders}
 			initialUrl={url}
 			onNavigate={handleNavigate}
+			onPrefetch={handlePrefetch}
 		>
 			<PulseFrameworkNavigationBinder client={client} />
 			<PulseProvider client={client} prerender={current}>

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -62,11 +62,13 @@ from pulse.messages import (
 	ClientChannelRequestMessage,
 	ClientChannelResponseMessage,
 	ClientMessage,
+	ClientNavigateMessage,
 	ClientPulseMessage,
 	Prerender,
 	PrerenderPayload,
 	ServerInitMessage,
 	ServerMessage,
+	ServerNavigateResultMessage,
 	ServerNavigateToMessage,
 )
 from pulse.middleware import (
@@ -271,6 +273,7 @@ class App:
 	_render_to_user: dict[str, str]
 	_sessions_in_request: dict[str, int]
 	_socket_to_render: dict[str, str]
+	_socket_requests: dict[str, PulseRequest]
 	_connecting_sockets: set[str]
 	_pending_socket_messages: dict[str, list[Serialized]]
 	_render_cleanups: dict[str, TimerHandleLike]
@@ -353,6 +356,7 @@ class App:
 		self._sessions_in_request = {}
 		# Map websocket sid -> renderId for message routing
 		self._socket_to_render = {}
+		self._socket_requests = {}
 		self._connecting_sockets = set()
 		self._pending_socket_messages = {}
 		# Map render_id -> cleanup timer handle for timeout-based expiry
@@ -934,6 +938,7 @@ class App:
 			except Exception:
 				self._connecting_sockets.discard(sid)
 				self._pending_socket_messages.pop(sid, None)
+				self._socket_requests.pop(sid, None)
 				self._socket_to_render.pop(sid, None)
 				raise
 			await self._drain_pending_socket_messages(sid)
@@ -981,6 +986,8 @@ class App:
 			# Map socket sid to renderId for message routing
 			self._socket_to_render[sid] = rid
 			pulse_request = PulseRequest.from_socketio_environ(environ, auth)
+			self._socket_requests[sid] = pulse_request
+
 			# Cancel any pending cleanup since session is now connected
 			self._cancel_render_cleanup(rid)
 
@@ -1015,6 +1022,7 @@ class App:
 		def disconnect(sid: str):  # pyright: ignore[reportUnusedFunction]
 			self._connecting_sockets.discard(sid)
 			self._pending_socket_messages.pop(sid, None)
+			self._socket_requests.pop(sid, None)
 			rid = self._socket_to_render.pop(sid, None)
 			if rid is not None:
 				render = self.render_sessions.get(rid)
@@ -1124,7 +1132,10 @@ class App:
 					)
 				else:
 					await self._handle_pulse_message(
-						render, session, cast(ClientPulseMessage, msg)
+						render,
+						session,
+						cast(ClientPulseMessage, msg),
+						request=self._socket_requests.get(sid),
 					)
 			except Exception as e:
 				render.report_error(msg.get("view"), "server", e)
@@ -1134,6 +1145,8 @@ class App:
 		render: RenderSession,
 		session: UserSession,
 		msg: ClientPulseMessage,
+		*,
+		request: PulseRequest | None = None,
 	) -> None:
 		async def _next() -> Ok[None]:
 			if msg["type"] == "attach":
@@ -1147,6 +1160,8 @@ class App:
 							"attachId": attach_id,
 						}
 					)
+			elif msg["type"] == "navigate":
+				await self._handle_navigate(render, session, msg, request)
 			elif msg["type"] == "client_resume":
 				render.resume(msg["resumeId"], msg["views"], msg["channels"])
 			elif msg["type"] == "update":
@@ -1188,6 +1203,118 @@ class App:
 					Exception("Request denied by server"),
 					{"kind": "deny"},
 				)
+
+	async def _handle_navigate(
+		self,
+		render: RenderSession,
+		session: UserSession,
+		msg: ClientNavigateMessage,
+		request: PulseRequest | None,
+	) -> None:
+		"""Render the views for a client navigation or hover prefetch.
+
+		The URL is matched against the Python route tree (the source of truth);
+		prerender middleware runs exactly as it does for HTTP prerenders.
+		"""
+		nav = msg["nav"]
+		route_info = msg["routeInfo"]
+
+		def reply(message: ServerNavigateResultMessage) -> None:
+			render.send(message)
+
+		match = self.routes.match(route_info["pathname"])
+		if match is None:
+			reply(
+				{
+					"type": "navigate_result",
+					"nav": nav,
+					"status": "notFound",
+					"redirect": self.not_found,
+				}
+			)
+			return
+		if request is None:
+			raise RuntimeError("Socket navigation is missing its connection request")
+
+		matched_routes, params = match
+		paths = [route.unique_path() for route in matched_routes]
+		info: RouteInfo = {
+			"pathname": route_info["pathname"],
+			"hash": route_info.get("hash", ""),
+			"query": route_info.get("query", ""),
+			"queryParams": route_info.get("queryParams", {}),
+			"pathParams": params.params,
+			"catchall": params.splat,
+		}
+		payload: PrerenderPayload = {"paths": paths, "routeInfo": info}
+
+		async def _process() -> PrerenderResponse:
+			results = render.navigate_views(paths, info)
+			views: dict[str, ServerInitMessage | ServerNavigateToMessage | None] = {}
+			for path in paths:
+				result = results[path]
+				if result is None or result["type"] == "vdom_init":
+					views[path] = result
+					continue
+				# A redirect/not-found interrupt was raised while rendering
+				nav_path = result["path"]
+				if result["replace"] and nav_path == self.not_found:
+					return NotFound()
+				return Redirect(path=str(nav_path) if nav_path else "/")
+			result_data: Prerender = {
+				"views": views,
+				"directives": {
+					"headers": {},
+					"query": {},
+					"socketio": {"auth": {}, "headers": {}, "query": {}},
+				},
+			}
+			return Ok(result_data)
+
+		try:
+			result = await self.middleware.prerender(
+				payload=payload,
+				request=request,
+				session=session.data,
+				next=_process,
+			)
+		except Exception as exc:
+			render.report_error(None, "navigate", exc)
+			reply({"type": "navigate_result", "nav": nav, "status": "error"})
+			return
+
+		if isinstance(result, Redirect):
+			reply(
+				{
+					"type": "navigate_result",
+					"nav": nav,
+					"status": "redirect",
+					"redirect": result.path or "/",
+				}
+			)
+		elif isinstance(result, NotFound):
+			reply(
+				{
+					"type": "navigate_result",
+					"nav": nav,
+					"status": "notFound",
+					"redirect": self.not_found,
+				}
+			)
+		elif isinstance(result, Ok):
+			reply(
+				{
+					"type": "navigate_result",
+					"nav": nav,
+					"status": "ok",
+					"views": cast(
+						dict[str, "ServerInitMessage | None"], result.payload["views"]
+					),
+				}
+			)
+		else:
+			# Denied by middleware
+			reply({"type": "navigate_result", "nav": nav, "status": "error"})
 
 	async def _handle_channel_message(
 		self,

--- a/packages/pulse/python/src/pulse/messages.py
+++ b/packages/pulse/python/src/pulse/messages.py
@@ -80,6 +80,21 @@ class ServerResumeMessage(TypedDict):
 	channels: NotRequired[list[ServerResumeChannel]]
 
 
+class ServerNavigateResultMessage(TypedDict):
+	"""Reply to a client navigate/prefetch request.
+
+	`views` maps each matched route pattern path to its freshly rendered init
+	message, or None when the client should keep using its live view for that
+	pattern (state persists across navigation).
+	"""
+
+	type: Literal["navigate_result"]
+	nav: str
+	status: Literal["ok", "redirect", "notFound", "error"]
+	redirect: NotRequired[str]
+	views: NotRequired[dict[str, "ServerInitMessage | None"]]
+
+
 class ServerAttachAckMessage(TypedDict):
 	type: Literal["attach_ack"]
 	view: str
@@ -156,6 +171,21 @@ class ClientDetachMessage(TypedDict):
 	view: str
 
 
+class ClientNavigateMessage(TypedDict):
+	"""Client-side navigation (or hover prefetch) over the socket.
+
+	The server re-matches `routeInfo.pathname` against the route tree (Python
+	is the source of truth), renders views for route patterns the session does
+	not have live yet, and replies with a navigate_result correlated by `nav`.
+	Prefetch requests render upcoming views without disturbing live ones.
+	"""
+
+	type: Literal["navigate"]
+	nav: str
+	routeInfo: RouteInfo
+	prefetch: NotRequired[bool]
+
+
 class ClientResumeView(TypedDict):
 	view: str
 	routeInfo: RouteInfo
@@ -230,6 +260,7 @@ ServerMessage = (
 	| ServerNavigateToMessage
 	| ServerReloadMessage
 	| ServerResumeMessage
+	| ServerNavigateResultMessage
 	| ServerAttachAckMessage
 	| ServerChannelMessage
 	| ServerJsExecMessage
@@ -241,6 +272,7 @@ ClientPulseMessage = (
 	| ClientAttachMessage
 	| ClientUpdateMessage
 	| ClientDetachMessage
+	| ClientNavigateMessage
 	| ClientResumeMessage
 	| ClientApiResultMessage
 	| ClientJsResultMessage

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -110,6 +110,10 @@ class View:
 	tree: RenderTree
 	session: Any
 	initialized: bool
+	# True once the client provably holds this view (HTTP prerender delivered
+	# it, or the client attached). Navigation reuse markers are only valid for
+	# delivered views.
+	delivered: bool
 	state: ViewState
 	pending_action: PendingAction | None
 	queue: list[ServerMessage] | None
@@ -132,6 +136,7 @@ class View:
 		self.tree = RenderTree(route.render())
 		self.tree.dispatch = self._dispatch_render
 		self.initialized = False
+		self.delivered = False
 		self.state = "pending"
 		self.pending_action = None
 		self.queue = []
@@ -197,6 +202,7 @@ class View:
 	def activate(self, send_message: Callable[[ServerMessage], Any]) -> None:
 		if self.state != "pending":
 			return
+		self.delivered = True
 		self._cancel_pending_timeout()
 		if self.queue:
 			for msg in self.queue:
@@ -445,12 +451,47 @@ class RenderSession:
 				# client's freshly initialized one.
 				view.queue = []
 			message = self.render(view)
+			view.delivered = True
 
 			results[path] = message
 			if message["type"] == "navigate_to":
 				self.dispose_view(view)
 				continue
 
+		return results
+
+	def navigate_views(
+		self, paths: list[str], route_info: RouteInfo
+	) -> dict[str, ServerInitMessage | ServerNavigateToMessage | None]:
+		"""Render views for a client navigation or prefetch.
+
+		Route patterns the session already has live (active or pending) views
+		for are returned as None: the client keeps using them and their route
+		info updates reactively after the navigation commits. Idle views are
+		disposed and rendered fresh. New views start pending with a dispose
+		TTL, so prefetched views that are never attached clean themselves up.
+		"""
+		results: dict[str, ServerInitMessage | ServerNavigateToMessage | None] = {}
+		for path in [ensure_absolute_path(p) for p in paths]:
+			view = self._views_by_path.get(path)
+			if view is not None and (view.state == "idle" or not view.delivered):
+				# Idle views are stale; undelivered pending views (an expired
+				# prefetch or a superseded navigation) were never committed
+				# client-side, so a reuse marker would dangle.
+				self.dispose_view(view)
+				view = None
+			if view is not None:
+				results[path] = None
+				continue
+			route = self.routes.find(path)
+			view = View(self, path, route, route_info)
+			self.views[view.id] = view
+			self._views_by_path[path] = view
+			view.start_pending(self.prerender_queue_timeout, action="dispose")
+			message = self.render(view)
+			results[path] = message
+			if message["type"] == "navigate_to":
+				self.dispose_view(view)
 		return results
 
 	# ---- Client lifecycle ----
@@ -484,7 +525,6 @@ class RenderSession:
 		channels: list[ClientResumeChannel],
 	) -> bool:
 		accepted_views: list[ServerResumeView] = []
-		accepted_ids: set[str] = set()
 
 		for declared in views:
 			view_id = declared["view"]
@@ -510,7 +550,6 @@ class RenderSession:
 					)
 				)
 				return False
-			accepted_ids.add(view_id)
 			resumed_view: ServerResumeView = {"view": view_id}
 			if attach_id := declared.get("attachId"):
 				resumed_view["attachId"] = attach_id
@@ -520,8 +559,8 @@ class RenderSession:
 		for channel in channels:
 			channel_id = str(channel.get("channel", ""))
 			view_id = str(channel.get("view", ""))
-			if view_id not in accepted_ids:
-				continue
+			# resume_client_channel validates view-bound channels against their
+			# owning view; channels without a view binding resume freely.
 			if self.channels.resume_client_channel(channel_id, view_id):
 				accepted_channels.append({"channel": channel_id, "view": view_id})
 

--- a/packages/pulse/python/tests/test_app_message_order.py
+++ b/packages/pulse/python/tests/test_app_message_order.py
@@ -27,7 +27,10 @@ async def test_socket_messages_for_render_are_serialized(
 	events: list[str] = []
 
 	async def handle_pulse_message(
-		_render: RenderSession, _session: UserSession, msg: ClientPulseMessage
+		_render: RenderSession,
+		_session: UserSession,
+		msg: ClientPulseMessage,
+		**_kwargs: object,
 	) -> None:
 		events.append(f"start:{msg['type']}")
 		if msg["type"] == "attach":
@@ -179,7 +182,10 @@ async def test_socket_messages_wait_for_connect_to_finish(
 	events: list[str] = []
 
 	async def handle_pulse_message(
-		_render: RenderSession, _session: UserSession, msg: ClientPulseMessage
+		_render: RenderSession,
+		_session: UserSession,
+		msg: ClientPulseMessage,
+		**_kwargs: object,
 	) -> None:
 		events.append(msg["type"])
 

--- a/packages/pulse/python/tests/test_channels.py
+++ b/packages/pulse/python/tests/test_channels.py
@@ -490,3 +490,27 @@ async def test_channel_pending_cancelled_on_render_close():
 	real_render.close()
 	with pytest.raises(ChannelClosed):
 		await pending
+
+
+def test_resume_accepts_unbound_channel():
+	app, render, session = make_route_render()
+	sent: list[dict[str, Any]] = []
+	render.send = sent.append  # pyright: ignore[reportAttributeAccessIssue]
+	with ps.PulseContext(app=app, session=session, render=render):
+		channel = render.channels.create("session-channel", bind_view=False)
+	connect_channel(render, channel)
+
+	ok = render.resume(
+		"resume-unbound",
+		[],
+		[{"channel": channel.id, "view": ""}],
+	)
+
+	assert ok is True
+	assert sent[-1] == {
+		"type": "server_resume",
+		"resumeId": "resume-unbound",
+		"status": "ok",
+		"views": [],
+		"channels": [{"channel": channel.id, "view": ""}],
+	}

--- a/packages/pulse/python/tests/test_ws_navigation.py
+++ b/packages/pulse/python/tests/test_ws_navigation.py
@@ -1,0 +1,245 @@
+"""WebSocket-native navigation: the client navigates by asking the server for
+the target's views over the socket. The server matches the URL against the
+Python route tree, reuses live views (state persists), and renders only the
+missing ones with a dispose TTL."""
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pulse as ps
+import pytest
+from pulse.messages import (
+	ClientNavigateMessage,
+	ServerMessage,
+	ServerNavigateResultMessage,
+)
+from pulse.render_session import RenderSession
+from pulse.request import PulseRequest
+from pulse.routing import RouteInfo
+from pulse.user_session import UserSession
+
+
+def make_route_info(pathname: str) -> RouteInfo:
+	return {
+		"pathname": pathname,
+		"hash": "",
+		"query": "",
+		"queryParams": {},
+		"pathParams": {},
+		"catchall": [],
+	}
+
+
+def make_request(pathname: str) -> PulseRequest:
+	return PulseRequest(
+		headers={},
+		cookies={},
+		scheme="http",
+		method="GET",
+		path=pathname,
+		query_string="",
+		client=None,
+	)
+
+
+def make_app() -> ps.App:
+	@ps.component
+	def layout():
+		return ps.div(ps.Outlet())
+
+	@ps.component
+	def home():
+		return ps.div("home")
+
+	@ps.component
+	def about():
+		return ps.div("about")
+
+	@ps.component
+	def gated():
+		ps.redirect("/about")
+		return ps.div("never")
+
+	return ps.App(
+		[
+			ps.Layout(
+				layout,
+				[
+					ps.Route("/", home),
+					ps.Route("about", about),
+					ps.Route("gated", gated),
+				],
+			)
+		]
+	)
+
+
+def setup_session(app: ps.App) -> tuple[RenderSession, Any, list[ServerMessage]]:
+	render = RenderSession("render-nav", app.routes)
+	session = SimpleNamespace(sid="session-nav", data={})
+	sent: list[ServerMessage] = []
+	render.connect(sent.append)
+	with ps.PulseContext(
+		app=app, session=cast(UserSession, cast(object, session)), render=render
+	):
+		render.prerender(["/<layout>", "/"], make_route_info("/"))
+		for path in ("/<layout>", "/"):
+			render.attach(render.view_for_path(path).id, make_route_info("/"))
+	return render, session, sent
+
+
+async def run_navigate(
+	app: ps.App,
+	render: RenderSession,
+	session: Any,
+	pathname: str,
+	nav: str = "nav-1",
+) -> ServerNavigateResultMessage:
+	msg: ClientNavigateMessage = {
+		"type": "navigate",
+		"nav": nav,
+		"routeInfo": make_route_info(pathname),
+	}
+	with ps.PulseContext(
+		app=app, session=cast(UserSession, cast(object, session)), render=render
+	):
+		await app._handle_navigate(  # pyright: ignore[reportPrivateUsage]
+			render,
+			cast(UserSession, cast(object, session)),
+			msg,
+			make_request(pathname),
+		)
+	sent = [m for m in render_sent[id(render)] if m["type"] == "navigate_result"]
+	return sent[-1]
+
+
+render_sent: dict[int, list[ServerMessage]] = {}
+
+
+@pytest.mark.asyncio
+async def test_navigate_reuses_live_views_and_renders_missing_ones():
+	app = make_app()
+	render, session, sent = setup_session(app)
+	render_sent[id(render)] = sent
+
+	result = await run_navigate(app, render, session, "/about")
+
+	assert result["status"] == "ok"
+	views = result.get("views")
+	assert views is not None
+	# The layout survives the navigation: the client keeps its live view.
+	assert views["/<layout>"] is None
+	about = views["/about"]
+	assert about is not None and about["type"] == "vdom_init"
+	assert about["routePath"] == "/about"
+
+	# The fresh view is pending with a dispose TTL until the client attaches.
+	view = render.view_for_path("/about")
+	assert view.id == about["view"]
+	assert view.state == "pending"
+	assert view.pending_action == "dispose"
+
+	# The home view was not disturbed (the client detaches it after committing).
+	assert render.view_for_path("/").state == "active"
+
+
+@pytest.mark.asyncio
+async def test_navigate_redirect_interrupt_reports_redirect():
+	app = make_app()
+	render, session, sent = setup_session(app)
+	render_sent[id(render)] = sent
+
+	result = await run_navigate(app, render, session, "/gated")
+
+	assert result["status"] == "redirect"
+	assert result.get("redirect") == "/about"
+	# The interrupted view must not linger.
+	with pytest.raises(ValueError):
+		render.view_for_path("/gated")
+
+
+@pytest.mark.asyncio
+async def test_navigate_unknown_path_reports_not_found():
+	app = make_app()
+	render, session, sent = setup_session(app)
+	render_sent[id(render)] = sent
+
+	result = await run_navigate(app, render, session, "/nope")
+
+	assert result["status"] == "notFound"
+	assert result.get("redirect") == app.not_found
+
+
+@pytest.mark.asyncio
+async def test_navigate_disposes_idle_views_and_renders_fresh():
+	app = make_app()
+	render, session, sent = setup_session(app)
+	render_sent[id(render)] = sent
+
+	# Simulate the about view going idle from an earlier visit.
+	with ps.PulseContext(
+		app=app, session=cast(UserSession, cast(object, session)), render=render
+	):
+		render.prerender(["/about"], make_route_info("/about"))
+	old_view = render.view_for_path("/about")
+	old_view.to_idle()
+	assert old_view.state == "idle"
+
+	result = await run_navigate(app, render, session, "/about")
+
+	assert result["status"] == "ok"
+	views = result.get("views")
+	assert views is not None
+	about = views["/about"]
+	assert about is not None
+	assert about["view"] != old_view.id
+	assert render.view_for_path("/about").id == about["view"]
+
+
+@pytest.mark.asyncio
+async def test_navigate_does_not_reuse_undelivered_prefetched_views():
+	"""A pending view from an unconsumed prefetch was never committed
+	client-side; navigating there must render fresh instead of sending a
+	dangling reuse marker."""
+	app = make_app()
+	render, session, sent = setup_session(app)
+	render_sent[id(render)] = sent
+
+	first = await run_navigate(app, render, session, "/about", nav="prefetch-1")
+	assert first["status"] == "ok"
+	views = first.get("views")
+	assert views is not None
+	prefetched = views["/about"]
+	assert prefetched is not None
+	# Never consumed: the view stays pending and undelivered.
+
+	second = await run_navigate(app, render, session, "/about", nav="nav-2")
+	assert second["status"] == "ok"
+	views2 = second.get("views")
+	assert views2 is not None
+	fresh = views2["/about"]
+	assert fresh is not None, "undelivered pending view must not be reused"
+	assert fresh["view"] != prefetched["view"]
+
+
+@pytest.mark.asyncio
+async def test_navigate_reuses_attached_views_only_after_delivery():
+	app = make_app()
+	render, session, sent = setup_session(app)
+	render_sent[id(render)] = sent
+
+	first = await run_navigate(app, render, session, "/about", nav="nav-1")
+	views = first.get("views")
+	assert views is not None
+	about = views["/about"]
+	assert about is not None
+	# The client commits and attaches: the view becomes delivered.
+	with ps.PulseContext(
+		app=app, session=cast(UserSession, cast(object, session)), render=render
+	):
+		render.attach(about["view"], make_route_info("/about"))
+
+	second = await run_navigate(app, render, session, "/about", nav="nav-2")
+	views2 = second.get("views")
+	assert views2 is not None
+	assert views2["/about"] is None, "attached views are reused"


### PR DESCRIPTION
5/6 of the custom-framework merge train (stacked on #100).

Navigation moves from HTTP prerender fetches onto the Pulse protocol: the client sends a `navigate` message, the server matches the URL against the Python route tree, runs prerender middleware, and replies with rendered views only for route patterns the session doesn't have live. Surviving patterns are reused — views stay mounted, state persists, route info syncs reactively after the commit. Fresh views start pending with a dispose TTL so abandoned navigations and unconsumed prefetches clean themselves up.

Hovering a `Link` prefetches the route's JS chunks and its server-rendered views; the click consumes the cache (hover+click = one navigate message). Same-pathname navigations (query/hash) skip the server. HTTP prerender remains as the socket-down fallback and for initial SSR.

Also relaxes resume: channels without a view binding resume freely; view-bound channels validate against their owning view (deferred from earlier levels together with its test).

**Validated**: `make all` green (includes `test_ws_navigation`); live: navigation to /about over the socket with **zero** HTTP prerender calls, and layout-level state persisting across navigation (view reuse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)