### PR TITLE
Harden client serializer against functions/symbols + release 0.1.104

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -161,7 +161,7 @@
     },
     "packages/pulse/js": {
       "name": "pulse-ui-client",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "dependencies": {
         "socket.io-client": "^4.8.1",
         "ws": "^8.18.3",

--- a/docs/content/docs/reference/pulse-client/serialization.mdx
+++ b/docs/content/docs/reference/pulse-client/serialization.mdx
@@ -49,6 +49,8 @@ A tuple containing:
 | `Map` | Converted to object (string keys only) |
 | `Object` | Recursively processed |
 | Circular refs | Tracked and restored |
+| `function`, `symbol` | Coerced to null (e.g. a stray React element won't crash the payload) |
+| `bigint`, other | Throws a contextual error naming the type and path |
 
 ### Example
 
@@ -88,6 +90,16 @@ serialize({ value: Infinity });
 // NaN is converted to null (with no error)
 serialize({ value: NaN });
 // [[[], [], [], []], { value: null }]
+
+// Functions and symbols can't cross the wire, so they're coerced to null rather
+// than crashing the whole payload (a common source is a React element, whose
+// $$typeof is a symbol, leaking into a callback argument)
+serialize({ onClick: () => {}, label: "Save" });
+// [[[], [], [], []], { onClick: null, label: "Save" }]
+
+// bigint (and any other genuinely unsupported type) throws a contextual error
+serialize({ amount: 10n });
+// Error: Cannot serialize value of type 'bigint' in 'amount'.
 ```
 
 ---

--- a/packages/pulse/js/package.json
+++ b/packages/pulse/js/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pulse-ui-client",
-	"version": "0.1.103",
+	"version": "0.1.104",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/erwinkn/pulse-ui",

--- a/packages/pulse/js/src/serialize/serializer.test.ts
+++ b/packages/pulse/js/src/serialize/serializer.test.ts
@@ -184,9 +184,45 @@ describe("v4 serialization", () => {
 		expect(() => deserialize(ser)).toThrow("Invalid date literal: 2024-02-30");
 	});
 
-	it("throws on unsupported values (function/symbol)", () => {
-		expect(() => serialize({ x: () => {} } as any)).toThrow();
-		expect(() => serialize({ x: Symbol("s") } as any)).toThrow();
+	it("coerces non-serializable values (functions/symbols) to null", () => {
+		// Functions and symbols can't cross the wire; rather than crash the whole
+		// payload we coerce them to null (like NaN). A common real-world source is a
+		// React element (whose `$$typeof` is a symbol) leaking into a callback arg —
+		// one stray element shouldn't nuke an entire form submission.
+		const fromFunction: any = deserialize(serialize({ x: () => {}, keep: 1 } as any));
+		expect(fromFunction).toEqual({ x: null, keep: 1 });
+		const fromSymbol: any = deserialize(serialize({ x: Symbol("s"), keep: 2 } as any));
+		expect(fromSymbol).toEqual({ x: null, keep: 2 });
+	});
+
+	it("keeps indices aligned when a dropped leaf sits among shared refs and Dates", () => {
+		// The serializer tracks refs/dates by positional node index, so a coerced leaf
+		// must consume an index just like the primitive it becomes. This interleaves a
+		// function (→ null), a shared ref, and a Date to prove round-trips stay aligned.
+		const shared = { v: 1 };
+		const data = {
+			a: shared,
+			arr: [() => {}, shared],
+			d: new Date("1970-01-01T00:00:00.000Z"),
+		};
+
+		const parsed: any = deserialize(serialize(data as any));
+
+		expect(parsed.arr[0]).toBe(null);
+		expect(parsed.a).toBe(parsed.arr[1]); // shared reference preserved
+		expect(parsed.a).toEqual({ v: 1 });
+		expect(parsed.d).toBeInstanceOf(Date);
+		expect(parsed.d.toISOString()).toBe("1970-01-01T00:00:00.000Z");
+	});
+
+	it("throws a clear, contextual error on genuinely unsupported types (bigint)", () => {
+		// Unlike functions/symbols, a bigint is real data the caller likely intended to
+		// send, so we error (with the path) rather than coercing it away. The message is
+		// built from `typeof`, never the raw value — interpolating a symbol here is what
+		// used to throw the cryptic "Cannot convert a symbol to a string".
+		expect(() => serialize({ amount: 10n } as any)).toThrow(
+			"Cannot serialize value of type 'bigint' in 'amount'.",
+		);
 	});
 
 	it("coerces NaN to null", () => {

--- a/packages/pulse/js/src/serialize/serializer.ts
+++ b/packages/pulse/js/src/serialize/serializer.ts
@@ -36,6 +36,16 @@ export function serialize(data: Serializable): Serialized {
 			return value;
 		}
 
+		// Functions and symbols cannot cross the wire. Rather than crash the whole
+		// payload, coerce them to null — exactly like NaN above. A common real-world
+		// source is a React element ($$typeof is a symbol) leaking into a callback arg;
+		// one stray element shouldn't nuke an entire form submission. `idx` was already
+		// consumed at the top of `process`, so the dropped leaf behaves like any other
+		// primitive and the ref/date/set/map indices stay aligned with `deserialize`.
+		if (typeof value === "function" || typeof value === "symbol") {
+			return null;
+		}
+
 		const prevRef = seen.get(value);
 		if (prevRef !== undefined) {
 			// Make sure to push the current index, but use the ref's index as the value!
@@ -90,7 +100,16 @@ export function serialize(data: Serializable): Serialized {
 			return rec;
 		}
 
-		throw new Error(`Unsupported value in serialization: ${value}`);
+		// Reachable only for genuinely unsupported types that carry real data the
+		// caller likely intended to send (e.g. bigint) — unlike functions/symbols, we
+		// don't silently drop these. Build the message from `typeof`, never from `value`
+		// itself: interpolating a symbol here would throw "Cannot convert a symbol to a
+		// string", masking both the real error and the `context` path.
+		const where = context ? ` in '${context}'` : "";
+		throw new Error(
+			`Cannot serialize value of type '${typeof value}'${where}. ` +
+				`Only JSON-compatible values (plus Date, Map, and Set) can be sent over the wire.`,
+		);
 	}
 
 	const payload = process(data);

--- a/packages/pulse/python/pyproject.toml
+++ b/packages/pulse/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pulse-framework"
-version = "0.1.103"
+version = "0.1.104"
 description = "Pulse - Full-stack framework for building real-time React applications in Python"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1323,7 +1323,7 @@ requires-dist = [
 
 [[package]]
 name = "pulse-framework"
-version = "0.1.103"
+version = "0.1.104"
 source = { editable = "packages/pulse/python" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Problem

The wire serializer (`pulse-ui-client`, `packages/pulse/js/src/serialize/serializer.ts`) had a fallback:

```ts
throw new Error(`Unsupported value in serialization: ${value}`);
```

When `value` is a JS **symbol**, interpolating it into the template literal *itself* throws `Cannot convert a symbol to a string` — destroying both the intended message and the `context` (path) the serializer threads. The common real-world trigger is a **React element** (whose `$$typeof` is a symbol) reaching a serialized callback arg, which hard-crashed a `MantineForm` submit (`form.render(onSubmit=...)`).

## Fix

- **functions/symbols → `null`** (mirrors the existing `NaN → null` coercion) instead of crashing the whole payload. A stray React element no longer nukes an entire form submit.
- The index is consumed at the top of `process`, so the coerced leaf behaves exactly like a primitive and the ref/date/set/map positional indices **stay aligned** with `deserialize` — verified for an interleaved shared-ref + `Date` + dropped-leaf case.
- **bigint / other genuinely-lossy types** still throw, now with a **path-aware** message built from `typeof` (never the raw value), so it can't re-trigger the symbol crash:
  `Cannot serialize value of type 'bigint' in 'amount'. …`

## Notes / decisions

- **Not "drop/omit".** An earlier proposal (authored against the stale 0.1.101 base, before `ffd4ec9`) dropped values *before* `globalIndex++` and omitted object keys. On `main`, every node — primitives included — consumes an index, so that approach misaligns the decoder (and it never filtered arrays). Coercing to `null` is the index-safe equivalent on the current positional format.
- The "shared refs + Dates misalignment" latent bug was **already fixed** on `main` by `ffd4ec9` ("Fix serializer primitive index collisions"); confirmed via round-trip. No separate change here.
- Python serializer left unchanged: it raises `TypeError` on functions server-side (a function in outbound data is a real bug); the reported crash is browser → server (JS-side).
- `clean.ts`/`encodeForWire` is dead code (commented out in `index.ts`) using a different explicit-`__id` format — intentionally not unified.

## Release

Bumps `pulse` (Python `pulse` + JS `pulse-ui-client`) `0.1.103 → 0.1.104` so downstream apps pick this up. `release.yml` publishes on merge to `main`.

## Validation

- `make all` → All checks passed (Python 1938 passed/1 skipped, JS 88 pass, basedpyright 0 errors, full TS typecheck incl. docs)
- New tests: function/symbol → null coercion, index alignment with interleaved shared ref + Date + dropped leaf, bigint contextual error
- Round-trip proof: `{ node: {$$typeof: Symbol, …}, cb: () => {}, when: Date }` → `$$typeof`/`cb` become `null`, rest intact, Date preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)