### PR TITLE
Fix dev server URL for non-local bind addresses

### DIFF
--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -45,6 +45,7 @@ from pulse.helpers import (
 	find_available_port,
 	get_client_address,
 	get_client_address_socketio,
+	local_server_url,
 )
 from pulse.hooks.core import hooks
 from pulse.messages import (
@@ -506,8 +507,7 @@ class App:
 			host = os.environ.get(ENV_PULSE_HOST)
 			port = os.environ.get(ENV_PULSE_PORT)
 			if host is not None and port is not None:
-				protocol = "http" if host in ("127.0.0.1", "localhost") else "https"
-				server_address = f"{protocol}://{host}:{port}"
+				server_address = local_server_url(host, port)
 			else:
 				server_address = self.dev_server_address
 

--- a/packages/pulse/python/src/pulse/cli/cmd.py
+++ b/packages/pulse/python/src/pulse/cli/cmd.py
@@ -38,7 +38,7 @@ from pulse.env import (
 	PulseEnv,
 	env,
 )
-from pulse.helpers import find_available_port, server_url
+from pulse.helpers import find_available_port, local_server_url
 from pulse.version import __version__ as PULSE_PY_VERSION
 
 cli = typer.Typer(
@@ -185,7 +185,7 @@ def run(
 
 		# All required servers are ready, show announcement
 		announced = True
-		logger.write_ready_announcement(address, port, server_url(address, port))
+		logger.write_ready_announcement(address, port, local_server_url(address, port))
 
 	# Build web command first (when needed) so we can set PULSE_REACT_SERVER_ADDRESS
 	# before building the uvicorn command, which needs that env var
@@ -247,7 +247,7 @@ def run(
 					raise typer.Exit(1) from None
 				logger.print("Generating routes")
 				try:
-					app_instance.run_codegen(server_url(address, port))
+					app_instance.run_codegen(local_server_url(address, port))
 				except Exception:
 					logger.error("Failed to generate routes")
 					logger.print_exception()

--- a/packages/pulse/python/src/pulse/helpers.py
+++ b/packages/pulse/python/src/pulse/helpers.py
@@ -302,10 +302,19 @@ async def maybe_await(value: T | Awaitable[T]) -> T:
 	return value
 
 
-def server_url(host: str, port: int | str) -> str:
-	"""Build a server URL, using https for non-local hosts."""
-	protocol = "http" if host in ("127.0.0.1", "localhost") else "https"
-	return f"{protocol}://{host}:{port}"
+def local_server_url(host: str, port: int | str) -> str:
+	"""Build the URL for a locally launched ``pulse run`` server.
+
+	``pulse run`` starts uvicorn over plain HTTP, so the URL is always http;
+	production TLS endpoints are configured explicitly via ``App(server_address=...)``
+	and never flow through here. Wildcard bind hosts (``0.0.0.0``, ``::``) are
+	normalized to localhost — a wildcard bind is not a connectable address, and
+	localhost is what a browser on the dev machine can reach. Other hosts (e.g. a
+	LAN IP for on-device testing) are kept as-is, still over http.
+	"""
+	if host in ("0.0.0.0", "::", ""):
+		host = "localhost"
+	return f"http://{host}:{port}"
 
 
 def find_available_port(start_port: int = 8000, max_attempts: int = 100) -> int:

--- a/packages/pulse/python/tests/test_cli.py
+++ b/packages/pulse/python/tests/test_cli.py
@@ -390,6 +390,23 @@ def test_run_fails_on_dependency_conflict(
 	assert "conflict between react@18 and react@19" in result.output
 
 
+@pytest.mark.parametrize(
+	"host, expected",
+	[
+		("localhost", "http://localhost:8000"),
+		("127.0.0.1", "http://127.0.0.1:8000"),
+		("0.0.0.0", "http://localhost:8000"),  # wildcard -> reachable localhost
+		("::", "http://localhost:8000"),
+		("192.168.1.50", "http://192.168.1.50:8000"),  # LAN IP kept, still http
+		("example.com", "http://example.com:8000"),  # never https for `pulse run`
+	],
+)
+def test_local_server_url(host: str, expected: str):
+	from pulse.helpers import local_server_url
+
+	assert local_server_url(host, 8000) == expected
+
+
 def test_run_existing_lock_suggests_interrupt(
 	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):


### PR DESCRIPTION
## Problem

`pulse run` derived the generated server URL from the bind address using an https-for-non-local heuristic (`protocol = "http" if host in ("127.0.0.1","localhost") else "https"`). The dev server is plain HTTP, so binding to a non-local address generated an unusable URL:

- `pulse run app.py --address 0.0.0.0` (the usual way to expose dev to your LAN / test on a phone) → `https://0.0.0.0:8000`. `0.0.0.0` isn't a browser-reachable address, and it's `https` against a plain-HTTP server.
- `pulse run app.py --address 192.168.1.x` → `https://192.168.1.x:8000` → TLS handshake against plain-HTTP uvicorn → fails.

That URL is baked into the generated `_layout.tsx` as `config.serverAddress` and `internalServerAddress`, and is used **directly** — the browser's `clientLoader` fetches `${serverAddress}${apiPrefix}/prerender`, and the SSR `loader` fetches `internalServerAddress`. There's no runtime origin fallback, so the dev session breaks. It worked only because the default `--address localhost` yields `http`.

This predates [#106](https://github.com/erwinkn/pulse-ui/pull/106); that PR preserved the existing behavior. Surfaced by code review and split out here.

## Fix

`pulse run` always launches uvicorn over plain HTTP (TLS in real deployments is configured via an explicit `App(server_address=...)`, which bypasses this derivation entirely). So:

- `server_url()` now always uses `http` and normalizes wildcard binds (`0.0.0.0`, `::`) to `localhost` — the address a browser on the dev machine can actually reach. Other hosts (a LAN IP) are kept as-is, over http.
- `asgi_factory`'s dev derivation now uses the same `server_url()` helper, so the CLI's pre-launch codegen and the server's startup regeneration agree.

## Tests

- `test_server_url` (parametrized): `localhost`/`127.0.0.1` stay http; `0.0.0.0` and `::` → `http://localhost`; a LAN IP and a domain stay http (never https).

## Verification

`make all` passes (1932 Python + 86 JS tests). End-to-end: `pulse run examples/inline_states.py --address 0.0.0.0` now bakes `serverAddress: "http://localhost:8088"` / `internalServerAddress = "http://localhost:8088"` into the generated `_layout.tsx` (previously `https://0.0.0.0:8088`); no `https://0.0.0.0` anywhere in the generated tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)