### PR TITLE
Release Pulse 0.1.102

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -161,7 +161,7 @@
     },
     "packages/pulse/js": {
       "name": "pulse-ui-client",
-      "version": "0.1.101",
+      "version": "0.1.102",
       "dependencies": {
         "socket.io-client": "^4.8.1",
         "ws": "^8.18.3",

--- a/docs/content/docs/(core)/concepts/data-fetching.mdx
+++ b/docs/content/docs/(core)/concepts/data-fetching.mdx
@@ -129,6 +129,12 @@ async def user(self):
 
 This "just works" for most cases.
 
+Queries also follow the client's connection. If the user closes their laptop or
+tabs away long enough to disconnect, `refetch_interval` polling pauses — Pulse
+doesn't keep hitting your API for a screen nobody is looking at. When they come
+back, intervals restart and any stale data (older than `stale_time`) refetches
+automatically, so the user always returns to fresh data.
+
 ### Keyed queries
 
 Sometimes automatic tracking isn't what you want. Maybe you're reading multiple state properties but only want to refetch when one specific value changes:

--- a/docs/content/docs/(core)/concepts/data-fetching.mdx
+++ b/docs/content/docs/(core)/concepts/data-fetching.mdx
@@ -165,7 +165,7 @@ The `@ps.query` decorator accepts options for common scenarios:
     keep_previous_data=True,  # Show old data while refetching (avoids flicker)
     stale_time=60.0,          # Data is "fresh" for 60 seconds
     retries=3,                # Retry failed requests up to 3 times
-    retry_delay=1.0,          # Wait 1 second between retries
+    retry_delay=1.0,          # Backoff base: 1s, then 2s, 4s... (capped at 30s)
     gc_time=300.0,            # Keep cached data around for 5 minutes
 )
 async def user(self):

--- a/docs/content/docs/reference/pulse/app.mdx
+++ b/docs/content/docs/reference/pulse/app.mdx
@@ -51,9 +51,9 @@ class App:
 | `proxy` | `Proxy` | `None` | Single-server proxy tuning |
 | `cors` | `CORSOptions` | `None` | CORS configuration |
 | `fastapi` | `dict` | `None` | Additional FastAPI options |
-| `session_timeout` | `float` | `60.0` | Session cleanup timeout (seconds) |
-| `prerender_queue_timeout` | `float` | `60.0` | Prerender queue timeout (seconds) |
-| `disconnect_queue_timeout` | `float` | `300.0` | Disconnected socket message queue timeout (seconds) |
+| `session_timeout` | `float` | `60.0` | How long a disconnected render session stays resumable before being closed (seconds) |
+| `prerender_queue_timeout` | `float` | `60.0` | How long a prerendered route waits for the client to attach before its render tree is released (seconds) |
+| `disconnect_queue_timeout` | `float` | `300.0` | How long updates are queued for a disconnected client before the route suspends — rendering pauses but state is kept; reconnecting within `session_timeout` resumes without a reload (seconds) |
 | `connection_status` | `ConnectionStatusConfig` | `None` | Connection status UI timing |
 | `render_loop_limit` | `int` | `50` | Maximum render loops before failing |
 

--- a/docs/content/docs/reference/pulse/queries.mdx
+++ b/docs/content/docs/reference/pulse/queries.mdx
@@ -82,6 +82,22 @@ def query(
 | `fetch_on_mount` | `bool` | `True` | Fetch when component mounts |
 | `key` | `QueryKey \| None` | `None` | Static key for shared queries |
 
+### Staleness and the connection lifecycle
+
+Queries follow the client's connection, similar to TanStack Query's window
+focus behavior:
+
+- While the client is **disconnected** (tab closed to the background, network
+  drop), `refetch_interval` polling pauses — no background fetches run for a
+  session nobody is watching.
+- When the client **reconnects**, intervals restart with an immediate
+  catch-up fetch, and non-interval queries refetch if their data is stale
+  (older than `stale_time`, or explicitly invalidated).
+
+Set `stale_time` to control how much staleness you tolerate on reconnect: with
+the default `0.0`, every reconnect refetches; with `stale_time=60`, data less
+than a minute old is reused as-is.
+
 ### Basic Usage
 
 ```python
@@ -201,7 +217,9 @@ Start the initial fetch if needed, then wait for completion.
 
 #### `invalidate() -> None`
 
-Mark the query as stale and trigger a refetch.
+Mark the query as stale and trigger a refetch. If the query has no observers
+(no mounted component is using it), the stale mark persists: the query
+refetches the next time it is observed or when the session reconnects.
 
 ```python
 state.user.invalidate()

--- a/docs/content/docs/reference/pulse/queries.mdx
+++ b/docs/content/docs/reference/pulse/queries.mdx
@@ -76,7 +76,7 @@ def query(
 | `refetch_interval` | `float \| None` | `None` | Auto-refetch interval in seconds |
 | `keep_previous_data` | `bool` | `False` | Keep previous data while refetching. Preserves data across key changes, even if the new key has `initial_data`. |
 | `retries` | `int` | `3` | Number of retry attempts |
-| `retry_delay` | `float \| None` | `2.0` | Delay between retries in seconds |
+| `retry_delay` | `float \| None` | `2.0` | Base delay (seconds) for exponential backoff between retries; doubles each attempt, capped at 30s |
 | `initial_data_updated_at` | `float \| datetime \| None` | `None` | Timestamp for initial data staleness |
 | `enabled` | `bool` | `True` | Whether query is enabled |
 | `fetch_on_mount` | `bool` | `True` | Fetch when component mounts |
@@ -350,7 +350,7 @@ def infinite_query(
 | `refetch_interval` | `float \| None` | `None` | Auto-refetch interval in seconds |
 | `keep_previous_data` | `bool` | `False` | Keep previous data while refetching. Preserves data across key changes. |
 | `retries` | `int` | `3` | Number of retry attempts |
-| `retry_delay` | `float \| None` | `2.0` | Delay between retries in seconds |
+| `retry_delay` | `float \| None` | `2.0` | Base delay (seconds) for exponential backoff between retries; doubles each attempt, capped at 30s |
 | `enabled` | `bool` | `True` | Whether query is enabled |
 | `fetch_on_mount` | `bool` | `True` | Fetch when component mounts |
 | `key` | `QueryKey` | required | Query key (use `@query.key` for dynamic keys) |

--- a/packages/pulse/js/package.json
+++ b/packages/pulse/js/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pulse-ui-client",
-	"version": "0.1.101",
+	"version": "0.1.102",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/erwinkn/pulse-ui",

--- a/packages/pulse/python/pyproject.toml
+++ b/packages/pulse/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pulse-framework"
-version = "0.1.101"
+version = "0.1.102"
 description = "Pulse - Full-stack framework for building real-time React applications in Python"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -265,6 +265,7 @@ class App:
 	_render_to_user: dict[str, str]
 	_sessions_in_request: dict[str, int]
 	_socket_to_render: dict[str, str]
+	_render_to_socket: dict[str, str]
 	_connecting_sockets: set[str]
 	_pending_socket_messages: dict[str, list[Serialized]]
 	_render_cleanups: dict[str, TimerHandleLike]
@@ -344,8 +345,11 @@ class App:
 		self._user_to_render = defaultdict(list)
 		self._render_to_user = {}
 		self._sessions_in_request = {}
-		# Map websocket sid -> renderId for message routing
+		# Map websocket sid <-> renderId for message routing. A render has at
+		# most one current socket; the reverse map identifies it so a stale
+		# socket's disconnect cannot tear down a newer connection.
 		self._socket_to_render = {}
+		self._render_to_socket = {}
 		self._connecting_sockets = set()
 		self._pending_socket_messages = {}
 		# Map render_id -> cleanup timer handle for timeout-based expiry
@@ -609,6 +613,11 @@ class App:
 				self._sessions_in_request[session.sid] -= 1
 				if self._sessions_in_request[session.sid] == 0:
 					del self._sessions_in_request[session.sid]
+					# Sessions without render sessions would otherwise be retained
+					# forever: cookie-less clients (bots, health checks) mint one
+					# per request. Their state lives in the cookie/session store,
+					# so dropping the in-memory object is safe.
+					self.close_session_if_inactive(session.sid)
 
 		# Apply prefix to all routes
 		prefix = self.api_prefix
@@ -792,6 +801,8 @@ class App:
 				self._connecting_sockets.discard(sid)
 				self._pending_socket_messages.pop(sid, None)
 				self._socket_to_render.pop(sid, None)
+				if rid and self._render_to_socket.get(rid) == sid:
+					del self._render_to_socket[rid]
 				raise
 			await self._drain_pending_socket_messages(sid)
 
@@ -809,12 +820,14 @@ class App:
 
 			if not rid:
 				# Still refuse connections without a renderId
+				self.close_session_if_inactive(session.sid)
 				raise ConnectionRefusedError(
 					f"Socket connect missing render_id session={session.sid}"
 				)
 
 			# Allow reconnects where the provided renderId no longer exists by creating a new RenderSession
 			render = self.render_sessions.get(rid)
+			created_render = render is None
 			if render is None:
 				# The client will try to attach to a non-existing RouteMount, which will cause a reload down the line
 				render = self.create_render(
@@ -823,24 +836,17 @@ class App:
 			else:
 				owner = self._render_to_user.get(render.id)
 				if owner != session.sid:
+					self.close_session_if_inactive(session.sid)
 					raise ConnectionRefusedError(
 						f"Socket connect session mismatch render={render.id} "
 						+ f"owner={owner} session={session.sid}"
 					)
 
-			def on_message(message: ServerMessage):
-				payload = serialize(message)
-				# `serialize` returns a tuple, which socket.io will mistake for multiple arguments
-				payload = list(payload)
-				self._tasks.create_task(self.sio.emit("message", list(payload), to=sid))
-
-			render.connect(on_message)
-			# Map socket sid to renderId for message routing
-			self._socket_to_render[sid] = rid
-
-			# Cancel any pending cleanup since session is now connected
-			self._cancel_render_cleanup(rid)
-
+			# Authorize before binding the socket. A denied (re)connect must not
+			# rebind or tear down an existing render that another live socket may
+			# still be using; only the render we created for this attempt is ours
+			# to clean up.
+			connect_error: Exception | None = None
 			with PulseContext.update(session=session, render=render):
 
 				async def _next():
@@ -860,20 +866,50 @@ class App:
 					)
 					res = _normalize_connect_response(res)
 				except Exception as exc:
-					render.report_error("/", "connect", exc)
+					# Treat a middleware error as allow, but surface it to the
+					# client once the socket is bound (see below).
+					connect_error = exc
 					res = Ok(None)
 				if isinstance(res, Deny):
-					# Tear down the created session if denied
-					self.close_render(rid)
-					self._socket_to_render.pop(sid, None)
+					if created_render:
+						self.close_render(rid)
+					else:
+						self.close_session_if_inactive(session.sid)
 					raise ConnectionRefusedError("Socket connection denied")
+
+			def on_message(message: ServerMessage):
+				payload = serialize(message)
+				# `serialize` returns a tuple, which socket.io will mistake for multiple arguments
+				payload = list(payload)
+				self._tasks.create_task(self.sio.emit("message", list(payload), to=sid))
+
+			render.connect(on_message)
+			# Map socket sid to renderId for message routing. If the client
+			# reconnected before the old socket's disconnect fired, unmap the
+			# old socket so its late disconnect can't tear down this connection.
+			old_sid = self._render_to_socket.get(rid)
+			if old_sid is not None and old_sid != sid:
+				self._socket_to_render.pop(old_sid, None)
+			self._socket_to_render[sid] = rid
+			self._render_to_socket[rid] = sid
+
+			# Cancel any pending cleanup since session is now connected
+			self._cancel_render_cleanup(rid)
+
+			# Now that the socket is bound, surface any connect-middleware error
+			# (reported pre-bind it would be dropped for a fresh render).
+			if connect_error is not None:
+				render.report_error("/", "connect", connect_error)
 
 		@self.sio.event
 		def disconnect(sid: str):  # pyright: ignore[reportUnusedFunction]
 			self._connecting_sockets.discard(sid)
 			self._pending_socket_messages.pop(sid, None)
 			rid = self._socket_to_render.pop(sid, None)
-			if rid is not None:
+			# Only the render's current socket may disconnect it; a stale
+			# socket's late disconnect must not tear down a newer connection.
+			if rid is not None and self._render_to_socket.get(rid) == sid:
+				del self._render_to_socket[rid]
 				render = self.render_sessions.get(rid)
 				if render:
 					render.disconnect()
@@ -961,8 +997,11 @@ class App:
 			session = self.user_sessions.get(owner_sid)
 			if session is None:
 				return
-			# Cancel any pending cleanup for active sessions (connected sessions stay alive)
-			self._cancel_render_cleanup(rid)
+			# Cancel any leftover cleanup for connected sessions. Never cancel
+			# for disconnected renders: nothing would reschedule it and the
+			# session would survive past its timeout.
+			if render.connected:
+				self._cancel_render_cleanup(rid)
 			try:
 				if msg["type"] == "channel_message":
 					await self._handle_channel_message(render, session, msg)
@@ -1179,6 +1218,9 @@ class App:
 		# Cancel any pending cleanup task
 		self._cancel_render_cleanup(rid)
 		self._render_message_locks.pop(rid, None)
+		socket_sid = self._render_to_socket.pop(rid, None)
+		if socket_sid is not None:
+			self._socket_to_render.pop(socket_sid, None)
 
 		render = self.render_sessions.pop(rid, None)
 		if not render:
@@ -1198,7 +1240,9 @@ class App:
 			session.dispose()
 
 	def close_session_if_inactive(self, sid: str):
-		if len(self._user_to_render[sid]) == 0:
+		if sid in self._sessions_in_request:
+			return
+		if not self._user_to_render.get(sid):
 			self.close_session(sid)
 
 	async def reload_connected_clients(self) -> int:

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -877,29 +877,34 @@ class App:
 						self.close_session_if_inactive(session.sid)
 					raise ConnectionRefusedError("Socket connection denied")
 
-			def on_message(message: ServerMessage):
-				payload = serialize(message)
-				# `serialize` returns a tuple, which socket.io will mistake for multiple arguments
-				payload = list(payload)
-				self._tasks.create_task(self.sio.emit("message", list(payload), to=sid))
+				# Bind the socket inside the session context so query resume
+				# (and recreated interval effects) capture the same
+				# (session, render) context as initial fetches.
+				def on_message(message: ServerMessage):
+					payload = serialize(message)
+					# `serialize` returns a tuple, which socket.io will mistake for multiple arguments
+					payload = list(payload)
+					self._tasks.create_task(
+						self.sio.emit("message", list(payload), to=sid)
+					)
 
-			render.connect(on_message)
-			# Map socket sid to renderId for message routing. If the client
-			# reconnected before the old socket's disconnect fired, unmap the
-			# old socket so its late disconnect can't tear down this connection.
-			old_sid = self._render_to_socket.get(rid)
-			if old_sid is not None and old_sid != sid:
-				self._socket_to_render.pop(old_sid, None)
-			self._socket_to_render[sid] = rid
-			self._render_to_socket[rid] = sid
+				render.connect(on_message)
+				# Map socket sid to renderId for message routing. If the client
+				# reconnected before the old socket's disconnect fired, unmap the
+				# old socket so its late disconnect can't tear down this connection.
+				old_sid = self._render_to_socket.get(rid)
+				if old_sid is not None and old_sid != sid:
+					self._socket_to_render.pop(old_sid, None)
+				self._socket_to_render[sid] = rid
+				self._render_to_socket[rid] = sid
 
-			# Cancel any pending cleanup since session is now connected
-			self._cancel_render_cleanup(rid)
+				# Cancel any pending cleanup since session is now connected
+				self._cancel_render_cleanup(rid)
 
-			# Now that the socket is bound, surface any connect-middleware error
-			# (reported pre-bind it would be dropped for a fresh render).
-			if connect_error is not None:
-				render.report_error("/", "connect", connect_error)
+				# Surface any connect-middleware error now that the socket is bound
+				# (reported pre-bind it would be dropped for a fresh render).
+				if connect_error is not None:
+					render.report_error("/", "connect", connect_error)
 
 		@self.sio.event
 		def disconnect(sid: str):  # pyright: ignore[reportUnusedFunction]

--- a/packages/pulse/python/src/pulse/queries/infinite_query.py
+++ b/packages/pulse/python/src/pulse/queries/infinite_query.py
@@ -184,6 +184,10 @@ class InfiniteQuery(Generic[T, TParam], Disposable):
 			observer = self._interval_observer
 			if observer is None:
 				return
+			# Don't stack a refetch behind one already queued/in flight (matches
+			# KeyedQuery's interval guard; also covers the resume() catch-up tick).
+			if self._has_pending_work():
+				return
 			self.invalidate(fetch_fn=observer._fetch_fn, observer=observer)  # pyright: ignore[reportPrivateUsage]
 
 		return Effect(
@@ -201,7 +205,11 @@ class InfiniteQuery(Generic[T, TParam], Disposable):
 		self._interval_observer = new_observer
 
 		if not interval_changed:
-			if self._interval_effect is None and new_interval is not None:
+			if (
+				self._interval_effect is None
+				and new_interval is not None
+				and not self._suspended
+			):
 				self._interval_effect = self._create_interval_effect(new_interval)
 			return
 
@@ -209,8 +217,50 @@ class InfiniteQuery(Generic[T, TParam], Disposable):
 			self._interval_effect.dispose()
 			self._interval_effect = None
 
-		if new_interval is not None:
+		if new_interval is not None and not self._suspended:
 			self._interval_effect = self._create_interval_effect(new_interval)
+
+	def is_stale(self, stale_time: float = 0.0) -> bool:
+		"""Whether the data is invalidated or older than stale_time seconds."""
+		if self.invalidated:
+			return True
+		return (time.time() - self.last_updated.read()) > stale_time
+
+	def suspend(self) -> None:
+		"""Stop interval refetching while the session is disconnected."""
+		if self._suspended:
+			return
+		self._suspended = True
+		if self._interval_effect is not None:
+			self._interval_effect.dispose()
+			self._interval_effect = None
+
+	def resume(self) -> None:
+		"""Restart interval refetching and refetch stale data on reconnect."""
+		if not self._suspended:
+			return
+		self._suspended = False
+		# Recreating the interval effect runs an immediate catch-up fetch
+		self._update_interval()
+		if self._interval is not None:
+			return
+		observers = [obs for obs in self._observers if obs._enabled.value]  # pyright: ignore[reportPrivateUsage]
+		if not observers:
+			return
+		stale_time = min(obs._stale_time for obs in observers)  # pyright: ignore[reportPrivateUsage]
+		# Don't stack a refetch behind an action that's already queued or
+		# running (e.g. a slow initial fetch still in flight at reconnect).
+		if self.is_stale(stale_time) and not self._has_pending_work():
+			self.invalidate(
+				fetch_fn=observers[0]._fetch_fn,  # pyright: ignore[reportPrivateUsage]
+				observer=observers[0],
+			)
+
+	def _has_pending_work(self) -> bool:
+		"""Whether an action is queued or a fetch task is in flight."""
+		if self._queue:
+			return True
+		return self._queue_task is not None and not self._queue_task.done()
 
 	# Reactive state
 	pages: ReactiveList[Page[T, TParam]]
@@ -234,6 +284,8 @@ class InfiniteQuery(Generic[T, TParam], Disposable):
 	_interval_effect: Effect | None
 	_interval: float | None
 	_interval_observer: "InfiniteQueryResult[T, TParam] | None"
+	_suspended: bool
+	invalidated: bool
 
 	def __init__(
 		self,
@@ -298,6 +350,8 @@ class InfiniteQuery(Generic[T, TParam], Disposable):
 		self._interval_effect = None
 		self._interval = None
 		self._interval_observer = None
+		self._suspended = False
+		self.invalidated = False
 
 	# ─────────────────────────────────────────────────────────────────────────
 	# Commit functions - update state after pages have been modified
@@ -325,6 +379,7 @@ class InfiniteQuery(Generic[T, TParam], Disposable):
 		"""Synchronous commit - updates state based on current pages."""
 		self._update_has_more()
 		self.last_updated.write(time.time())
+		self.invalidated = False
 		self.error.write(None)
 		self.status.write("success")
 		self.retries.write(0)
@@ -334,6 +389,7 @@ class InfiniteQuery(Generic[T, TParam], Disposable):
 		"""Synchronous error commit for set_error (no callbacks)."""
 		self.error.write(error)
 		self.last_updated.write(time.time())
+		self.invalidated = False
 		self.status.write("error")
 		self.is_fetching.write(False)
 
@@ -444,7 +500,12 @@ class InfiniteQuery(Generic[T, TParam], Disposable):
 		fetch_fn: Callable[[TParam], Awaitable[T]] | None = None,
 		observer: "InfiniteQueryResult[T, TParam] | None" = None,
 	):
-		"""Enqueue a refetch. Synchronous - does not wait for completion."""
+		"""Enqueue a refetch. Synchronous - does not wait for completion.
+
+		Without observers, the stale mark persists so the next observer (or a
+		session resume) refetches.
+		"""
+		self.invalidated = True
 		if cancel_fetch:
 			self._cancel_queue()
 		if len(self._observers) > 0:
@@ -1001,8 +1062,7 @@ class InfiniteQueryResult(Generic[T, TParam], Disposable):
 		return isinstance(self._query().current_action(), FetchPrevious)
 
 	def is_stale(self) -> bool:
-		query = self._query()
-		return (time.time() - query.last_updated.read()) > self._stale_time
+		return self._query().is_stale(self._stale_time)
 
 	async def fetch_next_page(
 		self,

--- a/packages/pulse/python/src/pulse/queries/infinite_query.py
+++ b/packages/pulse/python/src/pulse/queries/infinite_query.py
@@ -35,7 +35,11 @@ from pulse.queries.common import (
 	bind_state,
 	normalize_key,
 )
-from pulse.queries.query import RETRY_DELAY_DEFAULT, QueryConfig
+from pulse.queries.query import (
+	RETRY_DELAY_DEFAULT,
+	QueryConfig,
+	retry_backoff_delay,
+)
 from pulse.reactive import Computed, Effect, Signal, Untrack
 from pulse.reactive_extensions import ReactiveList, unwrap
 from pulse.scheduling import TimerHandleLike, create_task, later
@@ -386,10 +390,12 @@ class InfiniteQuery(Generic[T, TParam], Disposable):
 		self.retry_reason.write(None)
 
 	def _commit_error_sync(self, error: Exception):
-		"""Synchronous error commit for set_error (no callbacks)."""
+		"""Synchronous error commit for set_error (no callbacks).
+
+		Leaves ``last_updated`` (last successful fetch) and ``invalidated``
+		untouched so a failed refetch stays stale, matching TanStack Query.
+		"""
 		self.error.write(error)
-		self.last_updated.write(time.time())
-		self.invalidated = False
 		self.status.write("error")
 		self.is_fetching.write(False)
 
@@ -657,9 +663,12 @@ class InfiniteQuery(Generic[T, TParam], Disposable):
 					except asyncio.CancelledError:
 						raise
 					except Exception as e:
-						if self.retries.read() < self.cfg.retries:
+						attempt = self.retries.read()
+						if attempt < self.cfg.retries:
 							self._record_retry(e)
-							await asyncio.sleep(self.cfg.retry_delay)
+							await asyncio.sleep(
+								retry_backoff_delay(self.cfg.retry_delay, attempt)
+							)
 							continue
 						raise
 			except asyncio.CancelledError:
@@ -1562,7 +1571,8 @@ def infinite_query(
 		refetch_interval: Auto-refetch interval in seconds (default None).
 		keep_previous_data: Keep previous data while loading (default False).
 		retries: Number of retry attempts on failure (default 3).
-		retry_delay: Delay between retries in seconds (default 2.0).
+		retry_delay: Base delay (seconds) for exponential backoff between
+			retries — doubles each attempt, capped at 30s (default 2.0).
 		initial_data_updated_at: Timestamp for initial data staleness.
 		enabled: Whether query is enabled (default True).
 		fetch_on_mount: Fetch when component mounts (default True).

--- a/packages/pulse/python/src/pulse/queries/infinite_query.py
+++ b/packages/pulse/python/src/pulse/queries/infinite_query.py
@@ -38,6 +38,7 @@ from pulse.queries.common import (
 from pulse.queries.query import (
 	RETRY_DELAY_DEFAULT,
 	QueryConfig,
+	SuspendableQuery,
 	retry_backoff_delay,
 )
 from pulse.reactive import Computed, Effect, Signal, Untrack
@@ -146,7 +147,7 @@ class InfiniteQueryConfig(QueryConfig[list[Page[T, TParam]]], Generic[T, TParam]
 	max_pages: int
 
 
-class InfiniteQuery(Generic[T, TParam], Disposable):
+class InfiniteQuery(Generic[T, TParam], Disposable, SuspendableQuery):
 	"""Paginated query that stores data as a list of Page(data, param)."""
 
 	key: Key
@@ -217,9 +218,7 @@ class InfiniteQuery(Generic[T, TParam], Disposable):
 				self._interval_effect = self._create_interval_effect(new_interval)
 			return
 
-		if self._interval_effect is not None:
-			self._interval_effect.dispose()
-			self._interval_effect = None
+		self._dispose_interval_effect()
 
 		if new_interval is not None and not self._suspended:
 			self._interval_effect = self._create_interval_effect(new_interval)
@@ -230,20 +229,8 @@ class InfiniteQuery(Generic[T, TParam], Disposable):
 			return True
 		return (time.time() - self.last_updated.read()) > stale_time
 
-	def suspend(self) -> None:
-		"""Stop interval refetching while the session is disconnected."""
-		if self._suspended:
-			return
-		self._suspended = True
-		if self._interval_effect is not None:
-			self._interval_effect.dispose()
-			self._interval_effect = None
-
-	def resume(self) -> None:
-		"""Restart interval refetching and refetch stale data on reconnect."""
-		if not self._suspended:
-			return
-		self._suspended = False
+	@override
+	def _resume_after_suspend(self) -> None:
 		# Recreating the interval effect runs an immediate catch-up fetch
 		self._update_interval()
 		if self._interval is not None:
@@ -351,10 +338,9 @@ class InfiniteQuery(Generic[T, TParam], Disposable):
 		self._queue_task = None
 		self._observers = []
 		self._gc_handle = None
-		self._interval_effect = None
 		self._interval = None
 		self._interval_observer = None
-		self._suspended = False
+		self._init_suspendable_query()
 		self.invalidated = False
 
 	# ─────────────────────────────────────────────────────────────────────────
@@ -883,9 +869,7 @@ class InfiniteQuery(Generic[T, TParam], Disposable):
 		self._cancel_queue()
 		if self._queue_task and not self._queue_task.done():
 			self._queue_task.cancel()
-		if self._interval_effect is not None:
-			self._interval_effect.dispose()
-			self._interval_effect = None
+		self._dispose_interval_effect()
 		if self.cfg.on_dispose:
 			self.cfg.on_dispose(self)
 

--- a/packages/pulse/python/src/pulse/queries/query.py
+++ b/packages/pulse/python/src/pulse/queries/query.py
@@ -14,7 +14,7 @@ from typing import (
 	override,
 )
 
-from pulse.context import PulseContext
+from pulse.context import PULSE_CONTEXT
 from pulse.helpers import (
 	MISSING,
 	Disposable,
@@ -42,6 +42,7 @@ from pulse.state.state import State
 
 if TYPE_CHECKING:
 	from pulse.queries.protocol import QueryResult
+	from pulse.queries.store import QueryStore
 
 T = TypeVar("T")
 TState = TypeVar("TState", bound=State)
@@ -49,6 +50,7 @@ TState = TypeVar("TState", bound=State)
 RETRY_DELAY_DEFAULT = 2.0 if not is_pytest() else 0.01
 RETRY_MAX_DELAY = 30.0
 """Cap on the exponential backoff between retries (seconds), matching TanStack Query."""
+STATE_LOCAL_QUERY_STORE = "_pulse_local_query_store"
 
 
 def retry_backoff_delay(
@@ -64,6 +66,21 @@ def retry_backoff_delay(
 	long before that anyway.
 	"""
 	return min(base * 2.0 ** min(attempt, 1000), cap)
+
+
+def query_store_for_state(state: State) -> "QueryStore":
+	"""Return the render store, or a private state-local store outside render."""
+	ctx = PULSE_CONTEXT.get()
+	if ctx is not None and ctx.render is not None:
+		return ctx.render.query_store
+
+	store = getattr(state, STATE_LOCAL_QUERY_STORE, None)
+	if store is None:
+		from pulse.queries.store import QueryStore
+
+		store = QueryStore()
+		setattr(state, STATE_LOCAL_QUERY_STORE, store)
+	return store
 
 
 @dataclass(slots=True)
@@ -1318,10 +1335,7 @@ class QueryProperty(Generic[T, TState], InitializableProperty):
 			const_key = self._key  # ensure a constant reference
 			key_computed = Computed(lambda: const_key, name=f"query.key.{self.name}")
 
-		render = PulseContext.get().render
-		if render is None:
-			raise RuntimeError("No render session available")
-		store = render.query_store
+		store = query_store_for_state(state)
 
 		def query() -> KeyedQuery[T]:
 			key = key_computed()
@@ -1364,8 +1378,7 @@ class QueryProperty(Generic[T, TState], InitializableProperty):
 	) -> UnkeyedQueryResult[T]:
 		"""Create a private unkeyed query, registered with the session store
 		so it participates in suspend/resume."""
-		render = PulseContext.get().render
-		store = render.query_store if render is not None else None
+		store = query_store_for_state(state)
 		result = UnkeyedQueryResult[T](
 			fetch_fn=fetch_fn,
 			on_success=bind_state(state, self._on_success_fn)
@@ -1384,10 +1397,9 @@ class QueryProperty(Generic[T, TState], InitializableProperty):
 			refetch_interval=self._refetch_interval,
 			enabled=self._enabled,
 			fetch_on_mount=self._fetch_on_mount,
-			on_dispose=store.unregister_unkeyed if store is not None else None,
+			on_dispose=store.unregister_unkeyed,
 		)
-		if store is not None:
-			store.register_unkeyed(result)
+		store.register_unkeyed(result)
 		return result
 
 	def __get__(self, obj: Any, objtype: Any = None) -> "QueryResult[T]":

--- a/packages/pulse/python/src/pulse/queries/query.py
+++ b/packages/pulse/python/src/pulse/queries/query.py
@@ -293,7 +293,38 @@ async def run_fetch_with_retries(
 				return
 
 
-class KeyedQuery(Generic[T], Disposable):
+class SuspendableQuery:
+	_suspended: bool = False
+	_interval_effect: Effect | None = None
+
+	def _init_suspendable_query(self) -> None:
+		self._suspended = False
+		self._interval_effect = None
+
+	def _dispose_interval_effect(self) -> None:
+		if self._interval_effect is not None:
+			self._interval_effect.dispose()
+			self._interval_effect = None
+
+	def suspend(self) -> None:
+		"""Stop interval refetching while the session is disconnected."""
+		if self._suspended:
+			return
+		self._suspended = True
+		self._dispose_interval_effect()
+
+	def resume(self) -> None:
+		"""Restart interval refetching and refetch stale data on reconnect."""
+		if not self._suspended:
+			return
+		self._suspended = False
+		self._resume_after_suspend()
+
+	def _resume_after_suspend(self) -> None:
+		raise NotImplementedError
+
+
+class KeyedQuery(Generic[T], Disposable, SuspendableQuery):
 	"""
 	Query for keyed queries (shared across observers).
 	Uses direct task management without dependency tracking.
@@ -335,10 +366,9 @@ class KeyedQuery(Generic[T], Disposable):
 		self._task = None
 		self._task_initiator = None
 		self._gc_handle = None
-		self._interval_effect = None
 		self._interval = None
 		self._interval_observer = None
-		self._suspended = False
+		self._init_suspendable_query()
 
 	# --- Delegate signal access to state ---
 	@property
@@ -542,9 +572,7 @@ class KeyedQuery(Generic[T], Disposable):
 				self._interval_effect = self._create_interval_effect(new_interval)
 			return
 
-		if self._interval_effect is not None:
-			self._interval_effect.dispose()
-			self._interval_effect = None
+		self._dispose_interval_effect()
 
 		if new_interval is not None and not self._suspended:
 			self._interval_effect = self._create_interval_effect(new_interval)
@@ -555,20 +583,8 @@ class KeyedQuery(Generic[T], Disposable):
 			return True
 		return (time.time() - self.state.last_updated.read()) > stale_time
 
-	def suspend(self) -> None:
-		"""Stop interval refetching while the session is disconnected."""
-		if self._suspended:
-			return
-		self._suspended = True
-		if self._interval_effect is not None:
-			self._interval_effect.dispose()
-			self._interval_effect = None
-
-	def resume(self) -> None:
-		"""Restart interval refetching and refetch stale data on reconnect."""
-		if not self._suspended:
-			return
-		self._suspended = False
+	@override
+	def _resume_after_suspend(self) -> None:
 		# Recreating the interval effect runs an immediate catch-up fetch
 		self._update_interval()
 		if self._interval is not None:
@@ -655,14 +671,12 @@ class KeyedQuery(Generic[T], Disposable):
 		"""Clean up the query, cancelling any in-flight fetch."""
 		self.cancel_gc()
 		self.cancel()
-		if self._interval_effect is not None:
-			self._interval_effect.dispose()
-			self._interval_effect = None
+		self._dispose_interval_effect()
 		if self.cfg.on_dispose:
 			self.cfg.on_dispose(self)
 
 
-class UnkeyedQueryResult(Generic[T], Disposable):
+class UnkeyedQueryResult(Generic[T], Disposable, SuspendableQuery):
 	"""
 	Query for unkeyed queries (single observer with dependency tracking).
 	Uses an AsyncEffect to track dependencies and re-run on changes.
@@ -723,8 +737,7 @@ class UnkeyedQueryResult(Generic[T], Disposable):
 		self._refetch_interval = interval
 		self._keep_previous_data = keep_previous_data
 		self._enabled = Signal(enabled, name="query.enabled(unkeyed)")
-		self._interval_effect = None
-		self._suspended = False
+		self._init_suspendable_query()
 		self._on_dispose = on_dispose
 
 		# Create effect with auto-tracking (deps=None)
@@ -895,20 +908,8 @@ class UnkeyedQueryResult(Generic[T], Disposable):
 		"""Cancel the current fetch if running."""
 		self._effect.cancel(cancel_interval=False)
 
-	def suspend(self) -> None:
-		"""Stop interval refetching while the session is disconnected."""
-		if self._suspended:
-			return
-		self._suspended = True
-		if self._interval_effect is not None:
-			self._interval_effect.dispose()
-			self._interval_effect = None
-
-	def resume(self) -> None:
-		"""Restart interval refetching and refetch stale data on reconnect."""
-		if not self._suspended:
-			return
-		self._suspended = False
+	@override
+	def _resume_after_suspend(self) -> None:
 		if self._refetch_interval is not None:
 			# Recreating the interval effect runs an immediate catch-up fetch
 			self._setup_interval_effect(self._refetch_interval)
@@ -920,8 +921,7 @@ class UnkeyedQueryResult(Generic[T], Disposable):
 	@override
 	def dispose(self):
 		"""Clean up the query and its effect."""
-		if self._interval_effect is not None:
-			self._interval_effect.dispose()
+		self._dispose_interval_effect()
 		self._effect.dispose()
 		if self._on_dispose is not None:
 			self._on_dispose(self)

--- a/packages/pulse/python/src/pulse/queries/query.py
+++ b/packages/pulse/python/src/pulse/queries/query.py
@@ -88,9 +88,13 @@ class QueryState(Generic[T]):
 		is_fetching: Signal indicating if a fetch is in progress.
 		retries: Signal with current retry attempt count.
 		retry_reason: Signal with exception from last failed retry.
+		invalidated: Whether the data was explicitly marked stale. Persists
+			until the next fetch completes, so invalidating an unobserved
+			query forces a refetch when it is next observed or resumed.
 	"""
 
 	cfg: QueryConfig[T]
+	invalidated: bool
 
 	# Reactive signals for query state
 	data: Signal[T | None | Missing]
@@ -141,6 +145,7 @@ class QueryState(Generic[T]):
 		self.is_fetching = Signal(False, name=f"query.is_fetching({name})")
 		self.retries = Signal(0, name=f"query.retries({name})")
 		self.retry_reason = Signal(None, name=f"query.retry_reason({name})")
+		self.invalidated = False
 
 	def set_data(
 		self,
@@ -186,6 +191,7 @@ class QueryState(Generic[T]):
 		"""Set success state with data."""
 		self.data.write(data)
 		self.last_updated.write(time.time())
+		self.invalidated = False
 		self.error.write(None)
 		self.status.write("success")
 		if not manual:
@@ -197,6 +203,7 @@ class QueryState(Generic[T]):
 		"""Apply error state to the query."""
 		self.error.write(error)
 		self.last_updated.write(time.time())
+		self.invalidated = False
 		self.status.write("error")
 		if not manual:
 			self.is_fetching.write(False)
@@ -277,6 +284,7 @@ class KeyedQuery(Generic[T], Disposable):
 	_interval_effect: Effect | None
 	_interval: float | None
 	_interval_observer: "KeyedQueryResult[T] | None"
+	_suspended: bool
 
 	def __init__(
 		self,
@@ -305,6 +313,7 @@ class KeyedQuery(Generic[T], Disposable):
 		self._interval_effect = None
 		self._interval = None
 		self._interval_observer = None
+		self._suspended = False
 
 	# --- Delegate signal access to state ---
 	@property
@@ -500,7 +509,11 @@ class KeyedQuery(Generic[T], Disposable):
 		self._interval_observer = new_observer
 
 		if not interval_changed:
-			if self._interval_effect is None and new_interval is not None:
+			if (
+				self._interval_effect is None
+				and new_interval is not None
+				and not self._suspended
+			):
 				self._interval_effect = self._create_interval_effect(new_interval)
 			return
 
@@ -508,8 +521,43 @@ class KeyedQuery(Generic[T], Disposable):
 			self._interval_effect.dispose()
 			self._interval_effect = None
 
-		if new_interval is not None:
+		if new_interval is not None and not self._suspended:
 			self._interval_effect = self._create_interval_effect(new_interval)
+
+	def is_stale(self, stale_time: float = 0.0) -> bool:
+		"""Whether the data is invalidated or older than stale_time seconds."""
+		if self.state.invalidated:
+			return True
+		return (time.time() - self.state.last_updated.read()) > stale_time
+
+	def suspend(self) -> None:
+		"""Stop interval refetching while the session is disconnected."""
+		if self._suspended:
+			return
+		self._suspended = True
+		if self._interval_effect is not None:
+			self._interval_effect.dispose()
+			self._interval_effect = None
+
+	def resume(self) -> None:
+		"""Restart interval refetching and refetch stale data on reconnect."""
+		if not self._suspended:
+			return
+		self._suspended = False
+		# Recreating the interval effect runs an immediate catch-up fetch
+		self._update_interval()
+		if self._interval is not None:
+			return
+		observers = [obs for obs in self.observers if obs._enabled.value]  # pyright: ignore[reportPrivateUsage]
+		if not observers:
+			return
+		stale_time = min(obs._stale_time for obs in observers)  # pyright: ignore[reportPrivateUsage]
+		if self.is_stale(stale_time) and not self.is_scheduled:
+			self.run_fetch(
+				observers[0]._fetch_fn,  # pyright: ignore[reportPrivateUsage]
+				cancel_previous=False,
+				initiator=observers[0],
+			)
 
 	async def refetch(self, cancel_refetch: bool = True) -> ActionResult[T]:
 		"""
@@ -526,10 +574,12 @@ class KeyedQuery(Generic[T], Disposable):
 	def invalidate(self, cancel_refetch: bool = False):
 		"""
 		Marks query as stale. If there are active observers, triggers a refetch.
-		Uses the first observer's fetch function.
+		Without observers, the stale mark persists so the next observer (or a
+		session resume) refetches.
 
 		Note: Prefer calling invalidate() on KeyedQueryResult to ensure the correct fetch function is used.
 		"""
+		self.state.invalidated = True
 		if len(self.observers) > 0:
 			fetch_fn = self._get_first_observer_fetch_fn()
 			if not self.is_scheduled or cancel_refetch:
@@ -607,6 +657,8 @@ class UnkeyedQueryResult(Generic[T], Disposable):
 	_enabled: Signal[bool]
 	_interval_effect: Effect | None
 	_data_computed: Computed[T | None | Missing]
+	_suspended: bool
+	_on_dispose: "Callable[[UnkeyedQueryResult[T]], None] | None"
 
 	def __init__(
 		self,
@@ -623,6 +675,7 @@ class UnkeyedQueryResult(Generic[T], Disposable):
 		keep_previous_data: bool = False,
 		enabled: bool = True,
 		fetch_on_mount: bool = True,
+		on_dispose: "Callable[[UnkeyedQueryResult[T]], None] | None" = None,
 	):
 		self.state = QueryState(
 			name="unkeyed",
@@ -646,6 +699,8 @@ class UnkeyedQueryResult(Generic[T], Disposable):
 		self._keep_previous_data = keep_previous_data
 		self._enabled = Signal(enabled, name="query.enabled(unkeyed)")
 		self._interval_effect = None
+		self._suspended = False
+		self._on_dispose = on_dispose
 
 		# Create effect with auto-tracking (deps=None)
 		# Pass state as fetcher since it has the Signal attributes directly
@@ -756,7 +811,9 @@ class UnkeyedQueryResult(Generic[T], Disposable):
 
 	# --- Query operations ---
 	def is_stale(self) -> bool:
-		"""Check if the query data is stale based on stale_time."""
+		"""Check if the query data is invalidated or stale based on stale_time."""
+		if self.state.invalidated:
+			return True
 		return (time.time() - self.state.last_updated.read()) > self._stale_time
 
 	async def _run(self):
@@ -805,6 +862,7 @@ class UnkeyedQueryResult(Generic[T], Disposable):
 
 	def invalidate(self):
 		"""Mark the query as stale and refetch through the effect."""
+		self.state.invalidated = True
 		if not self.is_scheduled:
 			self.schedule()
 
@@ -812,12 +870,36 @@ class UnkeyedQueryResult(Generic[T], Disposable):
 		"""Cancel the current fetch if running."""
 		self._effect.cancel(cancel_interval=False)
 
+	def suspend(self) -> None:
+		"""Stop interval refetching while the session is disconnected."""
+		if self._suspended:
+			return
+		self._suspended = True
+		if self._interval_effect is not None:
+			self._interval_effect.dispose()
+			self._interval_effect = None
+
+	def resume(self) -> None:
+		"""Restart interval refetching and refetch stale data on reconnect."""
+		if not self._suspended:
+			return
+		self._suspended = False
+		if self._refetch_interval is not None:
+			# Recreating the interval effect runs an immediate catch-up fetch
+			self._setup_interval_effect(self._refetch_interval)
+			return
+		with Untrack():
+			if self._enabled.value and self.is_stale() and not self.is_scheduled:
+				self.schedule()
+
 	@override
 	def dispose(self):
 		"""Clean up the query and its effect."""
 		if self._interval_effect is not None:
 			self._interval_effect.dispose()
 		self._effect.dispose()
+		if self._on_dispose is not None:
+			self._on_dispose(self)
 
 
 class KeyedQueryResult(Generic[T], Disposable):
@@ -939,9 +1021,8 @@ class KeyedQueryResult(Generic[T], Disposable):
 		return cast(T | None, value)
 
 	def is_stale(self) -> bool:
-		"""Check if the query data is stale based on stale_time."""
-		query = self._query()
-		return (time.time() - query.last_updated.read()) > self._stale_time
+		"""Check if the query data is invalidated or stale based on stale_time."""
+		return self._query().is_stale(self._stale_time)
 
 	async def refetch(self, cancel_refetch: bool = True) -> ActionResult[T]:
 		"""
@@ -970,6 +1051,7 @@ class KeyedQueryResult(Generic[T], Disposable):
 	def invalidate(self):
 		"""Mark the query as stale and refetch using this observer's fetch function."""
 		query = self._query()
+		query.state.invalidated = True
 		if not query.is_scheduled and len(query.observers) > 0:
 			query.run_fetch(self._fetch_fn, cancel_previous=False, initiator=self)
 
@@ -1255,8 +1337,11 @@ class QueryProperty(Generic[T, TState], InitializableProperty):
 		initial_data_updated_at: float | dt.datetime | None,
 		state: TState,
 	) -> UnkeyedQueryResult[T]:
-		"""Create a private unkeyed query."""
-		return UnkeyedQueryResult[T](
+		"""Create a private unkeyed query, registered with the session store
+		so it participates in suspend/resume."""
+		render = PulseContext.get().render
+		store = render.query_store if render is not None else None
+		result = UnkeyedQueryResult[T](
 			fetch_fn=fetch_fn,
 			on_success=bind_state(state, self._on_success_fn)
 			if self._on_success_fn
@@ -1274,7 +1359,11 @@ class QueryProperty(Generic[T, TState], InitializableProperty):
 			refetch_interval=self._refetch_interval,
 			enabled=self._enabled,
 			fetch_on_mount=self._fetch_on_mount,
+			on_dispose=store.unregister_unkeyed if store is not None else None,
 		)
+		if store is not None:
+			store.register_unkeyed(result)
+		return result
 
 	def __get__(self, obj: Any, objtype: Any = None) -> "QueryResult[T]":
 		if obj is None:

--- a/packages/pulse/python/src/pulse/queries/query.py
+++ b/packages/pulse/python/src/pulse/queries/query.py
@@ -47,6 +47,23 @@ T = TypeVar("T")
 TState = TypeVar("TState", bound=State)
 
 RETRY_DELAY_DEFAULT = 2.0 if not is_pytest() else 0.01
+RETRY_MAX_DELAY = 30.0
+"""Cap on the exponential backoff between retries (seconds), matching TanStack Query."""
+
+
+def retry_backoff_delay(
+	base: float, attempt: int, cap: float = RETRY_MAX_DELAY
+) -> float:
+	"""Exponential backoff for a 0-based retry attempt.
+
+	Mirrors TanStack Query's default ``min(base * 2**attempt, cap)``: the delay
+	doubles each retry so a flaky endpoint is not hammered at a fixed interval.
+
+	The exponent is clamped so an absurd ``retries`` count can't overflow the
+	float conversion (``2**1024`` exceeds the max float); the result is capped
+	long before that anyway.
+	"""
+	return min(base * 2.0 ** min(attempt, 1000), cap)
 
 
 @dataclass(slots=True)
@@ -58,7 +75,9 @@ class QueryConfig(Generic[T]):
 
 	Attributes:
 		retries: Number of retry attempts on failure (default 3).
-		retry_delay: Delay in seconds between retry attempts (default 2.0).
+		retry_delay: Base delay in seconds for exponential backoff between
+			retries; the delay doubles each attempt and is capped at 30s
+			(default 2.0).
 		initial_data: Initial data value or factory function.
 		initial_data_updated_at: Timestamp for initial data staleness calculation.
 		gc_time: Seconds to keep unused query in cache before garbage collection.
@@ -200,10 +219,14 @@ class QueryState(Generic[T]):
 			self.retry_reason.write(None)
 
 	def apply_error(self, error: Exception, manual: bool = False):
-		"""Apply error state to the query."""
+		"""Apply error state to the query.
+
+		Does not touch ``last_updated`` (which tracks the last successful data
+		fetch) nor clear ``invalidated``: a failed refetch must leave the query
+		stale so it remains eligible to refetch, matching TanStack Query (which
+		clears ``isInvalidated`` on success only).
+		"""
 		self.error.write(error)
-		self.last_updated.write(time.time())
-		self.invalidated = False
 		self.status.write("error")
 		if not manual:
 			self.is_fetching.write(False)
@@ -258,7 +281,9 @@ async def run_fetch_with_retries(
 			current_retries = state.retries.read()
 			if current_retries < state.cfg.retries:
 				state.failed_retry(e)
-				await asyncio.sleep(state.cfg.retry_delay)
+				await asyncio.sleep(
+					retry_backoff_delay(state.cfg.retry_delay, current_retries)
+				)
 			else:
 				state.retry_reason.write(e)
 				state.apply_error(e)
@@ -1435,7 +1460,8 @@ def query(
 		refetch_interval: Auto-refetch interval in seconds (default None, disabled).
 		keep_previous_data: Keep previous data while loading (default False).
 		retries: Number of retry attempts on failure (default 3).
-		retry_delay: Delay between retries in seconds (default 2.0).
+		retry_delay: Base delay (seconds) for exponential backoff between
+			retries — doubles each attempt, capped at 30s (default 2.0).
 		initial_data_updated_at: Timestamp for initial data staleness calculation.
 		enabled: Whether query is enabled (default True).
 		fetch_on_mount: Fetch when component mounts (default True).

--- a/packages/pulse/python/src/pulse/queries/store.py
+++ b/packages/pulse/python/src/pulse/queries/store.py
@@ -1,8 +1,8 @@
 import datetime as dt
 from collections.abc import Callable
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar, cast, override
 
-from pulse.helpers import MISSING, Missing
+from pulse.helpers import MISSING, Disposable, Missing
 from pulse.queries.common import Key, QueryKey, normalize_key
 from pulse.queries.infinite_query import InfiniteQuery, Page
 from pulse.queries.query import RETRY_DELAY_DEFAULT, KeyedQuery, UnkeyedQueryResult
@@ -10,7 +10,7 @@ from pulse.queries.query import RETRY_DELAY_DEFAULT, KeyedQuery, UnkeyedQueryRes
 T = TypeVar("T")
 
 
-class QueryStore:
+class QueryStore(Disposable):
 	"""
 	Store for query entries. Manages creation, retrieval, and disposal of queries.
 
@@ -171,3 +171,7 @@ class QueryStore:
 		self._entries.clear()
 		# Unkeyed results are owned and disposed by their States; just drop refs
 		self._unkeyed.clear()
+
+	@override
+	def dispose(self) -> None:
+		self.dispose_all()

--- a/packages/pulse/python/src/pulse/queries/store.py
+++ b/packages/pulse/python/src/pulse/queries/store.py
@@ -5,7 +5,7 @@ from typing import Any, TypeVar, cast
 from pulse.helpers import MISSING, Missing
 from pulse.queries.common import Key, QueryKey, normalize_key
 from pulse.queries.infinite_query import InfiniteQuery, Page
-from pulse.queries.query import RETRY_DELAY_DEFAULT, KeyedQuery
+from pulse.queries.query import RETRY_DELAY_DEFAULT, KeyedQuery, UnkeyedQueryResult
 
 T = TypeVar("T")
 
@@ -13,10 +13,47 @@ T = TypeVar("T")
 class QueryStore:
 	"""
 	Store for query entries. Manages creation, retrieval, and disposal of queries.
+
+	Also tracks the session's connection state: while suspended (client
+	disconnected), interval refetching is paused; on resume, intervals restart
+	and stale queries refetch.
 	"""
+
+	suspended: bool
 
 	def __init__(self):
 		self._entries: dict[Key, KeyedQuery[Any] | InfiniteQuery[Any, Any]] = {}
+		self._unkeyed: set[UnkeyedQueryResult[Any]] = set()
+		self.suspended = False
+
+	def register_unkeyed(self, result: UnkeyedQueryResult[Any]) -> None:
+		"""Track an unkeyed query result so it participates in suspend/resume."""
+		self._unkeyed.add(result)
+		if self.suspended:
+			result.suspend()
+
+	def unregister_unkeyed(self, result: UnkeyedQueryResult[Any]) -> None:
+		self._unkeyed.discard(result)
+
+	def suspend_all(self) -> None:
+		"""Pause interval refetching for all queries (client disconnected)."""
+		if self.suspended:
+			return
+		self.suspended = True
+		for entry in self._entries.values():
+			entry.suspend()
+		for result in self._unkeyed:
+			result.suspend()
+
+	def resume_all(self) -> None:
+		"""Restart intervals and refetch stale queries (client reconnected)."""
+		if not self.suspended:
+			return
+		self.suspended = False
+		for entry in list(self._entries.values()):
+			entry.resume()
+		for result in list(self._unkeyed):
+			result.resume()
 
 	def items(self):
 		"""Iterate over all (key, query) pairs in the store."""
@@ -58,6 +95,8 @@ class QueryStore:
 			retry_delay=retry_delay,
 			on_dispose=_on_dispose,
 		)
+		if self.suspended:
+			entry.suspend()
 		self._entries[nkey] = entry
 		return entry
 
@@ -120,6 +159,8 @@ class QueryStore:
 			retry_delay=retry_delay,
 			on_dispose=_on_dispose,
 		)
+		if self.suspended:
+			entry.suspend()
 		self._entries[nkey] = entry
 		return entry
 
@@ -128,3 +169,5 @@ class QueryStore:
 		for entry in list(self._entries.values()):
 			entry.dispose()
 		self._entries.clear()
+		# Unkeyed results are owned and disposed by their States; just drop refs
+		self._unkeyed.clear()

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -417,13 +417,17 @@ class RenderSession:
 		exc: BaseException,
 		details: dict[str, Any] | None = None,
 	):
+		# Format from the exception object, not the ambient sys.exc_info(): this
+		# is also called outside an `except` block (e.g. a deferred connect error),
+		# where traceback.format_exc() would yield "NoneType: None".
+		stack = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
 		self.send(
 			{
 				"type": "server_error",
 				"path": path,
 				"error": {
 					"message": str(exc),
-					"stack": traceback.format_exc(),
+					"stack": stack,
 					"phase": phase,
 					"details": details or {},
 				},
@@ -434,7 +438,7 @@ class RenderSession:
 			path,
 			phase,
 			exc,
-			traceback.format_exc(),
+			stack,
 		)
 
 	# ---- State transitions ----

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -83,8 +83,7 @@ def run_js(expr: Any, *, result: bool = False) -> asyncio.Future[Any] | None:
 	return ctx.render.run_js(expr, result=result)
 
 
-MountState = Literal["pending", "active", "idle", "closed"]
-PendingAction = Literal["idle", "dispose"]
+MountState = Literal["pending", "active", "suspended", "closed"]
 T_Render = TypeVar("T_Render")
 
 
@@ -97,7 +96,8 @@ class RouteMount:
 	_pulse_ctx: PulseContext | None
 	initialized: bool
 	state: MountState
-	pending_action: PendingAction | None
+	ever_active: bool
+	dispose_on_timeout: bool
 	queue: list[ServerMessage] | None
 	queue_timeout: TimerHandleLike | None
 	mount_id: str
@@ -119,7 +119,8 @@ class RouteMount:
 		self.tree = RenderTree(route.render())
 		self.initialized = False
 		self.state = "pending"
-		self.pending_action = None
+		self.ever_active = False
+		self.dispose_on_timeout = False
 		self.queue = []
 		self.queue_timeout = None
 		self.mount_id = uuid.uuid4().hex
@@ -137,36 +138,27 @@ class RouteMount:
 			self.queue_timeout.cancel()
 			self.render.discard_timer(self.queue_timeout)
 			self.queue_timeout = None
-		self.pending_action = None
 
 	def _on_pending_timeout(self) -> None:
 		if self.state != "pending":
 			return
-		action = self.pending_action
-		self.pending_action = None
-		if action == "dispose":
+		# Mounts the client never attached to (e.g. crawler prerenders) and
+		# explicit detaches are garbage; attached mounts suspend so the user
+		# can resume with their state intact.
+		if self.dispose_on_timeout or not self.ever_active:
 			self.render.dispose_mount(self.path, self)
 			return
-		self.to_idle()
+		self.suspend()
 
-	def start_pending(self, timeout: float, *, action: PendingAction = "idle") -> None:
-		if self.state == "pending":
-			prev_action = self.pending_action
-			next_action: PendingAction = (
-				"dispose" if prev_action == "dispose" or action == "dispose" else "idle"
-			)
-			self._cancel_pending_timeout()
-			self.pending_action = next_action
-			self.queue_timeout = self.render.schedule_later(
-				timeout, self._on_pending_timeout
-			)
-			return
+	def start_pending(self, timeout: float, *, dispose: bool = False) -> None:
+		dispose = dispose or (self.state == "pending" and self.dispose_on_timeout)
 		self._cancel_pending_timeout()
-		if self.state == "idle" and self.effect:
-			self.effect.resume()
-		self.state = "pending"
-		self.queue = []
-		self.pending_action = action
+		if self.state != "pending":
+			if self.state == "suspended" and self.effect:
+				self.effect.resume()
+			self.state = "pending"
+			self.queue = []
+		self.dispose_on_timeout = dispose
 		self.queue_timeout = self.render.schedule_later(
 			timeout, self._on_pending_timeout
 		)
@@ -180,6 +172,18 @@ class RouteMount:
 				send_message(msg)
 		self.queue = None
 		self.state = "active"
+		self.ever_active = True
+		self.dispose_on_timeout = False
+
+	def suspend(self) -> None:
+		"""Pause rendering but keep the mounted tree and hook state for resume."""
+		if self.state != "pending":
+			return
+		self.state = "suspended"
+		self.queue = None
+		self._cancel_pending_timeout()
+		if self.effect:
+			self.effect.pause()
 
 	def deliver(
 		self, message: ServerMessage, send_message: Callable[[ServerMessage], Any]
@@ -194,15 +198,7 @@ class RouteMount:
 			return
 		if self.state == "closed":
 			raise RuntimeError(f"Message sent to closed mount {self.path!r}")
-
-	def to_idle(self) -> None:
-		if self.state != "pending":
-			return
-		self.state = "idle"
-		self.queue = None
-		self._cancel_pending_timeout()
-		if self.effect:
-			self.effect.pause()
+		# suspended: drop; the client gets a fresh init on resume
 
 	def ensure_effect(self, *, lazy: bool = False, flush: bool = True) -> None:
 		if self.effect is not None:
@@ -336,11 +332,16 @@ class RenderSession:
 			self._global_queue = []
 			for msg in queued:
 				self.send(msg)
+		# Restart query intervals and refetch stale data (no-op on first connect)
+		with PulseContext.update(render=self):
+			self.query_store.resume_all()
 
 	def disconnect(self):
-		"""WebSocket disconnected. Start queuing briefly before pausing."""
+		"""WebSocket disconnected. Queue briefly, then suspend mounts on timeout."""
 		self._send_message = None
 		self.connected = False
+		# Pause query interval refetching while nobody is watching
+		self.query_store.suspend_all()
 
 		for mount in self.route_mounts.values():
 			if mount.state == "active":
@@ -405,7 +406,6 @@ class RenderSession:
 			return
 		if mount.state == "pending":
 			mount.deliver(message, lambda _: None)
-		# idle: drop (effect should be paused anyway)
 
 	def report_error(
 		self,
@@ -485,7 +485,7 @@ class RenderSession:
 		"""
 		Client ready to receive updates for path.
 		- PENDING: flush queue, transition to ACTIVE
-		- IDLE: request reload
+		- SUSPENDED: re-render, send a fresh init, transition to ACTIVE
 		- ACTIVE: update route_info
 		- No mount: request reload
 		Returns True when callbacks can be accepted for this path.
@@ -493,16 +493,35 @@ class RenderSession:
 		path = ensure_absolute_path(path)
 		mount = self.route_mounts.get(path)
 
-		if mount is None or mount.state == "idle":
+		if mount is None:
 			# Initial render must come from prerender
 			self.send({"type": "reload"})
 			return False
 
-		# Update route info for active and pending mounts
 		mount.update_route(route_info)
+		if mount.state == "suspended":
+			return self._resume_mount(mount, path)
 		if mount.state == "pending" and self._send_message:
 			mount.activate(self._send_message)
 		return mount.state == "active"
+
+	def _resume_mount(self, mount: RouteMount, path: str) -> bool:
+		"""Reactivate a suspended mount by re-rendering and sending a fresh init.
+
+		The retained tree and hook state carry the user's work across the
+		disconnect; the client replaces its view with the new init.
+		"""
+		assert mount.effect is not None
+		mount.effect.resume()
+		with mount.effect.capture_deps(update_deps=True):
+			message = self.render(mount, path)
+		if message["type"] == "navigate_to":
+			self.send(message)
+			self.dispose_mount(path, mount)
+			return False
+		mount.state = "active"
+		self.send(message)
+		return True
 
 	def update_route(self, path: str, route_info: RouteInfo):
 		"""Update routing state (query params, etc.) for attached path."""
@@ -546,7 +565,7 @@ class RenderSession:
 			# by the replayed attach. The mount id was renewed above before this delay,
 			# so async work from the detached generation is still route-stale and cannot
 			# navigate during the grace period.
-			mount.start_pending(self.dev_strict_mode_detach_timeout, action="dispose")
+			mount.start_pending(self.dev_strict_mode_detach_timeout, dispose=True)
 			return
 		self.dispose_mount(path, mount)
 

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -332,7 +332,10 @@ class RenderSession:
 			self._global_queue = []
 			for msg in queued:
 				self.send(msg)
-		# Restart query intervals and refetch stale data (no-op on first connect)
+		# Restart query intervals and refetch stale data (no-op on first connect).
+		# Establishes render context here (so resume fetch-tasks register on this
+		# render); the session is inherited from the caller's context, which must
+		# wrap connect() so reconnect fetches match initial fetches.
 		with PulseContext.update(render=self):
 			self.query_store.resume_all()
 

--- a/packages/pulse/python/src/pulse/renderer.py
+++ b/packages/pulse/python/src/pulse/renderer.py
@@ -79,8 +79,17 @@ class RenderTree:
 		self.rendered = False
 
 	def render(self) -> VDOM:
-		"""First render. Returns VDOM."""
-		renderer = Renderer()
+		"""Render and return the full VDOM.
+
+		On an already-rendered tree (re-prerender, resume after suspend),
+		reconciles in place first so component hook state is preserved, then
+		serializes without re-invoking components.
+		"""
+		if self.rendered:
+			self.rerender()
+			renderer = Renderer(reuse_contents=True)
+		else:
+			renderer = Renderer()
 		vdom, self.element = renderer.render_tree(self.element)
 		self.callbacks = renderer.callbacks
 		self.rendered = True
@@ -108,9 +117,14 @@ class RenderTree:
 
 
 class Renderer:
-	def __init__(self) -> None:
+	# Serialize already-rendered components from their contents instead of
+	# re-invoking them (which would mint fresh hook state for children).
+	reuse_contents: bool
+
+	def __init__(self, *, reuse_contents: bool = False) -> None:
 		self.callbacks: Callbacks = {}
 		self.operations: list[VDOMOperation] = []
+		self.reuse_contents = reuse_contents
 
 	# ------------------------------------------------------------------
 	# Rendering helpers
@@ -131,6 +145,9 @@ class Renderer:
 	def render_component(
 		self, component: PulseNode, path: str
 	) -> tuple[VDOM, PulseNode]:
+		if self.reuse_contents and component.contents is not None:
+			vdom, component.contents = self.render_tree(component.contents, path)
+			return vdom, component
 		if component.hooks is None:
 			component.hooks = HookContext()
 		with component.hooks:

--- a/packages/pulse/python/tests/test_query.py
+++ b/packages/pulse/python/tests/test_query.py
@@ -7,7 +7,12 @@ import pulse as ps
 import pytest
 from pulse.helpers import MISSING
 from pulse.queries.protocol import QueryResult
-from pulse.queries.query import KeyedQuery, KeyedQueryResult, UnkeyedQueryResult
+from pulse.queries.query import (
+	STATE_LOCAL_QUERY_STORE,
+	KeyedQuery,
+	KeyedQueryResult,
+	UnkeyedQueryResult,
+)
 from pulse.queries.store import QueryStore
 from pulse.reactive import Computed, Untrack
 from pulse.render_session import RenderSession
@@ -3621,3 +3626,43 @@ def test_retry_backoff_delay_is_exponential_and_capped():
 	# Absurd attempt counts (retries >= 1024) must not overflow the float
 	assert retry_backoff_delay(1.0, 5000) == RETRY_MAX_DELAY
 	assert retry_backoff_delay(2.0, 100000) == RETRY_MAX_DELAY
+
+
+@pytest.mark.asyncio
+async def test_unkeyed_state_query_uses_local_store_without_render_context():
+	assert ps.PulseContext.get().render is None
+
+	class S(ps.State):
+		@ps.query(retries=0)
+		async def value(self) -> int:
+			return 1
+
+	state = S()
+	query = state.value
+	await query.wait()
+	assert query.data == 1
+
+	store = getattr(state, STATE_LOCAL_QUERY_STORE)
+	assert query in store._unkeyed  # pyright: ignore[reportPrivateUsage]
+	state.dispose()
+	assert store._unkeyed == set()  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.asyncio
+async def test_keyed_state_query_uses_local_store_without_render_context():
+	assert ps.PulseContext.get().render is None
+
+	class S(ps.State):
+		@ps.query(retries=0, key=("value",))
+		async def value(self) -> int:
+			return 1
+
+	state = S()
+	query = state.value
+	await query.wait()
+	assert query.data == 1
+
+	store = getattr(state, STATE_LOCAL_QUERY_STORE)
+	assert store.get(("value",)) is not None
+	state.dispose()
+	assert store.get(("value",)) is None

--- a/packages/pulse/python/tests/test_query.py
+++ b/packages/pulse/python/tests/test_query.py
@@ -3605,3 +3605,19 @@ async def test_query_with_callable_list_key_updates_on_inplace_change():
 		return result._query().key == ("user", 2)  # pyright: ignore[reportPrivateUsage]
 
 	assert await wait_for(key_matches, timeout=0.2)
+
+
+def test_retry_backoff_delay_is_exponential_and_capped():
+	from pulse.queries.query import RETRY_MAX_DELAY, retry_backoff_delay
+
+	# Doubles each (0-based) attempt
+	assert retry_backoff_delay(1.0, 0) == 1.0
+	assert retry_backoff_delay(1.0, 1) == 2.0
+	assert retry_backoff_delay(1.0, 2) == 4.0
+	assert retry_backoff_delay(2.0, 3) == 16.0
+	# Capped
+	assert retry_backoff_delay(1.0, 20) == RETRY_MAX_DELAY
+	assert retry_backoff_delay(2.0, 10, cap=50.0) == 50.0
+	# Absurd attempt counts (retries >= 1024) must not overflow the float
+	assert retry_backoff_delay(1.0, 5000) == RETRY_MAX_DELAY
+	assert retry_backoff_delay(2.0, 100000) == RETRY_MAX_DELAY

--- a/packages/pulse/python/tests/test_query_staleness.py
+++ b/packages/pulse/python/tests/test_query_staleness.py
@@ -1,0 +1,297 @@
+"""
+Staleness and suspend/resume semantics for queries (TanStack-style).
+
+- invalidate() marks data stale persistently: an unobserved query refetches
+  when it is next observed or when the session resumes.
+- Session disconnect pauses interval refetching; reconnect restarts intervals
+  and refetches stale queries.
+"""
+
+import asyncio
+from typing import Any
+
+import pulse as ps
+import pytest
+from pulse.queries.query import KeyedQueryResult, UnkeyedQueryResult
+from pulse.queries.store import QueryStore
+from pulse.reactive import Computed
+from pulse.render_session import RenderSession
+from pulse.routing import RouteTree
+from pulse.test_helpers import wait_for
+
+
+class FetchCounter:
+	count: int
+
+	def __init__(self) -> None:
+		self.count = 0
+
+	async def fetch(self) -> int:
+		self.count += 1
+		return self.count
+
+
+def observe(
+	store: QueryStore,
+	key: tuple[Any, ...],
+	counter: FetchCounter,
+	**kwargs: Any,
+) -> KeyedQueryResult[int]:
+	store.ensure(key)
+	return KeyedQueryResult(
+		Computed(lambda: store.ensure(key)), fetch_fn=counter.fetch, **kwargs
+	)
+
+
+@pytest.mark.asyncio
+async def test_invalidate_persists_without_observers():
+	store = QueryStore()
+	counter = FetchCounter()
+	result = observe(store, ("a",), counter, stale_time=1000.0)
+	await wait_for(lambda: counter.count == 1)
+	query = store.ensure(("a",))
+	result.dispose()
+	assert query.observers == []
+
+	# No observers: marks stale, doesn't fetch
+	query.invalidate()
+	await asyncio.sleep(0.01)
+	assert counter.count == 1
+	assert query.is_stale(1000.0)
+
+	# Next observer refetches despite fresh-looking last_updated
+	result2 = observe(store, ("a",), counter, stale_time=1000.0)
+	await wait_for(lambda: counter.count == 2)
+	assert not query.is_stale(1000.0)
+	result2.dispose()
+
+
+@pytest.mark.asyncio
+async def test_is_stale_clears_after_refetch():
+	store = QueryStore()
+	counter = FetchCounter()
+	result = observe(store, ("a",), counter, stale_time=1000.0)
+	await wait_for(lambda: counter.count == 1)
+	query = store.ensure(("a",))
+
+	assert not result.is_stale()
+	query.invalidate()
+	await wait_for(lambda: counter.count == 2)
+	assert not result.is_stale()
+	result.dispose()
+
+
+@pytest.mark.asyncio
+async def test_suspend_pauses_keyed_interval_refetching():
+	store = QueryStore()
+	counter = FetchCounter()
+	result = observe(store, ("a",), counter, refetch_interval=0.02)
+	await wait_for(lambda: counter.count >= 1)
+
+	store.suspend_all()
+	await asyncio.sleep(0.01)  # let any in-flight fetch settle
+	paused_count = counter.count
+	await asyncio.sleep(0.08)
+	assert counter.count == paused_count
+
+	# Resume runs an immediate catch-up fetch and restarts the interval
+	store.resume_all()
+	await wait_for(lambda: counter.count > paused_count)
+	result.dispose()
+
+
+@pytest.mark.asyncio
+async def test_resume_refetches_stale_queries():
+	store = QueryStore()
+	counter = FetchCounter()
+	result = observe(store, ("a",), counter, stale_time=0.0)
+	await wait_for(lambda: counter.count == 1)
+
+	store.suspend_all()
+	store.resume_all()
+	await wait_for(lambda: counter.count == 2)
+	result.dispose()
+
+
+@pytest.mark.asyncio
+async def test_resume_skips_fresh_queries():
+	store = QueryStore()
+	counter = FetchCounter()
+	result = observe(store, ("a",), counter, stale_time=1000.0)
+	await wait_for(lambda: counter.count == 1)
+
+	store.suspend_all()
+	store.resume_all()
+	await asyncio.sleep(0.02)
+	assert counter.count == 1
+	result.dispose()
+
+
+@pytest.mark.asyncio
+async def test_unkeyed_suspend_resume_interval():
+	store = QueryStore()
+	counter = FetchCounter()
+	result = UnkeyedQueryResult(
+		counter.fetch,
+		refetch_interval=0.02,
+		on_dispose=store.unregister_unkeyed,
+	)
+	store.register_unkeyed(result)
+	await wait_for(lambda: counter.count >= 1)
+
+	store.suspend_all()
+	await asyncio.sleep(0.01)
+	paused_count = counter.count
+	await asyncio.sleep(0.08)
+	assert counter.count == paused_count
+
+	store.resume_all()
+	await wait_for(lambda: counter.count > paused_count)
+
+	result.dispose()
+	assert result not in store._unkeyed  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.asyncio
+async def test_unkeyed_resume_refetches_stale():
+	counter = FetchCounter()
+	result = UnkeyedQueryResult(counter.fetch, stale_time=0.0)
+	await wait_for(lambda: counter.count == 1)
+
+	result.suspend()
+	result.resume()
+	await wait_for(lambda: counter.count == 2)
+
+	fresh_counter = FetchCounter()
+	fresh = UnkeyedQueryResult(fresh_counter.fetch, stale_time=1000.0)
+	await wait_for(lambda: fresh_counter.count == 1)
+	fresh.suspend()
+	fresh.resume()
+	await asyncio.sleep(0.02)
+	assert fresh_counter.count == 1
+
+	result.dispose()
+	fresh.dispose()
+
+
+@pytest.mark.asyncio
+async def test_infinite_invalidate_marks_stale_without_observers():
+	store = QueryStore()
+	query = store.ensure_infinite(
+		("inf",), initial_page_param=0, get_next_page_param=lambda pages: None
+	)
+	assert not query.is_stale(1000.0) or query.last_updated.value == 0.0
+	query.invalidate()
+	assert query.is_stale(1000.0)
+
+
+@pytest.mark.asyncio
+async def test_infinite_resume_does_not_stack_fetch_on_inflight():
+	"""Resume during an in-flight infinite fetch must not enqueue a duplicate."""
+	from pulse.queries.infinite_query import InfiniteQuery, InfiniteQueryResult
+
+	calls = 0
+	release = asyncio.Event()
+
+	async def fetcher(page_param: int) -> int:
+		nonlocal calls
+		calls += 1
+		await release.wait()
+		return page_param
+
+	query: InfiniteQuery[int, int] = InfiniteQuery(
+		("inf", "inflight"),
+		initial_page_param=0,
+		get_next_page_param=lambda _pages: None,
+	)
+	observer = InfiniteQueryResult(
+		Computed(lambda: query, name="inf(inflight)"),
+		fetch_fn=fetcher,
+		stale_time=0.0,
+	)
+	# Initial fetch is now in flight (blocked on `release`)
+	await wait_for(lambda: calls == 1)
+
+	# Disconnect + reconnect while the fetch is still running
+	query.suspend()
+	query.resume()
+	await asyncio.sleep(0.01)
+
+	# No second fetch was stacked behind the in-flight one
+	assert calls == 1
+
+	release.set()
+	await query.wait()
+	assert calls == 1
+
+	observer.dispose()
+	query.dispose()
+
+
+@pytest.mark.asyncio
+async def test_infinite_interval_resume_does_not_stack_fetch_on_inflight():
+	"""Resume of an interval infinite query must not stack a fetch via the
+	recreated interval effect's immediate catch-up tick."""
+	from pulse.queries.infinite_query import InfiniteQuery, InfiniteQueryResult
+
+	calls = 0
+	release = asyncio.Event()
+
+	async def fetcher(page_param: int) -> int:
+		nonlocal calls
+		calls += 1
+		await release.wait()
+		return page_param
+
+	query: InfiniteQuery[int, int] = InfiniteQuery(
+		("inf", "interval-inflight"),
+		initial_page_param=0,
+		get_next_page_param=lambda _pages: None,
+	)
+	# Long interval so only the resume-time immediate tick matters in-window
+	observer = InfiniteQueryResult(
+		Computed(lambda: query, name="inf(interval-inflight)"),
+		fetch_fn=fetcher,
+		refetch_interval=100.0,
+	)
+	await wait_for(lambda: calls == 1)
+
+	query.suspend()
+	query.resume()  # recreates the interval effect (immediate tick)
+	await asyncio.sleep(0.01)
+
+	assert calls == 1  # the immediate tick saw work in flight and skipped
+
+	release.set()
+	await query.wait()
+	assert calls == 1
+
+	observer.dispose()
+	query.dispose()
+
+
+@pytest.mark.asyncio
+async def test_session_connection_drives_query_suspension():
+	session = RenderSession("test-id", RouteTree([]))
+	store = session.query_store
+	counter = FetchCounter()
+	result = observe(store, ("a",), counter, stale_time=0.0)
+	await wait_for(lambda: counter.count == 1)
+
+	# First connect is not a resume: no refetch
+	session.connect(lambda msg: None)
+	await asyncio.sleep(0.02)
+	assert counter.count == 1
+	assert store.suspended is False
+
+	session.disconnect()
+	assert store.suspended is True
+
+	# Reconnect refetches the stale query
+	with ps.PulseContext.update(render=session):
+		session.connect(lambda msg: None)
+	assert store.suspended is False
+	await wait_for(lambda: counter.count == 2)
+
+	result.dispose()
+	session.close()

--- a/packages/pulse/python/tests/test_query_staleness.py
+++ b/packages/pulse/python/tests/test_query_staleness.py
@@ -67,6 +67,41 @@ async def test_invalidate_persists_without_observers():
 
 
 @pytest.mark.asyncio
+async def test_invalidated_survives_failed_refetch():
+	"""A failed refetch must leave an invalidated query stale, and must not
+	bump last_updated (matches TanStack: clear isInvalidated on success only)."""
+	store = QueryStore()
+	should_fail = {"v": False}
+
+	async def fetcher() -> int:
+		if should_fail["v"]:
+			raise ValueError("boom")
+		return 1
+
+	store.ensure(("a",), retries=0)
+	result = KeyedQueryResult(
+		Computed(lambda: store.ensure(("a",))),
+		fetch_fn=fetcher,
+		stale_time=1000.0,
+	)
+	await wait_for(lambda: result.data == 1)
+	query = store.ensure(("a",))
+	assert not query.is_stale(1000.0)  # fresh after success
+	last = query.last_updated.value
+
+	should_fail["v"] = True
+	query.invalidate()  # marks stale + triggers refetch
+	await wait_for(lambda: query.status() == "error")
+
+	# invalidated persists across the failed refetch → still stale
+	assert query.is_stale(1000.0)
+	# the error did not bump the "last successful update" timestamp
+	assert query.last_updated.value == last
+
+	result.dispose()
+
+
+@pytest.mark.asyncio
 async def test_is_stale_clears_after_refetch():
 	store = QueryStore()
 	counter = FetchCounter()
@@ -295,3 +330,36 @@ async def test_session_connection_drives_query_suspension():
 
 	result.dispose()
 	session.close()
+
+
+@pytest.mark.asyncio
+async def test_resume_fetch_runs_with_session_context():
+	"""A reconnect-triggered refetch must carry the session in PulseContext,
+	just like an initial fetch — so a fetch_fn reading ps.session() works.
+
+	connect() inherits the session from the caller's context (the orchestration
+	layer wraps it), rather than taking it as a parameter."""
+	sentinel = object()
+	render = RenderSession("test-id", RouteTree([]))
+	store = render.query_store
+	seen: list[Any] = []
+
+	async def fetcher() -> int:
+		seen.append(ps.PulseContext.get().session)
+		return 1
+
+	result = KeyedQueryResult(
+		Computed(lambda: store.ensure(("a",))), fetch_fn=fetcher, stale_time=0.0
+	)
+	await wait_for(lambda: result.data == 1)
+
+	# Disconnect (suspend), then reconnect inside the owning session's context
+	render.disconnect()
+	with ps.PulseContext.update(session=sentinel, render=render):
+		render.connect(lambda msg: None)
+
+	# The resume-triggered refetch observed the session in context
+	await wait_for(lambda: sentinel in seen)
+
+	result.dispose()
+	render.close()

--- a/packages/pulse/python/tests/test_render_session.py
+++ b/packages/pulse/python/tests/test_render_session.py
@@ -72,9 +72,9 @@ def make_route_info(
 	}
 
 
-def transition_mount_to_idle(session: RenderSession, path: str) -> None:
-	mount = session.route_mounts[path]
-	mount.to_idle()
+def expire_pending_mount(session: RenderSession, path: str) -> None:
+	"""Simulate the pending-queue timer firing for a mount."""
+	session.route_mounts[path]._on_pending_timeout()  # pyright: ignore[reportPrivateUsage]
 
 
 # TODO: clean this up - this was refactored using GPT-5 and is thus quite hacky
@@ -987,8 +987,8 @@ async def test_state_preserved_across_reconnect():
 
 
 @pytest.mark.asyncio
-async def test_effect_paused_in_idle_state():
-	"""Test that effects are paused when mount transitions to IDLE state."""
+async def test_mount_suspended_after_disconnect_timeout():
+	"""Attached mounts suspend (tree kept, rendering paused) when the queue times out."""
 	routes = make_routes()
 	session = RenderSession("test-id", routes)
 
@@ -1004,25 +1004,27 @@ async def test_effect_paused_in_idle_state():
 	assert mount.effect.paused is False
 	assert mount.state == "active"
 
-	# Disconnect puts mount in PENDING state (not paused)
+	# Disconnect puts mount in PENDING state (still rendering + queuing)
 	session.disconnect()
 	assert mount.state == "pending"
-	assert mount.effect.paused is False  # Still running in PENDING
+	assert mount.effect.paused is False
 
-	# Manually trigger transition to IDLE (simulating timeout)
-	transition_mount_to_idle(session, "/a")
+	# Simulate the disconnect queue timeout firing
+	expire_pending_mount(session, "/a")
 
-	# Now the effect should be paused
-	assert mount.state == "idle"
+	# The mount is suspended: rendering paused, queue dropped, tree retained
+	assert session.route_mounts["/a"] is mount
+	assert mount.state == "suspended"
 	assert mount.effect.paused is True
-	assert mount.effect.batch is None
+	assert mount.queue is None
+	assert mount.tree.rendered is True
 
 	session.close()
 
 
 @pytest.mark.asyncio
-async def test_multiple_routes_idle_attach_requests_reload():
-	"""Test that attaching idle routes requests a reload."""
+async def test_attach_resumes_suspended_mounts_with_fresh_init():
+	"""Re-attaching suspended mounts sends a fresh vdom_init instead of a reload."""
 	routes = make_routes()
 	session = RenderSession("test-id", routes)
 
@@ -1037,44 +1039,72 @@ async def test_multiple_routes_idle_attach_requests_reload():
 
 	assert len(messages1) == 0
 
-	# Disconnect - goes to PENDING
+	# Disconnect, then let the queue time out
 	session.disconnect()
+	expire_pending_mount(session, "/a")
+	expire_pending_mount(session, "/b")
 	mount_a = session.route_mounts["/a"]
 	mount_b = session.route_mounts["/b"]
-	assert mount_a.state == "pending"
-	assert mount_b.state == "pending"
+	assert mount_a.state == "suspended"
+	assert mount_b.state == "suspended"
 
-	# Manually transition to IDLE (simulating timeout)
-	transition_mount_to_idle(session, "/a")
-	transition_mount_to_idle(session, "/b")
-
-	# Both effects should now be paused
-	effect_a = mount_a.effect
-	effect_b = mount_b.effect
-	assert effect_a is not None
-	assert effect_b is not None
-	assert effect_a.paused is True
-	assert effect_b.paused is True
-	assert mount_a.state == "idle"
-	assert mount_b.state == "idle"
-
-	# Reconnect
+	# Reconnect and re-attach
 	messages2: list[ServerMessage] = []
 	session.connect(lambda msg: messages2.append(msg))
 
 	with ps.PulseContext.update(render=session):
+		assert session.attach("/a", make_route_info("/a")) is True
+		assert session.attach("/b", make_route_info("/b")) is True
+
+	assert [m["type"] for m in messages2] == ["vdom_init", "vdom_init"]
+	assert mount_a.state == "active"
+	assert mount_b.state == "active"
+	assert mount_a.effect is not None and mount_a.effect.paused is False
+	assert mount_b.effect is not None and mount_b.effect.paused is False
+
+	session.close()
+
+
+@pytest.mark.asyncio
+async def test_suspend_resume_preserves_state():
+	"""Component state survives a disconnect that outlives the message queue."""
+	routes = RouteTree([Route("a", StatefulCounter)])
+	session = RenderSession("test-id", routes)
+
+	messages: list[ServerMessage] = []
+	session.connect(lambda msg: messages.append(msg))
+
+	with ps.PulseContext.update(render=session):
+		session.prerender(["/a"], make_route_info("/a"))
 		session.attach("/a", make_route_info("/a"))
-		session.attach("/b", make_route_info("/b"))
 
-	# Should request reload for each idle attach
-	reload_messages = [m for m in messages2 if m["type"] == "reload"]
-	assert len(reload_messages) == 2
+	session.execute_callback("/a", "1.onClick", [])
+	session.flush()
 
-	# Both effects should remain paused
-	assert effect_a.paused is True
-	assert effect_b.paused is True
-	assert mount_a.state == "idle"
-	assert mount_b.state == "idle"
+	# Disconnect long enough for the mount to suspend
+	session.disconnect()
+	expire_pending_mount(session, "/a")
+	assert session.route_mounts["/a"].state == "suspended"
+
+	# State written while suspended is reflected on resume
+	session.execute_callback("/a", "1.onClick", [])
+	session.flush()
+
+	# Reconnect: attach resumes with a fresh init carrying the current count
+	messages2: list[ServerMessage] = []
+	session.connect(lambda msg: messages2.append(msg))
+	with ps.PulseContext.update(render=session):
+		assert session.attach("/a", make_route_info("/a")) is True
+
+	assert len(messages2) == 1
+	init = messages2[0]
+	assert init["type"] == "vdom_init"
+	assert "2" in str(init["vdom"])
+
+	# Callbacks keep working after resume
+	session.execute_callback("/a", "1.onClick", [])
+	session.flush()
+	assert any(m["type"] == "vdom_update" for m in messages2[1:])
 
 	session.close()
 
@@ -1723,7 +1753,6 @@ def test_dev_strict_mode_detach_replay_reuses_mount_without_reload():
 
 	assert session.route_mounts["/a"] is mount
 	assert mount.state == "pending"
-	assert mount.pending_action == "dispose"
 	assert mount.mount_id != first_mount_id
 
 	with ps.PulseContext.update(render=session):
@@ -1860,8 +1889,8 @@ def test_execute_callback_stale_key_is_noop(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.mark.asyncio
-async def test_prerender_queue_timeout_transitions_to_idle():
-	"""Test that prerender without attach eventually transitions to idle."""
+async def test_prerender_queue_timeout_disposes_mount():
+	"""Prerender without attach disposes the mount once the queue times out."""
 	routes = RouteTree([Route("a", simple_component)])
 	# Very short timeout for testing
 	session = RenderSession("test-id", routes, prerender_queue_timeout=0.01)
@@ -1874,30 +1903,29 @@ async def test_prerender_queue_timeout_transitions_to_idle():
 	assert mount.effect is not None
 	assert mount.effect.paused is False
 
-	# Manually trigger the timeout (simulating time passing)
-	transition_mount_to_idle(session, "/a")
+	await asyncio.sleep(0.05)
 
-	assert mount.state == "idle"
-	assert mount.effect.paused is True
+	assert "/a" not in session.route_mounts
+	assert mount.state == "closed"
+	assert mount.tree.rendered is False
 
 	session.close()
 
 
 @pytest.mark.asyncio
-async def test_attach_from_idle_requests_reload():
-	"""Test that attaching to an idle mount requests a reload."""
+async def test_attach_after_dispose_requests_reload():
+	"""Attaching to a disposed mount requests a reload."""
 	routes = RouteTree([Route("a", simple_component)])
 	session = RenderSession("test-id", routes)
 
-	# Prerender, then transition to idle
+	# Prerender, then expire the pending queue
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"])
 
 	mount = session.route_mounts["/a"]
-	transition_mount_to_idle(session, "/a")
-	assert mount.state == "idle"
-	assert mount.effect is not None
-	assert mount.effect.paused is True
+	expire_pending_mount(session, "/a")
+	assert mount.state == "closed"
+	assert "/a" not in session.route_mounts
 
 	# Now attach
 	messages: list[ServerMessage] = []
@@ -1906,10 +1934,154 @@ async def test_attach_from_idle_requests_reload():
 	with ps.PulseContext.update(render=session):
 		session.attach("/a", make_route_info("/a"))
 
-	# Should request reload and leave mount idle
-	assert mount.state == "idle"
-	assert mount.effect.paused is True
 	assert len(messages) == 1
 	assert messages[0]["type"] == "reload"
+
+	session.close()
+
+
+@pytest.mark.asyncio
+async def test_rerender_does_not_accumulate_objects():
+	"""Re-rendering a mounted route many times must not retain per-render objects.
+
+	Long-lived sessions (dashboards, polling pages) re-render thousands of times;
+	any per-render retention in the renderer/transpiler/hooks would balloon a
+	single session over hours.
+	"""
+	import gc
+
+	from pulse.hooks.core import HookContext
+	from pulse.reactive import Effect
+	from pulse.transpiler.nodes import Element, PulseNode
+
+	routes = RouteTree([Route("a", StatefulCounter)])
+	session = RenderSession("test-id", routes)
+	session.connect(lambda msg: None)
+
+	with ps.PulseContext.update(render=session):
+		session.prerender(["/a"], make_route_info("/a"))
+		session.attach("/a", make_route_info("/a"))
+
+	def rerender_once():
+		session.execute_callback("/a", "1.onClick", [])
+		session.flush()
+
+	tracked = (Element, PulseNode, HookContext, Effect)
+
+	def census() -> dict[str, int]:
+		gc.collect()
+		counts = dict.fromkeys((cls.__name__ for cls in tracked), 0)
+		for obj in gc.get_objects():
+			name = type(obj).__name__
+			if type(obj) in tracked:
+				counts[name] += 1
+		return counts
+
+	# Warm up so caches and hook state reach steady state
+	for _ in range(5):
+		rerender_once()
+	baseline = census()
+
+	for _ in range(50):
+		rerender_once()
+	after = census()
+
+	assert after == baseline
+
+	session.close()
+
+
+class ChildCounterState(ps.State):
+	count: int = 0
+
+
+@ps.component
+def NestedChild():
+	with ps.init():
+		state = ChildCounterState()
+
+	def bump():
+		state.count += 1
+
+	return ps.span(onClick=bump)[str(state.count)]
+
+
+@ps.component
+def NestedParent():
+	return ps.div()[NestedChild()]
+
+
+@pytest.mark.asyncio
+async def test_reprerender_preserves_child_component_state():
+	"""Re-prerendering a mounted route must reconcile, not rebuild child hook state."""
+	routes = RouteTree([Route("a", NestedParent)])
+	session = RenderSession("test-id", routes)
+
+	messages: list[ServerMessage] = []
+	session.connect(lambda msg: messages.append(msg))
+
+	with ps.PulseContext.update(render=session):
+		session.prerender(["/a"], make_route_info("/a"))
+		session.attach("/a", make_route_info("/a"))
+
+	# Bump the child component's state
+	session.execute_callback("/a", "0.onClick", [])
+	session.flush()
+
+	# Re-prerender the mounted route (client-side navigation re-init)
+	with ps.PulseContext.update(render=session):
+		result = session.prerender(["/a"], make_route_info("/a"))["/a"]
+
+	assert result["type"] == "vdom_init"
+	assert "1" in str(result["vdom"])
+
+	session.close()
+
+
+@pytest.mark.asyncio
+async def test_reprerender_does_not_accumulate_objects():
+	"""Repeated re-prerenders of a mounted route must not leak hook state.
+
+	Client-side navigations re-prerender mounted routes (e.g. layouts); each
+	one used to rebuild child components, stranding their old hook effects.
+	"""
+	import gc
+
+	from pulse.hooks.core import HookContext
+	from pulse.reactive import Effect
+	from pulse.transpiler.nodes import Element, PulseNode
+
+	routes = RouteTree([Route("a", NestedParent)])
+	session = RenderSession("test-id", routes)
+	session.connect(lambda msg: None)
+
+	with ps.PulseContext.update(render=session):
+		session.prerender(["/a"], make_route_info("/a"))
+		session.attach("/a", make_route_info("/a"))
+
+	def reprerender_once():
+		with ps.PulseContext.update(render=session):
+			session.prerender(["/a"], make_route_info("/a"))
+			session.attach("/a", make_route_info("/a"))
+
+	tracked = (Element, PulseNode, HookContext, Effect)
+
+	def census() -> dict[str, int]:
+		gc.collect()
+		counts = dict.fromkeys((cls.__name__ for cls in tracked), 0)
+		for obj in gc.get_objects():
+			if type(obj) in tracked:
+				counts[type(obj).__name__] += 1
+		return counts
+
+	for _ in range(3):
+		reprerender_once()
+	baseline = census()
+
+	for _ in range(20):
+		reprerender_once()
+	after = census()
+
+	assert after == baseline
 
 	session.close()

--- a/packages/pulse/python/tests/test_render_session.py
+++ b/packages/pulse/python/tests/test_render_session.py
@@ -2085,3 +2085,40 @@ async def test_reprerender_does_not_accumulate_objects():
 	assert after == baseline
 
 	session.close()
+
+
+@pytest.mark.asyncio
+async def test_async_callback_error_reports_real_traceback():
+	"""An async callback that raises is reported from a task done-callback —
+	outside any `except` block — so report_error must still produce a real
+	stack (not the "NoneType: None" that traceback.format_exc() would give)."""
+
+	@ps.component
+	def Page():
+		async def on_click():
+			raise ValueError("async boom")
+
+		return ps.button(onClick=on_click)["go"]
+
+	routes = RouteTree([Route("a", Page)])
+	session = RenderSession("test-id", routes)
+	messages: list[ServerMessage] = []
+	session.connect(messages.append)
+
+	with ps.PulseContext.update(render=session):
+		session.prerender(["/a"])
+		session.attach("/a", make_route_info("/a"))
+
+	session.execute_callback("/a", first_callback_key(session, "/a"), [])
+	await wait_for(lambda: any(m["type"] == "server_error" for m in messages))
+
+	errors = [m for m in messages if m["type"] == "server_error"]
+	assert len(errors) == 1
+	err = cast(Any, errors[0])["error"]
+	assert err["phase"] == "callback"
+	assert err["details"]["async"] is True
+	assert "async boom" in err["stack"]
+	assert "ValueError" in err["stack"]
+	assert "NoneType: None" not in err["stack"]
+
+	session.close()

--- a/packages/pulse/python/tests/test_render_session.py
+++ b/packages/pulse/python/tests/test_render_session.py
@@ -7,16 +7,21 @@ that updates from one session do not leak into the other.
 """
 
 import asyncio
+import gc
+from collections.abc import Callable, Iterator
 from typing import Any, cast, override
 
 import pulse as ps
 import pytest
 from pulse import javascript
+from pulse.hooks.core import HookContext
 from pulse.hooks.runtime import NotFoundInterrupt, RedirectInterrupt
 from pulse.messages import ServerMessage
+from pulse.reactive import Effect
 from pulse.render_session import RenderSession
 from pulse.routing import Route, RouteInfo, RouteTree
 from pulse.test_helpers import wait_for
+from pulse.transpiler.nodes import Element, PulseNode
 
 
 @javascript
@@ -77,53 +82,48 @@ def expire_pending_mount(session: RenderSession, path: str) -> None:
 	session.route_mounts[path]._on_pending_timeout()  # pyright: ignore[reportPrivateUsage]
 
 
-# TODO: clean this up - this was refactored using GPT-5 and is thus quite hacky
-def mount_with_listener(session: RenderSession, path: str):
-	# Maintain a session-level set of listened paths and a shared message log
-	listened: set[str] | None = getattr(session, "_test_listened_paths", None)
-	if listened is None:
-		listened = set()
-		session._test_listened_paths = listened  # pyright: ignore[reportAttributeAccessIssue]
+class PathMessages:
+	messages: list[ServerMessage]
+	path: str
 
-	log: list[ServerMessage] | None = getattr(session, "_test_message_log", None)
-	if log is None:
-		log = []
-		session._test_message_log = log  # pyright: ignore[reportAttributeAccessIssue]
+	def __init__(self, messages: list[ServerMessage], path: str) -> None:
+		self.messages = messages
+		self.path = path
 
-		def on_message(msg: ServerMessage):
-			if msg.get("type") == "api_call":
-				return
-			p = msg.get("path")
-			if not isinstance(p, str):
-				return
-			# Only record messages for paths we're currently listening to
-			if p in getattr(session, "_test_listened_paths", set()):  # pyright: ignore[reportUnknownArgumentType]
-				session._test_message_log.append(msg)  # pyright: ignore[reportAttributeAccessIssue]
+	def __iter__(self) -> Iterator[ServerMessage]:
+		for message in self.messages:
+			if message.get("path") == self.path:
+				yield message
 
-		session.connect(on_message)
 
-	# Start listening for this path
-	listened.add(path)
+class RouteMessageLog:
+	session: RenderSession
+	listened_paths: set[str]
+	messages: list[ServerMessage]
 
-	class _PathMessages:
-		def __iter__(self):  # type: ignore[override]
-			for m in getattr(session, "_test_message_log", []):
-				if m.get("path") == path:
-					yield m
+	def __init__(self, session: RenderSession) -> None:
+		self.session = session
+		self.listened_paths = set()
+		self.messages = []
+		self.session.connect(self._record)
 
-	# Ensure RenderSession is present in PulseContext when attaching so the
-	# captured context for the render effect includes it
-	with ps.PulseContext.update(render=session):
-		session.prerender(sorted(listened))
-		session.attach(path, make_route_info(path))
+	def _record(self, message: ServerMessage) -> None:
+		if message.get("type") == "api_call":
+			return
+		path = message.get("path")
+		if isinstance(path, str) and path in self.listened_paths:
+			self.messages.append(message)
 
-	def disconnect():
-		# Stop listening for this path; messages are still in the shared log
-		lst = getattr(session, "_test_listened_paths", set())  # pyright: ignore[reportUnknownArgumentType]
-		if isinstance(lst, set):
-			lst.discard(path)
+	def mount(self, path: str) -> tuple[PathMessages, Callable[[], None]]:
+		self.listened_paths.add(path)
+		with ps.PulseContext.update(render=self.session):
+			self.session.prerender(sorted(self.listened_paths))
+			self.session.attach(path, make_route_info(path))
 
-	return _PathMessages(), disconnect
+		def disconnect() -> None:
+			self.listened_paths.discard(path)
+
+		return PathMessages(self.messages, path), disconnect
 
 
 def extract_count_from_ctx(session: RenderSession, path: str) -> int:
@@ -180,12 +180,14 @@ async def test_two_sessions_two_routes_are_isolated():
 	routes = make_routes()
 	s1 = RenderSession("s1", routes)
 	s2 = RenderSession("s2", routes)
+	log_s1 = RouteMessageLog(s1)
+	log_s2 = RouteMessageLog(s2)
 
 	# Mount both routes on both sessions and keep listeners active
-	msgs_s1_a, disc_s1_a = mount_with_listener(s1, "/a")
-	msgs_s1_b, disc_s1_b = mount_with_listener(s1, "/b")
-	msgs_s2_a, disc_s2_a = mount_with_listener(s2, "/a")
-	msgs_s2_b, disc_s2_b = mount_with_listener(s2, "/b")
+	msgs_s1_a, disc_s1_a = log_s1.mount("/a")
+	msgs_s1_b, disc_s1_b = log_s1.mount("/b")
+	msgs_s2_a, disc_s2_a = log_s2.mount("/a")
+	msgs_s2_b, disc_s2_b = log_s2.mount("/b")
 
 	# Initial counts are zero
 	assert extract_count_from_ctx(s1, "/a") == 0
@@ -279,12 +281,14 @@ async def test_global_state_shared_within_session_and_isolated_across_sessions()
 	routes = make_global_routes()
 	s1 = RenderSession("s1", routes)
 	s2 = RenderSession("s2", routes)
+	log_s1 = RouteMessageLog(s1)
+	log_s2 = RouteMessageLog(s2)
 
 	# Mount both routes on both sessions
-	msgs_s1_a, disc_s1_a = mount_with_listener(s1, "/a")
-	msgs_s1_b, disc_s1_b = mount_with_listener(s1, "/b")
-	msgs_s2_a, disc_s2_a = mount_with_listener(s2, "/a")
-	msgs_s2_b, disc_s2_b = mount_with_listener(s2, "/b")
+	msgs_s1_a, disc_s1_a = log_s1.mount("/a")
+	msgs_s1_b, disc_s1_b = log_s1.mount("/b")
+	msgs_s2_a, disc_s2_a = log_s2.mount("/a")
+	msgs_s2_b, disc_s2_b = log_s2.mount("/b")
 
 	# Initial counts are zero across both routes/sessions
 	assert extract_global_count(s1, "/a") == 0
@@ -348,7 +352,8 @@ async def test_global_state_disposed_on_session_close():
 		[Route("a", ps.component(lambda: ps.div()[ps.span()[str(accessor().count)]]))]
 	)
 	s = RenderSession("s1", routes)
-	_msgs, disc = mount_with_listener(s, "/a")
+	log = RouteMessageLog(s)
+	_msgs, disc = log.mount("/a")
 	# Ensure instance is created by rendering
 	assert extract_count_from_ctx(s, "/a") == 0
 
@@ -1948,12 +1953,6 @@ async def test_rerender_does_not_accumulate_objects():
 	any per-render retention in the renderer/transpiler/hooks would balloon a
 	single session over hours.
 	"""
-	import gc
-
-	from pulse.hooks.core import HookContext
-	from pulse.reactive import Effect
-	from pulse.transpiler.nodes import Element, PulseNode
-
 	routes = RouteTree([Route("a", StatefulCounter)])
 	session = RenderSession("test-id", routes)
 	session.connect(lambda msg: None)
@@ -2045,12 +2044,6 @@ async def test_reprerender_does_not_accumulate_objects():
 	Client-side navigations re-prerender mounted routes (e.g. layouts); each
 	one used to rebuild child components, stranding their old hook effects.
 	"""
-	import gc
-
-	from pulse.hooks.core import HookContext
-	from pulse.reactive import Effect
-	from pulse.transpiler.nodes import Element, PulseNode
-
 	routes = RouteTree([Route("a", NestedParent)])
 	session = RenderSession("test-id", routes)
 	session.connect(lambda msg: None)

--- a/packages/pulse/python/tests/test_socket_lifecycle.py
+++ b/packages/pulse/python/tests/test_socket_lifecycle.py
@@ -1,0 +1,197 @@
+"""
+Socket connect/disconnect lifecycle tests at the App level.
+
+A render session has at most one current socket. When a client reconnects
+before the old socket's disconnect event fires, the stale disconnect must not
+tear down the new connection or strand the render session's cleanup timer.
+"""
+
+from typing import Any, override
+
+import pulse as ps
+import pytest
+from pulse.user_session import CookieSessionStore
+
+
+def make_app(monkeypatch: pytest.MonkeyPatch) -> ps.App:
+	monkeypatch.setenv("PULSE_REACT_SERVER_ADDRESS", "http://localhost:3000")
+	app = ps.App(routes=[])
+	app.setup("http://example.com")
+	return app
+
+
+def make_environ(app: ps.App, sid: str) -> dict[str, str]:
+	store = app.session_store
+	assert isinstance(store, CookieSessionStore)
+	cookie = store.encode(sid, {})
+	return {"HTTP_COOKIE": f"{app.cookie.name}={cookie}"}
+
+
+@pytest.mark.asyncio
+async def test_stale_socket_disconnect_does_not_clobber_live_connection(
+	monkeypatch: pytest.MonkeyPatch,
+):
+	app = make_app(monkeypatch)
+	environ = make_environ(app, "user-1")
+	auth = {"render_id": "render-1"}
+
+	connect = app.sio.handlers["/"]["connect"]
+	disconnect = app.sio.handlers["/"]["disconnect"]
+
+	await connect("socket-a", environ, auth)
+	render = app.render_sessions["render-1"]
+	assert render.connected
+
+	# Client reconnects before the old socket's disconnect event fires
+	await connect("socket-b", environ, auth)
+	assert render.connected
+
+	# The stale socket's disconnect must not disconnect the render
+	disconnect("socket-a")
+	assert render.connected
+	assert app._render_cleanups == {}  # pyright: ignore[reportPrivateUsage]
+	assert app._socket_to_render == {"socket-b": "render-1"}  # pyright: ignore[reportPrivateUsage]
+
+	# Disconnect from the current socket tears it down and schedules cleanup
+	disconnect("socket-b")
+	assert not render.connected
+	assert "render-1" in app._render_cleanups  # pyright: ignore[reportPrivateUsage]
+	assert app._socket_to_render == {}  # pyright: ignore[reportPrivateUsage]
+
+	await app.close()
+
+
+class TogglableDenyMiddleware(ps.PulseMiddleware):
+	deny: bool
+
+	def __init__(self) -> None:
+		self.deny = False
+
+	@override
+	async def connect(self, *, request: Any, session: Any, next: Any) -> Any:
+		if self.deny:
+			return ps.Deny()
+		return await next()
+
+
+@pytest.mark.asyncio
+async def test_denied_reconnect_does_not_destroy_existing_render(
+	monkeypatch: pytest.MonkeyPatch,
+):
+	monkeypatch.setenv("PULSE_REACT_SERVER_ADDRESS", "http://localhost:3000")
+	mw = TogglableDenyMiddleware()
+	app = ps.App(routes=[], middleware=mw)
+	app.setup("http://example.com")
+	environ = make_environ(app, "user-1")
+	auth = {"render_id": "render-1"}
+	connect = app.sio.handlers["/"]["connect"]
+
+	# Initial connection is allowed
+	await connect("socket-a", environ, auth)
+	render = app.render_sessions["render-1"]
+	assert render.connected
+
+	# Client reconnects (e.g. flaky network) but is now denied. The denied
+	# reconnect must NOT tear down the live render the original socket uses.
+	mw.deny = True
+	with pytest.raises(ConnectionRefusedError):
+		await connect("socket-b", environ, auth)
+
+	assert "render-1" in app.render_sessions
+	assert render.connected
+	# The original socket's mapping is untouched
+	assert app._socket_to_render == {"socket-a": "render-1"}  # pyright: ignore[reportPrivateUsage]
+	assert app._render_to_socket == {"render-1": "socket-a"}  # pyright: ignore[reportPrivateUsage]
+
+	await app.close()
+
+
+@pytest.mark.asyncio
+async def test_denied_fresh_connection_disposes_created_render(
+	monkeypatch: pytest.MonkeyPatch,
+):
+	monkeypatch.setenv("PULSE_REACT_SERVER_ADDRESS", "http://localhost:3000")
+	mw = TogglableDenyMiddleware()
+	mw.deny = True
+	app = ps.App(routes=[], middleware=mw)
+	app.setup("http://example.com")
+	environ = make_environ(app, "user-1")
+	connect = app.sio.handlers["/"]["connect"]
+
+	# A brand-new render created for this attempt is cleaned up on deny
+	with pytest.raises(ConnectionRefusedError):
+		await connect("socket-a", environ, {"render_id": "render-new"})
+
+	assert app.render_sessions == {}
+	assert app._socket_to_render == {}  # pyright: ignore[reportPrivateUsage]
+	assert app._render_to_socket == {}  # pyright: ignore[reportPrivateUsage]
+
+	await app.close()
+
+
+class RaisingConnectMiddleware(ps.PulseMiddleware):
+	@override
+	async def connect(self, *, request: Any, session: Any, next: Any) -> Any:
+		raise RuntimeError("boom in connect middleware")
+
+
+@pytest.mark.asyncio
+async def test_connect_middleware_exception_is_surfaced_after_bind(
+	monkeypatch: pytest.MonkeyPatch,
+):
+	"""A connect-middleware exception is treated as allow, and the error is
+	delivered to the now-bound client (not dropped pre-bind)."""
+	monkeypatch.setenv("PULSE_REACT_SERVER_ADDRESS", "http://localhost:3000")
+	app = ps.App(routes=[], middleware=RaisingConnectMiddleware())
+	app.setup("http://example.com")
+	environ = make_environ(app, "user-1")
+	connect = app.sio.handlers["/"]["connect"]
+
+	sent: list[Any] = []
+	monkeypatch.setattr(
+		app.sio, "emit", lambda *a, **k: sent.append((a, k)) or _noop_future()
+	)
+
+	# Fresh render: connection is allowed despite the middleware raising
+	await connect("socket-a", environ, {"render_id": "render-1"})
+	render = app.render_sessions["render-1"]
+	assert render.connected
+
+	# Give the emit task a tick to run
+	import asyncio
+
+	await asyncio.sleep(0)
+
+	# A server_error for the connect phase reached the (bound) client
+	flat = [a for (a, _k) in sent]
+	assert any(
+		args and args[0] == "message" and _is_connect_error(args) for args in flat
+	), sent
+
+	await app.close()
+
+
+async def _noop_future() -> None:
+	return None
+
+
+def _is_connect_error(emit_args: Any) -> bool:
+	# emit("message", payload, to=sid) — payload is a serialized list
+	payload = emit_args[1] if len(emit_args) > 1 else None
+	return "server_error" in str(payload) and "connect" in str(payload)
+
+
+@pytest.mark.asyncio
+async def test_close_render_unmaps_socket(monkeypatch: pytest.MonkeyPatch):
+	app = make_app(monkeypatch)
+	environ = make_environ(app, "user-1")
+	auth = {"render_id": "render-1"}
+
+	connect = app.sio.handlers["/"]["connect"]
+	await connect("socket-a", environ, auth)
+
+	app.close_render("render-1")
+	assert app._socket_to_render == {}  # pyright: ignore[reportPrivateUsage]
+	assert app._render_to_socket == {}  # pyright: ignore[reportPrivateUsage]
+
+	await app.close()

--- a/packages/pulse/python/tests/test_socket_lifecycle.py
+++ b/packages/pulse/python/tests/test_socket_lifecycle.py
@@ -6,6 +6,7 @@ before the old socket's disconnect event fires, the stale disconnect must not
 tear down the new connection or strand the render session's cleanup timer.
 """
 
+import asyncio
 from typing import Any, override
 
 import pulse as ps
@@ -65,6 +66,7 @@ class TogglableDenyMiddleware(ps.PulseMiddleware):
 	deny: bool
 
 	def __init__(self) -> None:
+		super().__init__()
 		self.deny = False
 
 	@override
@@ -147,10 +149,12 @@ async def test_connect_middleware_exception_is_surfaced_after_bind(
 	environ = make_environ(app, "user-1")
 	connect = app.sio.handlers["/"]["connect"]
 
-	sent: list[Any] = []
-	monkeypatch.setattr(
-		app.sio, "emit", lambda *a, **k: sent.append((a, k)) or _noop_future()
-	)
+	sent: list[tuple[Any, ...]] = []
+
+	async def fake_emit(*args: Any, **kwargs: Any) -> None:
+		sent.append(args)
+
+	monkeypatch.setattr(app.sio, "emit", fake_emit)
 
 	# Fresh render: connection is allowed despite the middleware raising
 	await connect("socket-a", environ, {"render_id": "render-1"})
@@ -158,27 +162,18 @@ async def test_connect_middleware_exception_is_surfaced_after_bind(
 	assert render.connected
 
 	# Give the emit task a tick to run
-	import asyncio
-
 	await asyncio.sleep(0)
 
 	# A server_error for the connect phase reached the (bound) client
-	flat = [a for (a, _k) in sent]
 	assert any(
-		args and args[0] == "message" and _is_connect_error(args) for args in flat
+		args
+		and args[0] == "message"
+		and "server_error" in str(args)
+		and "connect" in str(args)
+		for args in sent
 	), sent
 
 	await app.close()
-
-
-async def _noop_future() -> None:
-	return None
-
-
-def _is_connect_error(emit_args: Any) -> bool:
-	# emit("message", payload, to=sid) — payload is a serialized list
-	payload = emit_args[1] if len(emit_args) > 1 else None
-	return "server_error" in str(payload) and "connect" in str(payload)
 
 
 @pytest.mark.asyncio

--- a/packages/pulse/python/tests/test_socket_lifecycle.py
+++ b/packages/pulse/python/tests/test_socket_lifecycle.py
@@ -164,14 +164,21 @@ async def test_connect_middleware_exception_is_surfaced_after_bind(
 	# Give the emit task a tick to run
 	await asyncio.sleep(0)
 
-	# A server_error for the connect phase reached the (bound) client
-	assert any(
+	# A server_error for the connect phase reached the (bound) client, and it
+	# carries the real traceback (not the "NoneType: None" that format_exc()
+	# yields when report_error runs outside the except block).
+	connect_errors = [
 		args
+		for args in sent
+		if args
 		and args[0] == "message"
 		and "server_error" in str(args)
 		and "connect" in str(args)
-		for args in sent
-	), sent
+	]
+	assert connect_errors, sent
+	payload_text = str(connect_errors[0])
+	assert "boom in connect middleware" in payload_text
+	assert "NoneType: None" not in payload_text
 
 	await app.close()
 

--- a/packages/pulse/python/tests/test_user_session.py
+++ b/packages/pulse/python/tests/test_user_session.py
@@ -111,3 +111,62 @@ async def test_server_session_response_wait_survives_superseded_save(
 	assert any(
 		session_data.get("auth") == "second" for session_data in store.data.values()
 	)
+
+
+@pytest.mark.asyncio
+async def test_http_request_without_render_does_not_retain_user_session(
+	monkeypatch: pytest.MonkeyPatch,
+):
+	"""Cookie-less requests (bots, health checks) must not accumulate sessions."""
+	monkeypatch.setenv("PULSE_REACT_SERVER_ADDRESS", "http://localhost:3000")
+	app = ps.App(routes=[])
+	app.setup("http://example.com")
+
+	transport = httpx.ASGITransport(app=app.fastapi)
+	async with httpx.AsyncClient(
+		transport=transport, base_url="http://testserver"
+	) as client:
+		for _ in range(3):
+			resp = await client.get("/_pulse/health", cookies=None)
+			assert resp.status_code == 200
+
+	assert app.user_sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_prerender_request_retains_user_session(
+	monkeypatch: pytest.MonkeyPatch,
+):
+	"""Sessions that own a render session stay alive after the request."""
+	monkeypatch.setenv("PULSE_REACT_SERVER_ADDRESS", "http://localhost:3000")
+
+	@ps.component
+	def home():
+		return ps.div("ok")
+
+	app = ps.App(routes=[ps.Route("a", home)])
+	app.setup("http://example.com")
+
+	transport = httpx.ASGITransport(app=app.fastapi)
+	async with httpx.AsyncClient(
+		transport=transport, base_url="http://testserver"
+	) as client:
+		resp = await client.post(
+			"/_pulse/prerender",
+			json={
+				"paths": ["/a"],
+				"routeInfo": {
+					"pathname": "/a",
+					"hash": "",
+					"query": "",
+					"queryParams": {},
+					"pathParams": {},
+					"catchall": [],
+				},
+			},
+		)
+		assert resp.status_code == 200
+
+	assert len(app.user_sessions) == 1
+	assert len(app.render_sessions) == 1
+	await app.close()

--- a/skills/pulse/references/app.md
+++ b/skills/pulse/references/app.md
@@ -37,7 +37,7 @@ app = ps.App(
 | `api_prefix` | `str` | `"/_pulse"` | API route prefix |
 | `cors` | `CORSOptions` | Auto | CORS configuration |
 | `fastapi` | `dict` | `None` | FastAPI constructor options |
-| `session_timeout` | `float` | `60.0` | Session cleanup timeout (seconds) |
+| `session_timeout` | `float` | `60.0` | How long a disconnected render session stays resumable before being closed (seconds) |
 
 ## Deployment Modes
 

--- a/skills/pulse/references/queries.md
+++ b/skills/pulse/references/queries.md
@@ -91,6 +91,10 @@ async def lazy_data(self) -> T: ...
 async def live_data(self) -> T: ...
 ```
 
+Interval polling pauses while the client is disconnected. On reconnect,
+intervals restart with a catch-up fetch and non-interval queries refetch if
+stale (older than `stale_time` or invalidated).
+
 Enable/disable programmatically:
 
 ```python
@@ -117,7 +121,7 @@ state.user.is_scheduled # True if a refetch is scheduled/running
 
 ```python
 state.user.refetch()     # Force refetch
-state.user.invalidate()  # Mark stale, refetch if observed
+state.user.invalidate()  # Mark stale; refetch now if observed, else on next observe/reconnect
 state.user.set_data(val) # Manually set data (optimistic update)
 await state.user.wait()  # Wait for current fetch to complete
 state.user.enable()      # Enable the query

--- a/skills/pulse/references/queries.md
+++ b/skills/pulse/references/queries.md
@@ -22,7 +22,7 @@ class UserState(ps.State):
     stale_time=0,            # Seconds before data considered stale (default 0)
     gc_time=300.0,           # Seconds before unused cache is garbage collected
     retries=3,               # Retry attempts on failure
-    retry_delay=2.0,         # Delay between retries in seconds
+    retry_delay=2.0,         # Base delay (s); exponential backoff, doubles each retry, capped at 30s
     keep_previous_data=True, # Keep old data while refetching
     enabled=True,            # Whether query runs automatically (default True)
     fetch_on_mount=True,     # Fetch when component mounts (default True)

--- a/uv.lock
+++ b/uv.lock
@@ -1323,7 +1323,7 @@ requires-dist = [
 
 [[package]]
 name = "pulse-framework"
-version = "0.1.101"
+version = "0.1.102"
 source = { editable = "packages/pulse/python" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- fix server-side render/socket lifecycle memory growth and preserve suspended route state across reconnects
- pause/resume query polling with reconnect refetch semantics, including local query stores outside render context
- include main serializer primitive index collision fix
- bump pulse-framework and pulse-ui-client to 0.1.102

## Release audit
- origin/main had unreleased changes only for pulse
- this branch had unreleased changes only for pulse
- after the 0.1.102 bump, scripts/version_audit.py reports all packages clean

## Validation
- bun run build
- uv build --package pulse-framework --out-dir /tmp/pulse-ui-build
- make all