### PR TITLE
Docs: cross-feature documentation sweep for the new stack

### DIFF
--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -19,7 +19,7 @@
 
 ## 5. Test the setup flow
 - Run through `setup.mdx` on a fresh machine to catch missing steps
-- The React Router scaffolding command may have changed
+- The web project is now copied from `examples/web/` (no scaffolding command yet); verify that flow works outside the monorepo
 
 ## 6. Get feedback
 - Have someone unfamiliar with Pulse read Getting Started and first few tutorial pages

--- a/docs/content/docs/(core)/advanced/channels.mdx
+++ b/docs/content/docs/(core)/advanced/channels.mdx
@@ -169,7 +169,12 @@ def ChatClient(*, channelId: str):
         # This runs in the browser when the server emits "new_message"
         console.log("Got message:", payload)
 
-    useEffect(lambda: bridge.on("new_message", on_new_message), [bridge])
+    def subscribe():
+        if not bridge:
+            return  # bridge is null until the channel is acquired
+        return bridge.on("new_message", on_new_message)
+
+    useEffect(subscribe, [bridge])
 
     # Send events to the server
     def send_message(text: str):
@@ -183,14 +188,14 @@ def ChatClient(*, channelId: str):
 
 A note on `@ps.javascript`: This decorator lets you write JavaScript logic that runs in the browser. The code inside looks like Python but transpiles to JavaScript. This is useful when you need browser APIs (like `localStorage`, `window`, or DOM manipulation) or want to optimize performance by keeping some logic client-side.
 
-The `usePulseChannel` hook returns a bridge object with three methods:
+The `usePulseChannel` hook returns `null` until the channel is acquired (after the first render), then a bridge object with three methods:
 - `on(event, handler)` - Listen for events from the server
 - `emit(event, payload)` - Send events to the server (fire-and-forget)
 - `request(event, payload)` - Send a request and await the server's response
 
 ## Channel lifecycle
 
-Channels are tied to the route where they're created. When the user navigates to a different route, the channel closes automatically and resources are cleaned up. This prevents memory leaks and stale connections.
+Channels are tied to the view (the rendered page) where they're created. When that view is disposed—because the user navigated somewhere its route no longer matches—the channel closes automatically and resources are cleaned up. This prevents memory leaks and stale connections. Views that survive a navigation (like a layout during sibling navigation) keep their channels alive.
 
 If you need a channel that persists across route changes (like a global notification system), create it at a higher level in your component tree, such as in a layout component.
 

--- a/docs/content/docs/(core)/glossary.mdx
+++ b/docs/content/docs/(core)/glossary.mdx
@@ -178,7 +178,19 @@ Dynamic URL segments like `/users/:id`. The `:id` part matches any value and is 
 Key-value pairs in the URL after `?`, like `?page=2&sort=name`. Used for filters, pagination, and other optional state.
 
 **Navigation**
-Programmatically changing the URL and rendering a different route. Can be client-side (no page reload) or a full redirect.
+Programmatically changing the URL and rendering a different route. Can be client-side (no page reload) or a full redirect. In Pulse, client-side navigation flows over the WebSocket: the server matches the new URL, renders the new views, and reuses views whose route still matches—so their state survives the navigation.
+
+**View**
+A single rendered route or layout instance for one browser tab. Each view has a unique server-generated ID, and everything scoped to that page—callbacks, channels, refs—is tied to it. Views whose route still matches after a navigation are reused with their state intact; the rest are disposed.
+
+**Prefetching**
+Loading a page's resources before the user clicks. Pulse links prefetch both the route's JavaScript chunks and the server-rendered views (on hover by default), so clicking commits instantly.
+
+**Route Manifest**
+The generated `routes.ts` file mirroring your Python route tree on the client. It exports `pulseRouteTree` (the route structure, used for client-side matching) and `routeLoaders` (dynamic imports that code-split the bundle per route). The Python route tree remains the source of truth.
+
+**SSR Server**
+A small Bun process that renders the initial HTML for page requests. `pulse run` starts it alongside the Python server; in single-server mode the Python server forwards page requests to it and serves everything from one origin.
 
 ## Sessions & State Persistence
 

--- a/docs/content/docs/(core)/mental-model.mdx
+++ b/docs/content/docs/(core)/mental-model.mdx
@@ -39,7 +39,7 @@ In detail:
 3. **User interacts** — When someone clicks a button or types in an input, that event travels back to your Python code over WebSocket
 4. **State updates trigger re-render** — Your event handler updates state, Pulse re-runs your component, computes new changes, and the cycle continues
 
-This "diff and patch" approach is borrowed from React. It keeps updates fast even for complex UIs.
+This "diff and patch" approach is borrowed from React. It keeps updates fast even for complex UIs. Rendering is fine-grained: each component tracks the state it reads, so a state change re-runs only the components that depend on it—not the whole page—and only their changes are sent to the browser.
 
 ## Sessions and isolation
 

--- a/docs/content/docs/(core)/tutorial/01-basics.mdx
+++ b/docs/content/docs/(core)/tutorial/01-basics.mdx
@@ -84,7 +84,7 @@ Save your code to a file (e.g., `app.py`) and run:
 uv run pulse run app.py
 ```
 
-Open the URL shown in your terminal (usually http://localhost:5173) to see your app in action.
+Open the URL shown in your terminal (usually http://localhost:8000) to see your app in action.
 
 ## See also
 

--- a/docs/content/docs/(core)/tutorial/index.mdx
+++ b/docs/content/docs/(core)/tutorial/index.mdx
@@ -22,7 +22,7 @@ Create a file (e.g., `app.py`) and run it with:
 uv run pulse run path/to/app.py
 ```
 
-Your terminal will show two panes: the Python server on the left and the React app on the right. Visit the URL shown (usually http://localhost:5173) to see your app. Use `q` to stop.
+Your terminal will show the logs of the Python server and the web servers (assets + SSR), each with its own tag. Visit the URL shown (usually http://localhost:8000) to see your app.
 
 Pulse automatically reloads when you make changes during development, so you can iterate quickly.
 

--- a/docs/content/docs/packages/pulse-js-client.mdx
+++ b/docs/content/docs/packages/pulse-js-client.mdx
@@ -35,33 +35,33 @@ When you build a Pulse application, the Python server generates a virtual DOM (V
 The client is automatically included when you create a Pulse app. You don't need to install it manually unless you're building custom integrations.
 
 ```bash
-bun add pulse-client
+bun add pulse-ui-client
 ```
 
 ## Key Components
 
-### PulseProvider
+### PulseApp
 
-The root provider that establishes the WebSocket connection to your server.
+The all-in-one app shell: the built-in router, the WebSocket client, and the route renderer in one component. The generated `web/app/pulse/_layout.tsx` wraps it with your app's configuration.
 
 ```tsx
-import { PulseProvider } from "pulse-client";
+import { PulseApp } from "pulse-ui-client";
 
-function App() {
-  return (
-    <PulseProvider config={{ serverUrl: "http://localhost:8000" }}>
-      <Routes />
-    </PulseProvider>
-  );
-}
+<PulseApp
+  routes={pulseRouteTree}
+  routeLoaders={routeLoaders}
+  config={config}
+  prerender={prerender}
+  url={url}
+/>
 ```
 
 ### PulseView
 
-Renders a server-driven view for a specific route.
+Renders a server-driven view for a route. The generated route modules render this for you.
 
 ```tsx
-import { PulseView } from "pulse-client";
+import { PulseView } from "pulse-ui-client";
 
 function Dashboard() {
   return <PulseView path="/dashboard" registry={registry} />;
@@ -73,7 +73,7 @@ function Dashboard() {
 Hook to access the client instance for advanced use cases.
 
 ```tsx
-import { usePulseClient } from "pulse-client";
+import { usePulseClient } from "pulse-ui-client";
 
 function MyComponent() {
   const client = usePulseClient();
@@ -83,20 +83,23 @@ function MyComponent() {
 
 ### usePulseChannel
 
-Hook for real-time bidirectional messaging between client and server.
+Hook for real-time bidirectional messaging between client and server. Returns `null` until the channel is acquired.
 
 ```tsx
-import { usePulseChannel } from "pulse-client";
+import { usePulseChannel } from "pulse-ui-client";
 
 function Chat() {
   const channel = usePulseChannel("chat");
 
-  channel.on("new_message", (msg) => {
-    // Handle incoming message
-  });
+  useEffect(() => {
+    if (!channel) return;
+    return channel.on("new_message", (msg) => {
+      // Handle incoming message
+    });
+  }, [channel]);
 
   const sendMessage = () => {
-    channel.emit("message", { text: "Hello" });
+    channel?.emit("message", { text: "Hello" });
   };
 }
 ```
@@ -105,14 +108,14 @@ function Chat() {
 
 ### PulseForm
 
-A form component that handles submission and serialization.
+A form component that submits via `fetch` so the view stays mounted during submission.
 
 ```tsx
-import { PulseForm, submitForm } from "pulse-client";
+import { PulseForm } from "pulse-ui-client";
 
 function MyForm() {
   return (
-    <PulseForm onSubmit={(data) => console.log(data)}>
+    <PulseForm action="/api/submit">
       <input name="email" />
       <button type="submit">Submit</button>
     </PulseForm>
@@ -125,7 +128,7 @@ function MyForm() {
 The client provides utilities for serializing and deserializing data between Python and JavaScript.
 
 ```tsx
-import { serialize, deserialize } from "pulse-client";
+import { serialize, deserialize } from "pulse-ui-client";
 
 // Serialize data for sending to server
 const wire = serialize({ date: new Date() });
@@ -137,19 +140,23 @@ const data = deserialize(wire);
 ## Exports
 
 **Components:**
-- `PulseProvider` - Root provider for connection management
+- `PulseApp` - All-in-one app shell (router + provider + routes)
+- `PulseProvider` - Context provider for the WebSocket client
 - `PulseView` - Renders server-driven views
 - `PulseForm` - Form handling component
+- `Link`, `Outlet`, `PulseRouterProvider`, `PulseRoutes` - Built-in router
 
 **Hooks:**
 - `usePulseClient()` - Access the client instance
 - `usePulseChannel(name)` - Real-time messaging
+- `useNavigate()`, `useLocation()`, `useParams()`, `useRouteInfo()` - Router hooks
 
 **Functions:**
 - `serialize` - Convert data for wire transfer
 - `deserialize` - Parse data from wire format
 - `submitForm` - Programmatic form submission
-- `extractServerRouteInfo` - Extract route information
+- `matchRoutes` - Match a pathname against the route manifest
+- `buildRouteInfo` - Build a `RouteInfo` from a location
 
 **Types:**
 - `VDOM`, `VDOMNode`, `VDOMElement` - Virtual DOM types

--- a/docs/content/docs/reference/pulse-client/classes.mdx
+++ b/docs/content/docs/reference/pulse-client/classes.mdx
@@ -226,7 +226,8 @@ Converts VDOM trees to React elements and applies incremental updates. This is u
 class VDOMRenderer {
   constructor(
     client: PulseSocketIOClient,
-    path: string,
+    channels: PulseChannelManager,
+    viewId: string,
     registry?: ComponentRegistry
   );
 
@@ -242,7 +243,8 @@ class VDOMRenderer {
 ```ts
 constructor(
   client: PulseSocketIOClient,
-  path: string,
+  channels: PulseChannelManager,
+  viewId: string,
   registry?: ComponentRegistry
 )
 ```
@@ -250,7 +252,8 @@ constructor(
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `client` | `PulseSocketIOClient` | The Pulse client for callbacks |
-| `path` | `string` | View path for callback routing |
+| `channels` | `PulseChannelManager` | Channel manager for the view (used by refs) |
+| `viewId` | `string` | Unique id of the view, used to scope callbacks |
 | `registry` | `ComponentRegistry` | Optional component registry |
 
 ### Methods
@@ -316,16 +319,22 @@ evaluateExpr(expr: VDOMNode): unknown
 ### Example: Custom Renderer
 
 ```tsx
-import { VDOMRenderer, usePulseClient, usePulsePrerender } from "pulse-ui-client";
-import { useMemo, useState, useEffect } from "react";
+import {
+  VDOMRenderer,
+  usePulseClient,
+  usePulseChannelManagerForView,
+  usePulsePrerender,
+} from "pulse-ui-client";
+import { useMemo, useState } from "react";
 
 function CustomView({ path }: { path: string }) {
   const client = usePulseClient();
-  const prerender = usePulsePrerender(path);
+  const prerender = usePulsePrerender(path); // { view, routePath, vdom }
+  const channels = usePulseChannelManagerForView(prerender.view);
 
   const renderer = useMemo(
-    () => new VDOMRenderer(client, path, {}),
-    [client, path]
+    () => new VDOMRenderer(client, channels, prerender.view, {}),
+    [client, channels, prerender.view]
   );
 
   const [tree, setTree] = useState(() => renderer.init(prerender));

--- a/docs/content/docs/reference/pulse-client/components.mdx
+++ b/docs/content/docs/reference/pulse-client/components.mdx
@@ -9,31 +9,36 @@ React components for building Pulse applications.
 
 ---
 
-## PulseProvider
+## PulseApp
 
-Root context provider that establishes the WebSocket connection and provides the Pulse client to descendant components. Wrap your entire app (or the portion using Pulse) with this component.
+The all-in-one app shell. Composes the Pulse router (`PulseRouterProvider`), the WebSocket client (`PulseProvider`), and the route renderer (`PulseRoutes`). The generated `web/app/pulse/_layout.tsx` exports a `PulseApp` wrapper with your app's configuration baked in—your entry files render it, and global providers wrap it.
 
 ```tsx
-import { PulseProvider } from "pulse-ui-client";
+import { PulseApp } from "pulse-ui-client";
 
-function PulseProvider(props: PulseProviderProps): ReactNode
+function PulseApp(props: PulseAppProps): ReactNode
 ```
 
 ### Props
 
 ```ts
-interface PulseProviderProps {
-  children: ReactNode;
+interface PulseAppProps {
+  routes: PulseRoute[];
+  routeLoaders: RouteLoaderMap;
   config: PulseConfig;
   prerender: PulsePrerender;
+  /** URL of the initial request; required for SSR. */
+  url?: string;
 }
 ```
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `children` | `ReactNode` | Child components to render |
+| `routes` | `PulseRoute[]` | The generated route manifest (`pulseRouteTree`) |
+| `routeLoaders` | `RouteLoaderMap` | Dynamic imports for each route's module |
 | `config` | `PulseConfig` | Connection and status configuration |
 | `prerender` | `PulsePrerender` | Prerendered views and directives from SSR |
+| `url` | `string` | URL of the initial request (required for SSR) |
 
 ### PulseConfig
 
@@ -53,7 +58,7 @@ interface ConnectionStatusConfig {
 
 The connection status configuration controls when status messages appear:
 
-- **initialConnectingDelay** - How long to wait before showing "Connecting..." on first load. A small delay (e.g., 500ms) prevents flash on fast connections.
+- **initialConnectingDelay** - How long to wait before showing "Connecting..." on first load. A small delay prevents flash on fast connections.
 - **initialErrorDelay** - How long to wait before showing an error if initial connection fails.
 - **reconnectErrorDelay** - How long to wait before showing an error when reconnecting after disconnect.
 
@@ -71,53 +76,51 @@ interface PulsePrerender {
 }
 
 interface PulsePrerenderView {
+  view: string;       // Unique id of the server-side view
+  routePath: string;  // Route pattern path (e.g. "/users/:id")
   vdom: VDOM;
 }
 
 interface Directives {
   headers?: Record<string, string>;
+  query?: Record<string, string>;
   socketio?: SocketIODirectives;
 }
 
 interface SocketIODirectives {
   headers?: Record<string, string>;
   auth?: Record<string, string>;
+  query?: Record<string, string>;
 }
 ```
 
-The `prerender` prop contains server-side rendered content and connection directives. In a typical setup, this comes from your SSR loader.
+The `prerender` prop contains the server-rendered views (keyed by route pattern path) and connection directives. In a typical setup, the SSR server embeds it in the HTML as `window.__PULSE_PRERENDER__` and `src/entry-client.tsx` deserializes it.
 
 ### Example
 
 ```tsx
-import { PulseProvider } from "pulse-ui-client";
-import { BrowserRouter } from "react-router";
+// src/entry-client.tsx
+import { deserialize, preloadRoutesForPath, type PulsePrerender } from "pulse-ui-client";
+import { hydrateRoot } from "react-dom/client";
+import { PulseApp } from "../app/pulse/_layout";
+import { pulseRouteTree, routeLoaders } from "../app/pulse/routes";
 
-function App() {
-  return (
-    <BrowserRouter>
-      <PulseProvider
-        config={{
-          serverAddress: "http://localhost:8000",
-          apiPrefix: "/_pulse",
-          connectionStatus: {
-            initialConnectingDelay: 500,
-            initialErrorDelay: 5000,
-            reconnectErrorDelay: 3000,
-          },
-        }}
-        prerender={{ views: {}, directives: {} }}
-      >
-        <Routes />
-      </PulseProvider>
-    </BrowserRouter>
+async function main() {
+  const prerender = deserialize(window.__PULSE_PRERENDER__) as PulsePrerender;
+  await preloadRoutesForPath(pulseRouteTree, routeLoaders, window.location.pathname);
+
+  hydrateRoot(
+    document.getElementById("root")!,
+    <PulseApp prerender={prerender} url={window.location.href} />,
   );
 }
+
+void main();
 ```
 
 ### Connection Status UI
 
-PulseProvider automatically shows connection status in a fixed toast at the bottom-right corner:
+PulseApp automatically shows connection status in a fixed toast at the bottom-right corner:
 
 - **"Connecting..."** - Shown after `initialConnectingDelay` during initial connection
 - **"Reconnecting..."** - Shown immediately when connection is lost
@@ -125,9 +128,39 @@ PulseProvider automatically shows connection status in a fixed toast at the bott
 
 ---
 
+## PulseProvider
+
+Context provider that supplies the Pulse WebSocket client and prerender data to descendant components. `PulseApp` renders it for you—you only need it directly if you're assembling the shell yourself.
+
+```tsx
+import { PulseProvider } from "pulse-ui-client";
+
+function PulseProvider(props: PulseProviderProps): ReactNode
+```
+
+### Props
+
+```ts
+interface PulseProviderProps {
+  children: ReactNode;
+  client: PulseSocketIOClient;
+  prerender: PulsePrerender;
+}
+```
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `children` | `ReactNode` | Child components to render |
+| `client` | `PulseSocketIOClient` | The Pulse WebSocket client instance |
+| `prerender` | `PulsePrerender` | Prerendered views and directives from SSR |
+
+The client class is not exported—`PulseApp` constructs it from `PulseConfig`. Prefer `PulseApp` unless you have a strong reason not to.
+
+---
+
 ## PulseView
 
-Renders a Pulse view at a specific path. This component subscribes to server updates and handles VDOM reconciliation automatically.
+Renders a Pulse view for a route. It looks up the server-rendered view for its route pattern path, attaches to it by view id over the WebSocket, and handles VDOM reconciliation automatically. Each generated route module renders one `PulseView`.
 
 ```tsx
 import { PulseView } from "pulse-ui-client";
@@ -146,7 +179,7 @@ interface PulseViewProps {
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `path` | `string` | View mount path (must match server route) |
+| `path` | `string` | Route pattern path (e.g. `/users/:id`), used to find the view in the prerender payload |
 | `registry` | `Record<string, unknown>` | Component registry for mount points |
 
 ### Component Registry
@@ -170,21 +203,7 @@ function MyPage() {
 
 ### Route Integration
 
-PulseView automatically syncs with React Router. It extracts path parameters, query parameters, and hash from the current location and sends them to the server.
-
-```tsx
-import { Routes, Route } from "react-router";
-import { PulseView } from "pulse-ui-client";
-
-function AppRoutes() {
-  return (
-    <Routes>
-      <Route path="/users/:id" element={<PulseView path="/users" registry={registry} />} />
-      <Route path="/*" element={<PulseView path="/" registry={registry} />} />
-    </Routes>
-  );
-}
-```
+PulseView automatically syncs with the Pulse router. It reads path parameters, query parameters, and hash from the current location (via `useRouteInfo()`) and sends them to the server whenever they change. You normally don't render `PulseView` yourself—the generated route modules do, and `PulseRoutes` renders them at the right place in the layout hierarchy.
 
 ### Server Error Handling
 
@@ -273,8 +292,88 @@ function ContactForm() {
 
 ---
 
+## Router Components
+
+Pulse ships its own client router. These components are used by `PulseApp` and the generated code, but they're also available for custom client components.
+
+### Link
+
+Client-side navigation link with prefetching. This is what `ps.Link` renders to.
+
+```ts
+type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  to: string;
+  /**
+   * Prefetch strategy:
+   * - "intent" (default): prefetch on hover/focus
+   * - "viewport": prefetch when the link scrolls into view
+   * - "render": prefetch as soon as the link renders
+   * - "none": never prefetch
+   */
+  prefetch?: "none" | "intent" | "render" | "viewport";
+  /** Skip client routing and let the browser load the document. */
+  reloadDocument?: boolean;
+  replace?: boolean;
+};
+```
+
+Prefetching warms both the route's JS chunks and the server-rendered views for the target URL, so the subsequent click commits instantly.
+
+```tsx
+import { Link } from "pulse-ui-client";
+
+<Link to="/dashboard" prefetch="viewport">Dashboard</Link>
+```
+
+### Outlet
+
+Renders the matched child route's element inside a layout. This is what `ps.Outlet` renders to.
+
+```tsx
+import { Outlet } from "pulse-ui-client";
+
+function Layout() {
+  return (
+    <div>
+      <nav>...</nav>
+      <Outlet />
+    </div>
+  );
+}
+```
+
+### PulseRouterProvider
+
+The router context: owns the location state machine, popstate handling, navigation sequencing, scroll restoration, and error surfacing. Rendered by `PulseApp`.
+
+```ts
+interface PulseRouterProviderProps {
+  routes: PulseRoute[];
+  routeLoaders: RouteLoaderMap;
+  /** URL of the initial request; required for SSR, optional in the browser. */
+  initialUrl?: string;
+  /** Called before a navigation commits. Throwing aborts the navigation. */
+  onNavigate?: (target: NavigationTarget) => Promise<void | (() => void)>;
+  /** Called when a link wants to prefetch a target URL. */
+  onPrefetch?: (target: NavigationTarget) => void;
+  children: ReactNode;
+}
+```
+
+### PulseRoutes
+
+Renders the matched route hierarchy (layouts wrapping the leaf route) for the current location. Rendered by `PulseApp` inside the providers.
+
+```tsx
+import { PulseRoutes } from "pulse-ui-client";
+
+<PulseRoutes />
+```
+
+---
+
 ## See Also
 
-- [Hooks](/docs/reference/pulse-client/hooks) - usePulseClient, usePulseChannel, usePulsePrerender
+- [Hooks](/docs/reference/pulse-client/hooks) - usePulseClient, usePulseChannel, router hooks
 - [Classes](/docs/reference/pulse-client/classes) - ChannelBridge, VDOMRenderer
 - [Types](/docs/reference/pulse-client/types) - TypeScript type definitions

--- a/docs/content/docs/reference/pulse-client/hooks.mdx
+++ b/docs/content/docs/reference/pulse-client/hooks.mdx
@@ -86,13 +86,13 @@ interface PulseClient {
   isConnected(): boolean;
   onConnectionChange(listener: ConnectionStatusListener): () => void;
 
-  // Route management
-  updateRoute(path: string, routeInfo: RouteInfo): void;
-  attach(path: string, view: MountedView): void;
-  detach(path: string): void;
+  // View management (views are identified by their server-generated id)
+  updateRoute(viewId: string, routeInfo: RouteInfo): void;
+  attach(viewId: string, view: MountedView): void;
+  detach(viewId: string): void;
 
   // Callbacks
-  invokeCallback(path: string, callback: string, args: any[]): void;
+  invokeCallback(viewId: string, callback: string, args: any[]): void;
 }
 ```
 
@@ -130,7 +130,7 @@ Returns `null` during the first render, then a `ChannelBridge` instance after th
 
 The hook manages channel subscription automatically:
 
-1. On mount: acquires the channel for the current `PulseView` path
+1. On mount: acquires the channel, bound to the enclosing view's id
 2. On unmount: releases the channel lease
 3. When the lease is released: the client bridge closes
 
@@ -237,12 +237,14 @@ function usePulsePrerender(path: string): PulsePrerenderView
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `path` | `string` | View path to get prerender data for |
+| `path` | `string` | Route pattern path to get prerender data for (e.g. `/users/:id`) |
 
 ### Returns
 
 ```ts
 interface PulsePrerenderView {
+  view: string;       // Unique id of the server-side view
+  routePath: string;  // Route pattern path
   vdom: VDOM;
 }
 ```
@@ -272,8 +274,88 @@ This hook is primarily used internally by `PulseView`. Most applications won't n
 
 ---
 
+## usePulseViewId
+
+Hook to get the unique id of the enclosing view. Every rendered route or layout instance is a view with a server-generated id, and all protocol messages (callbacks, channels, refs) are scoped to it.
+
+```ts
+import { usePulseViewId } from "pulse-ui-client";
+
+function usePulseViewId(): string
+```
+
+### Throws
+
+Throws if used outside of a `PulseView`.
+
+---
+
+## Router Hooks
+
+Hooks for the built-in Pulse router. All of them throw if used outside a `PulseRouterProvider` (which `PulseApp` renders for you).
+
+### useNavigate
+
+```ts
+function useNavigate(): NavigateFunction
+
+type NavigateFunction = (to: string | number, options?: NavigateOptions) => void;
+
+type NavigateOptions = {
+  replace?: boolean;
+  preventScrollReset?: boolean;
+};
+```
+
+Navigate programmatically. Pass a path (`navigate("/dashboard")`) or a history delta (`navigate(-1)` to go back).
+
+### useLocation
+
+```ts
+function useLocation(): LocationLike
+
+interface LocationLike {
+  pathname: string;
+  search: string;
+  hash: string;
+}
+```
+
+The current location.
+
+### useParams
+
+```ts
+function useParams(): Record<string, string | undefined>
+```
+
+Path parameters for the current match (e.g. `{ id: "123" }` for `/users/:id`).
+
+### useRouteInfo
+
+```ts
+function useRouteInfo(): RouteInfo
+```
+
+The full route info for the current location—pathname, query, hash, path params, and catch-all segments. This is what `PulseView` sends to the server.
+
+### useNavigationError
+
+```ts
+function useNavigationError(): NavigationError | null
+
+type NavigationError = {
+  error: Error;
+  location: LocationLike;
+};
+```
+
+The last navigation error, or `null`. When a navigation fails, the router stays on the current page and surfaces the error here.
+
+---
+
 ## See Also
 
-- [Components](/docs/reference/pulse-client/components) - PulseProvider, PulseView, PulseForm
+- [Components](/docs/reference/pulse-client/components) - PulseApp, PulseView, PulseForm, router components
 - [Classes](/docs/reference/pulse-client/classes) - ChannelBridge, VDOMRenderer
-- [Channels guide](/docs/guide/channels) - How to use channels
+- [Channels guide](/docs/advanced/channels) - How to use channels

--- a/docs/content/docs/reference/pulse-client/index.mdx
+++ b/docs/content/docs/reference/pulse-client/index.mdx
@@ -17,60 +17,53 @@ bun add pulse-ui-client
 
 ## Peer Dependencies
 
-The package requires React 18 or 19 and React Router 7:
+The package requires React 18 or 19—nothing else. Routing is built in:
 
 ```json
 {
   "peerDependencies": {
     "react": "^18 || ^19",
-    "react-dom": "^18 || ^19",
-    "react-router": "^7"
+    "react-dom": "^18 || ^19"
   }
 }
 ```
 
 ## Quick Start
 
-Here's a minimal setup connecting a React app to a Pulse backend:
+In a Pulse project, the generated `web/app/pulse/_layout.tsx` exports a configured `PulseApp` that your entry files render. Here's what that looks like:
 
 ```tsx
-import { PulseProvider, PulseView } from "pulse-ui-client";
-import { BrowserRouter, Routes, Route } from "react-router";
+import { PulseApp, type PulsePrerender } from "pulse-ui-client";
+import { pulseRouteTree, routeLoaders } from "./routes";
 
-// Component registry for custom mount points
-const registry = {
-  MyButton: (props) => <button {...props} />,
-};
-
-function App() {
+function App({ prerender, url }: { prerender: PulsePrerender; url?: string }) {
   return (
-    <BrowserRouter>
-      <PulseProvider
-        config={{
-          serverAddress: "http://localhost:8000",
-          apiPrefix: "/_pulse",
-          connectionStatus: {
-            initialConnectingDelay: 500,
-            initialErrorDelay: 5000,
-            reconnectErrorDelay: 3000,
-          },
-        }}
-        prerender={{ views: {}, directives: {} }}
-      >
-        <Routes>
-          <Route path="/*" element={<PulseView path="/" registry={registry} />} />
-        </Routes>
-      </PulseProvider>
-    </BrowserRouter>
+    <PulseApp
+      routes={pulseRouteTree}
+      routeLoaders={routeLoaders}
+      config={{
+        serverAddress: "http://localhost:8000",
+        apiPrefix: "/_pulse",
+        connectionStatus: {
+          initialConnectingDelay: 2000,
+          initialErrorDelay: 8000,
+          reconnectErrorDelay: 8000,
+        },
+      }}
+      prerender={prerender}
+      url={url}
+    />
   );
 }
 ```
 
 Let's break this down:
 
-1. **PulseProvider** wraps your app and manages the WebSocket connection
-2. **PulseView** renders the UI for a specific route path
-3. **registry** maps component names to React components for custom mount points
+1. **PulseApp** composes the router (`PulseRouterProvider` → `PulseProvider` → `PulseRoutes`) into one shell
+2. **routes / routeLoaders** come from the generated route manifest—`routes` mirrors your Python route tree, `routeLoaders` code-splits one module per route
+3. **prerender** is the server-rendered payload (views + directives) from the initial HTML request
+
+To wrap the whole app with global providers (themes, etc.), do it around `PulseApp` in your `src/entry-client.tsx` and `src/entry-server.tsx`.
 
 ## What's Included
 
@@ -78,15 +71,19 @@ The package exports several categories of APIs:
 
 ### Components
 
-- **PulseProvider** - Root context provider for WebSocket connection
-- **PulseView** - Renders Pulse views and handles updates
+- **PulseApp** - All-in-one app shell: router + provider + routes
+- **PulseProvider** - Context provider for the WebSocket client
+- **PulseView** - Renders a Pulse view and handles updates
 - **PulseForm** - Form component that submits without unmounting
+- **PulseRouterProvider / PulseRoutes / Outlet / Link** - The built-in router
 
 ### Hooks
 
 - **usePulseClient** - Access the Pulse client instance
 - **usePulseChannel** - Subscribe to bidirectional channels
 - **usePulsePrerender** - Access prerendered view data
+- **usePulseViewId** - The id of the enclosing view
+- **useNavigate / useLocation / useParams / useRouteInfo / useNavigationError** - Router hooks
 
 ### Classes
 
@@ -97,24 +94,29 @@ The package exports several categories of APIs:
 ### Utilities
 
 - **serialize** / **deserialize** - Wire format encoding
-- **extractServerRouteInfo** - Extract route info in loaders
+- **buildRouteInfo** - Build a `RouteInfo` from a location
+- **matchRoutes** - Match a pathname against a `PulseRoute[]` tree
 - **submitForm** - Programmatic form submission
 
 ## Architecture
 
-The client maintains a persistent WebSocket connection to the Pulse server:
+The client maintains a persistent WebSocket connection to the Pulse server. Every rendered route or layout instance is a **view** with a unique server-generated id, and all messages are scoped to that id:
 
 ```
 React App                          Pulse Server
     |                                   |
-    |-- attach (path, routeInfo) ------>|
-    |<-------- vdom_init (VDOM) --------|
+    |-- attach (view, routeInfo) ------>|
+    |<---- vdom_init (view, VDOM) ------|
     |                                   |
-    |<------ vdom_update (ops[]) -------|  (on state change)
+    |<--- vdom_update (view, ops[]) ----|  (on state change)
     |                                   |
-    |-- callback (path, id, args) ----->|  (on user interaction)
+    |-- callback (view, id, args) ----->|  (on user interaction)
     |                                   |
+    |-- navigate (nav, routeInfo) ----->|  (on link click)
+    |<--- navigate_result (views) ------|
 ```
+
+Navigation also flows over the socket: the server matches the URL against the Python route tree, renders the new views, and reuses surviving ones (their state persists).
 
 When a user interacts with the UI, callbacks are sent to the server. The server updates state and sends VDOM patches back. The client applies these patches incrementally, preserving React's reconciliation benefits.
 

--- a/docs/content/docs/reference/pulse-client/serialization.mdx
+++ b/docs/content/docs/reference/pulse-client/serialization.mdx
@@ -227,21 +227,27 @@ a.ref = b;  // circular
 
 ---
 
-## extractServerRouteInfo
+## buildRouteInfo
 
-Extracts route information from a React Router loader function. Use this in SSR loaders to pass route context to the Pulse server.
+Builds a `RouteInfo` object from a location plus matched parameters. The router uses this internally to produce the route info it sends to the server; it's exported for custom integrations.
 
 ```ts
-import { extractServerRouteInfo } from "pulse-ui-client";
+import { buildRouteInfo } from "pulse-ui-client";
 
-function extractServerRouteInfo(args: LoaderFunctionArgs): RouteInfo
+function buildRouteInfo(
+  location: LocationLike,
+  pathParams: Record<string, string | undefined>,
+  catchall: string[],
+): RouteInfo
 ```
 
 ### Parameters
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `args` | `LoaderFunctionArgs` | React Router loader arguments |
+| `location` | `LocationLike` | `{ pathname, search, hash }` |
+| `pathParams` | `Record<string, string \| undefined>` | Matched path parameters |
+| `catchall` | `string[]` | Matched catch-all segments |
 
 ### Returns
 
@@ -259,20 +265,16 @@ interface RouteInfo {
 ### Example
 
 ```ts
-import { extractServerRouteInfo } from "pulse-ui-client";
-import type { LoaderFunctionArgs } from "react-router";
+import { buildRouteInfo, matchRoutes } from "pulse-ui-client";
+import { pulseRouteTree } from "../app/pulse/routes";
 
-export async function loader(args: LoaderFunctionArgs) {
-  const routeInfo = extractServerRouteInfo(args);
+const location = { pathname: "/users/123", search: "?tab=settings", hash: "" };
+const match = matchRoutes(pulseRouteTree, location.pathname);
 
-  // routeInfo.pathname = "/users/123"
-  // routeInfo.pathParams = { id: "123" }
-  // routeInfo.queryParams = { tab: "settings" }
-
-  // Pass to Pulse server for SSR
-  const prerender = await fetchPulsePrerender(routeInfo);
-  return { prerender };
-}
+const routeInfo = buildRouteInfo(location, match?.params ?? {}, match?.catchall ?? []);
+// routeInfo.pathname = "/users/123"
+// routeInfo.pathParams = { id: "123" }
+// routeInfo.queryParams = { tab: "settings" }
 ```
 
 ---

--- a/docs/content/docs/reference/pulse-client/types.mdx
+++ b/docs/content/docs/reference/pulse-client/types.mdx
@@ -35,6 +35,21 @@ interface ConnectionStatusConfig {
 }
 ```
 
+### PulseAppProps
+
+Props for the `PulseApp` component.
+
+```ts
+interface PulseAppProps {
+  routes: PulseRoute[];
+  routeLoaders: RouteLoaderMap;
+  config: PulseConfig;
+  prerender: PulsePrerender;
+  /** URL of the initial request; required for SSR. */
+  url?: string;
+}
+```
+
 ### PulseProviderProps
 
 Props for the `PulseProvider` component.
@@ -42,14 +57,14 @@ Props for the `PulseProvider` component.
 ```ts
 interface PulseProviderProps {
   children: ReactNode;
-  config: PulseConfig;
+  client: PulseSocketIOClient;
   prerender: PulsePrerender;
 }
 ```
 
 ### PulsePrerender
 
-Server-side prerender data.
+Server-side prerender data. Views are keyed by their route pattern path.
 
 ```ts
 interface PulsePrerender {
@@ -58,6 +73,8 @@ interface PulsePrerender {
 }
 
 interface PulsePrerenderView {
+  view: string;       // Unique id of the server-side view
+  routePath: string;  // Route pattern path (e.g. "/users/:id")
   vdom: VDOM;
 }
 ```
@@ -69,12 +86,14 @@ Connection directives for authentication and headers.
 ```ts
 interface Directives {
   headers?: Record<string, string>;
+  query?: Record<string, string>;
   socketio?: SocketIODirectives;
 }
 
 interface SocketIODirectives {
   headers?: Record<string, string>;
   auth?: Record<string, string>;
+  query?: Record<string, string>;
 }
 ```
 
@@ -119,6 +138,46 @@ interface RouteInfo {
 | `queryParams` | Parsed query parameters |
 | `pathParams` | Route parameters from path |
 | `catchall` | Segments from catch-all route (`/*`) |
+
+### PulseRoute
+
+A node in the generated route manifest (`pulseRouteTree`). Mirrors the Python route tree; layouts are pathless nodes.
+
+```ts
+type PulseRoute = {
+  id: string;          // Unique route path (matches the Python side)
+  path?: string;       // URL segment(s); absent for layouts
+  index?: boolean;     // True for index routes
+  children?: PulseRoute[];
+};
+```
+
+### MatchResult
+
+Result of matching a pathname against a `PulseRoute[]` tree with `matchRoutes`.
+
+```ts
+type MatchResult = {
+  matches: PulseRoute[];  // Root-to-leaf chain of matched routes
+  params: Record<string, string | undefined>;
+  catchall: string[];
+};
+```
+
+### RouteModule / RouteLoader / RouteLoaderMap
+
+Code-split route modules and their loaders (the generated `routeLoaders`).
+
+```ts
+type RouteModule = {
+  default: ComponentType<any>;
+  registry?: Record<string, unknown>;
+  path?: string;
+};
+
+type RouteLoader = () => Promise<RouteModule>;
+type RouteLoaderMap = Record<string, RouteLoader>;
+```
 
 ---
 
@@ -349,7 +408,7 @@ interface ReconciliationUpdate {
 
 ## Message Types
 
-Messages sent between client and server over WebSocket.
+Messages sent between client and server over WebSocket. All view-scoped messages carry the unique id of the owning view (`view`).
 
 ### Client Messages
 
@@ -359,6 +418,7 @@ type ClientMessage =
   | ClientCallbackMessage
   | ClientUpdateMessage
   | ClientDetachMessage
+  | ClientNavigateMessage
   | ClientApiResultMessage
   | ClientChannelRequestMessage
   | ClientChannelResponseMessage;
@@ -366,13 +426,14 @@ type ClientMessage =
 
 #### ClientAttachMessage
 
-Attaches to a view path.
+Attaches to a view by id.
 
 ```ts
 interface ClientAttachMessage {
   type: "attach";
-  path: string;
+  view: string;
   routeInfo: RouteInfo;
+  attachId: string;
 }
 ```
 
@@ -383,7 +444,7 @@ Invokes a server callback.
 ```ts
 interface ClientCallbackMessage {
   type: "callback";
-  path: string;
+  view: string;
   callback: string;
   args: any[];
 }
@@ -391,24 +452,37 @@ interface ClientCallbackMessage {
 
 #### ClientUpdateMessage
 
-Updates route info for an attached path.
+Updates route info for an attached view.
 
 ```ts
 interface ClientUpdateMessage {
   type: "update";
-  path: string;
+  view: string;
   routeInfo: RouteInfo;
 }
 ```
 
 #### ClientDetachMessage
 
-Detaches from a view path.
+Detaches from a view.
 
 ```ts
 interface ClientDetachMessage {
   type: "detach";
-  path: string;
+  view: string;
+}
+```
+
+#### ClientNavigateMessage
+
+Requests the views for a new location (sent on link clicks and prefetches). `nav` is a client sequence number used to drop stale responses.
+
+```ts
+interface ClientNavigateMessage {
+  type: "navigate";
+  nav: string;
+  routeInfo: RouteInfo;
+  prefetch?: boolean;
 }
 ```
 
@@ -464,6 +538,7 @@ type ServerMessage =
   | ServerErrorMessage
   | ServerApiCallMessage
   | ServerNavigateToMessage
+  | ServerNavigateResultMessage
   | ServerChannelRequestMessage
   | ServerChannelResponseMessage;
 ```
@@ -475,7 +550,8 @@ Initial VDOM for a view.
 ```ts
 interface ServerInitMessage {
   type: "vdom_init";
-  path: string;
+  view: string;
+  routePath: string;  // Route pattern path (e.g. "/users/:id")
   vdom: VDOM;
 }
 ```
@@ -487,7 +563,7 @@ VDOM updates.
 ```ts
 interface ServerUpdateMessage {
   type: "vdom_update";
-  path: string;
+  view: string;
   ops: VDOMUpdate[];
 }
 ```
@@ -499,7 +575,8 @@ Server error information.
 ```ts
 interface ServerErrorMessage {
   type: "server_error";
-  path: string;
+  // Omitted for session-level errors that are not tied to a view
+  view?: string;
   error: ServerError;
 }
 
@@ -508,6 +585,21 @@ interface ServerError {
   stack?: string;
   phase: "render" | "callback" | "mount" | "unmount" | "navigate" | "server";
   details?: Record<string, any>;
+}
+```
+
+#### ServerNavigateResultMessage
+
+Response to a `navigate` message: the view set for the new location.
+
+```ts
+interface ServerNavigateResultMessage {
+  type: "navigate_result";
+  nav: string;
+  status: "ok" | "redirect" | "notFound" | "error";
+  redirect?: string;
+  // Route pattern path -> fresh init message, or null to keep the live view
+  views?: Record<string, ServerInitMessage | null>;
 }
 ```
 
@@ -529,7 +621,7 @@ interface ServerApiCallMessage {
 
 #### ServerNavigateToMessage
 
-Navigation instruction.
+Server-initiated navigation (e.g. `ps.navigate()`). Handled by the client router like a link click. `sourceView` lets the client drop navigations from views that have since been disposed.
 
 ```ts
 interface ServerNavigateToMessage {
@@ -537,8 +629,8 @@ interface ServerNavigateToMessage {
   path: string;
   replace: boolean;
   hard: boolean;
-  sourceRoutePath?: string;
-  sourcePath?: string;
+  sourceView?: string;
+  sourcePathname?: string;
 }
 ```
 
@@ -586,10 +678,10 @@ interface PulseClient {
   disconnect(): void;
   isConnected(): boolean;
   onConnectionChange(listener: ConnectionStatusListener): () => void;
-  updateRoute(path: string, routeInfo: RouteInfo): void;
-  invokeCallback(path: string, callback: string, args: any[]): void;
-  attach(path: string, view: MountedView): void;
-  detach(path: string): void;
+  updateRoute(viewId: string, routeInfo: RouteInfo): void;
+  invokeCallback(viewId: string, callback: string, args: any[]): void;
+  attach(viewId: string, view: MountedView): void;
+  detach(viewId: string): void;
 }
 ```
 
@@ -611,7 +703,7 @@ type ConnectionStatusListener = (status: ConnectionStatus) => void;
 
 ### MountedView
 
-Callbacks for a mounted view.
+Callbacks registered when attaching to a view.
 
 ```ts
 interface MountedView {
@@ -620,6 +712,7 @@ interface MountedView {
   onUpdate: (ops: VDOMUpdate[]) => void;
   onJsExec: (msg: ServerJsExecMessage) => void;
   onServerError: (error: ServerError) => void;
+  deserializeMessage: (data: Serialized) => ServerMessage;
 }
 ```
 

--- a/docs/content/docs/reference/pulse/app.mdx
+++ b/docs/content/docs/reference/pulse/app.mdx
@@ -16,13 +16,12 @@ class App:
         middleware: PulseMiddleware | Sequence[PulseMiddleware] | None = None,
         plugins: Sequence[Plugin] | None = None,
         cookie: Cookie | None = None,
-        session_store: SessionStore | None = None,
+        session_store: SessionStore | CookieSessionStore | None = None,
         server_address: str | None = None,
         dev_server_address: str = "http://localhost:8000",
         internal_server_address: str | None = None,
         not_found: str = "/not-found",
         mode: PulseMode = "single-server",
-        proxy: Proxy | None = None,
         cors: CORSOptions | None = None,
         fastapi: dict[str, Any] | None = None,
         session_timeout: float = 60.0,
@@ -30,6 +29,7 @@ class App:
         disconnect_queue_timeout: float = 300.0,
         connection_status: ConnectionStatusConfig | None = None,
         render_loop_limit: int = 50,
+        unowned_reactives: Literal["error", "warn", "ignore"] = "error",
     ): ...
 ```
 
@@ -48,7 +48,6 @@ class App:
 | `internal_server_address` | `str` | `None` | Internal URL for server-side fetches |
 | `not_found` | `str` | `"/not-found"` | Path for 404 page |
 | `mode` | `PulseMode` | `"single-server"` | Deployment mode |
-| `proxy` | `Proxy` | `None` | Single-server proxy tuning |
 | `cors` | `CORSOptions` | `None` | CORS configuration |
 | `fastapi` | `dict` | `None` | Additional FastAPI options |
 | `session_timeout` | `float` | `60.0` | Session cleanup timeout (seconds) |
@@ -56,6 +55,7 @@ class App:
 | `disconnect_queue_timeout` | `float` | `300.0` | Disconnected socket message queue timeout (seconds) |
 | `connection_status` | `ConnectionStatusConfig` | `None` | Connection status UI timing |
 | `render_loop_limit` | `int` | `50` | Maximum render loops before failing |
+| `unowned_reactives` | `"error" \| "warn" \| "ignore"` | `"error"` | Policy when a component render constructs Effects/States with no owner (nothing would dispose them). Use `ps.init()`, `ps.state(...)`, or `@ps.effect` instead |
 
 Framework routes live under the reserved `/_pulse/*` namespace and are not configurable.
 
@@ -97,14 +97,12 @@ ASGI factory for production deployment. Called on each reload.
 #### run_codegen
 
 ```python
-def run_codegen(
-    self,
-    address: str | None = None,
-    internal_address: str | None = None,
-) -> None
+def run_codegen(self, address: str | None = None) -> None
 ```
 
-Generate React Router code for all routes.
+Generate the web app code (route manifest + route modules) for all routes. Updates `server_address` if `address` is provided.
+
+**Raises:** `RuntimeError` if no server address is available.
 
 #### setup
 
@@ -145,27 +143,6 @@ Deployment mode for the application.
 |-------|-------------|
 | `"single-server"` | Python and React on same origin (default) |
 | `"subdomains"` | Python API on subdomain (e.g., `api.example.com`) |
-
----
-
-## Proxy
-
-Configuration for the single-server React proxy.
-
-```python
-@dataclass
-class Proxy:
-    max_concurrency: int = 100
-    incoming_streaming_threshold: int = 512 * 1024
-    outgoing_streaming_threshold: int = 5 * 1024 * 1024
-    stream_chunk_size: int = 512 * 1024
-    connect_timeout: float | None = 30.0
-    disconnect_watch_timeout: float = 30.0
-    disconnect_watch_max_sleep: float = 1.0
-    disconnect_watch_base_sleep: float = 0.001
-```
-
-Pass it to `App(proxy=ps.Proxy(...))`. Used only in `"single-server"` mode.
 
 ---
 

--- a/packages/pulse/python/README.md
+++ b/packages/pulse/python/README.md
@@ -35,7 +35,7 @@ src/pulse/
 ├── routing.py          # Route/Layout definitions, URL matching
 ├── vdom.py             # VDOM node types (Element, Component, Node)
 ├── renderer.py         # VDOM rendering and diffing
-├── render_session.py   # Per-browser session, manages mounted routes
+├── render_session.py   # Per-browser session, manages views (rendered route/layout instances)
 ├── reactive.py         # Signal/Computed/Effect primitives
 ├── reactive_extensions.py  # ReactiveList, ReactiveDict, ReactiveSet
 ├── state.py            # State management
@@ -71,7 +71,7 @@ src/pulse/
 ├── components/         # Built-in components
 │   ├── for_.py         # <For> loop component
 │   ├── if_.py          # <If> conditional component
-│   └── react_router.py # Link, Outlet for routing
+│   └── router.py       # Link, Outlet for routing (binds to the pulse-ui-client router)
 │
 ├── html/               # HTML element bindings
 │   ├── tags.py         # div, span, button, etc.
@@ -83,8 +83,8 @@ src/pulse/
 │   ├── function.py     # JsFunction, @javascript decorator
 │   └── imports.py      # Import/CssImport for client-side JS
 │
-├── codegen/            # Code generation for React Router
-│   ├── codegen.py      # Generates routes.ts, loaders
+├── codegen/            # Code generation for the web app
+│   ├── codegen.py      # Generates routes.ts (route manifest), _layout.tsx, route modules
 │   └── templates/      # Mako templates for generated code
 │
 ├── cli/                # Command-line interface

--- a/skills/pulse/SKILL.md
+++ b/skills/pulse/SKILL.md
@@ -511,9 +511,11 @@ app = ps.App(
 ## Commands
 
 ```bash
-uv run pulse run app.py          # Dev server :8000
+uv run pulse run app.py          # Dev server :8000 (uvicorn + Vite assets + Bun SSR)
 uv run pulse run app.py --port 3000
 uv run pulse run app.py --interrupt  # Stop existing dev instance first
+uv run pulse build app.py        # Production build (client + SSR bundles)
+uv run pulse run app.py --prod   # Production servers (uvicorn + Bun SSR)
 make all                         # Format, lint, typecheck, test
 ```
 
@@ -686,7 +688,7 @@ app = ps.App(
     routes=[...],
     mode="single-server",  # or "subdomains" for multi-tenant
     server_address="https://myapp.com",  # Required for production
-    codegen=ps.CodegenConfig(router="@tanstack/react-router"),  # Optional
+    codegen=ps.CodegenConfig(web_dir="web"),  # Optional, where the web project lives
     session_store=ps.CookieSessionStore(secret_key="..."),  # Production sessions
 )
 ```


### PR DESCRIPTION
6/6 of the custom-framework merge train (stacked on the WS-navigation PR).

Documentation that spans multiple features of the train: client reference pages (classes, components, hooks, serialization, types), glossary, mental model, tutorial intro, channels guide, package READMEs, and the Pulse skill. Feature-specific docs already rode with their feature PRs.

After this merges, the stack tip is byte-identical to the original `custom-react-framework` branch except `bun.lock`, where the stack carries the freshly regenerated lockfile (the original branch's lockfile still contains stale entries for the deleted root `web/` workspace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)