### PR TITLE
Add HTTP offloading for large messages

### DIFF
--- a/docs/content/docs/(core)/advanced/large-messages.mdx
+++ b/docs/content/docs/(core)/advanced/large-messages.mdx
@@ -1,0 +1,56 @@
+---
+title: "Large messages"
+---
+
+Pulse sends every UI update to the browser over a single ordered WebSocket. That ordering is what keeps your app consistent—messages arrive in exactly the order the server produced them. But it has a downside: a single multi-megabyte message blocks every message queued behind it while it drains, including the heartbeats that keep the connection alive. A big enough payload can stall interactive updates and even trip a ping timeout that drops the socket. On top of that, if the connection drops mid-message, the whole message has to be sent again.
+
+To avoid this, Pulse transparently offloads large messages to HTTP using a [claim check](/docs/glossary) pattern. You don't have to do anything—it's on by default. The only knob is a single `App` option.
+
+```python
+import pulse as ps
+
+app = ps.App(
+    routes=[...],
+    large_message_threshold=512 * 1024,  # bytes; default is 256 * 1024 (256 KiB)
+)
+```
+
+When an outgoing message's JSON encoding is larger than `large_message_threshold`, the server gzip-compresses it, stashes it, and sends a tiny reference over the socket instead. The browser fetches the real payload over HTTP (which can be retried independently), then processes it in order with everything else. The socket stays free for the small, fast, interactive updates it's good at.
+
+Most of the time you'll never notice this happening. It kicks in for things like a query returning a large dataset or an initial render of a big table.
+
+## Tuning the threshold
+
+The default (256 KiB) is a good starting point. Raise it if you'd rather keep moderately large messages on the socket, or lower it if you're seeing latency spikes from big updates.
+
+```python
+# Offload sooner (more messages go over HTTP)
+app = ps.App(routes=[...], large_message_threshold=64 * 1024)
+
+# Disable offloading entirely (everything stays on the socket)
+app = ps.App(routes=[...], large_message_threshold=None)
+```
+
+## What you'll see in devtools
+
+Because the mechanism is invisible in your Python code, the browser's network tab is where you'll spot it. Offloaded messages show up as `GET` requests to:
+
+```
+/_pulse/payloads/{render_id}/{payload_id}
+```
+
+These responses come back with `Content-Encoding: gzip`, so devtools will show a compressed transfer size smaller than the decoded size.
+
+## Operational notes
+
+- **Compressed.** Payloads are gzip-compressed on the server and served with `Content-Encoding: gzip`.
+- **One-shot.** Each payload is deleted the first time it's fetched. A second request for the same payload returns `404`.
+- **Session-scoped.** A payload can only be fetched by the user session that owns its render session. Requests from anyone else get a `404`.
+- **Short-lived.** If a payload is never fetched (say the tab closed), it's evicted from the server after 60 seconds.
+- **Self-healing.** If the browser can't fetch a payload after a few retries, it reloads the page—the missed update can't be replayed, so a reload is the clean way back to a consistent state.
+
+## See also
+
+- [Channels](/docs/advanced/channels) — server-initiated messages over the socket
+- [App reference](/docs/reference/pulse/app) — the full list of `ps.App` options
+- [Glossary](/docs/glossary) — WebSocket, serialization, and other terms

--- a/docs/content/docs/(core)/advanced/meta.json
+++ b/docs/content/docs/(core)/advanced/meta.json
@@ -5,6 +5,7 @@
     "refs",
     "js-interop",
     "custom-hooks",
-    "middleware"
+    "middleware",
+    "large-messages"
   ]
 }

--- a/docs/content/docs/(core)/glossary.mdx
+++ b/docs/content/docs/(core)/glossary.mdx
@@ -208,6 +208,9 @@ Registering to receive messages on a channel. When events arrive, your handler f
 **Broadcast**
 Sending a message to all connected clients, not just one. Used for features like live notifications or collaborative editing.
 
+**Claim Check / Payload Offloading**
+A pattern for keeping large messages off the WebSocket. Instead of sending a big payload over the socket (where it would block everything queued behind it), Pulse stashes it, sends a tiny reference, and lets the browser fetch the real payload over HTTP. This gives retries while keeping the socket free for small, fast updates. Controlled by `App(large_message_threshold=...)`.
+
 ## JavaScript Interop
 
 **Transpilation**

--- a/docs/content/docs/reference/pulse/app.mdx
+++ b/docs/content/docs/reference/pulse/app.mdx
@@ -28,6 +28,7 @@ class App:
         session_timeout: float = 60.0,
         prerender_queue_timeout: float = 60.0,
         disconnect_queue_timeout: float = 300.0,
+        large_message_threshold: int | None = 256 * 1024,
         connection_status: ConnectionStatusConfig | None = None,
         render_loop_limit: int = 50,
     ): ...
@@ -54,6 +55,7 @@ class App:
 | `session_timeout` | `float` | `60.0` | Session cleanup timeout (seconds) |
 | `prerender_queue_timeout` | `float` | `60.0` | Prerender queue timeout (seconds) |
 | `disconnect_queue_timeout` | `float` | `300.0` | Disconnected socket message queue timeout (seconds) |
+| `large_message_threshold` | `int \| None` | `256 * 1024` | Byte size above which server→client messages are offloaded to HTTP. `None` disables. See [Large messages](/docs/advanced/large-messages). |
 | `connection_status` | `ConnectionStatusConfig` | `None` | Connection status UI timing |
 | `render_loop_limit` | `int` | `50` | Maximum render loops before failing |
 

--- a/packages/pulse/js/src/client.test.ts
+++ b/packages/pulse/js/src/client.test.ts
@@ -61,11 +61,12 @@ async function makeClient(
 		initialErrorDelay: 0,
 		reconnectErrorDelay: 0,
 	},
+	directives = {},
 ) {
 	const { PulseSocketIOClient } = await import("./client");
 	return new PulseSocketIOClient(
 		"http://pulse.test",
-		{},
+		directives,
 		vi.fn() as any,
 		connectionStatus,
 	);
@@ -81,6 +82,24 @@ function sentMessages(target: FakeSocket = socket) {
 
 function waitForEffects() {
 	return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function wait(ms: number) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function messageResponse(message: object) {
+	return new Response(JSON.stringify(serialize(message)), {
+		status: 200,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+function payloadDirectives() {
+	return {
+		query: { pulse_deployment: "dep-1" },
+		socketio: { auth: { render_id: "render-1" } },
+	};
 }
 
 describe("PulseSocketIOClient attach ack", () => {
@@ -117,6 +136,7 @@ describe("PulseSocketIOClient attach ack", () => {
 				attachId: attach.attachId,
 			}),
 		);
+		await waitForEffects();
 
 		expect(sentMessages()[1]).toMatchObject({
 			type: "callback",
@@ -143,6 +163,7 @@ describe("PulseSocketIOClient attach ack", () => {
 				attachId: attach.attachId,
 			}),
 		);
+		await waitForEffects();
 
 		expect(sentMessages().map((message) => message.type)).toEqual([
 			"attach",
@@ -287,6 +308,107 @@ describe("PulseSocketIOClient attach ack", () => {
 		await waitForEffects();
 
 		expect(reload).not.toHaveBeenCalled();
+	});
+});
+
+describe("PulseSocketIOClient payload refs", () => {
+	beforeEach(() => {
+		io.mockClear();
+	});
+
+	it("processes payload refs and later socket messages in original order", async () => {
+		const events: string[] = [];
+		const client = await makeClient(undefined, payloadDirectives());
+		const connected = client.connect();
+		client.attach("/", {
+			routeInfo,
+			onInit: vi.fn(() => events.push("init")),
+			onUpdate: vi.fn(() => events.push("update")),
+			onJsExec: vi.fn(),
+			onServerError: vi.fn(),
+		});
+		socket.trigger("connect");
+		await connected;
+
+		let resolveFetch: (response: Response) => void = () => {};
+		const fetchResponse = new Promise<Response>((resolve) => {
+			resolveFetch = resolve;
+		});
+		const fetchMock = vi
+			.spyOn(globalThis, "fetch")
+			.mockReturnValue(fetchResponse as ReturnType<typeof fetch>);
+
+		socket.trigger("message", serialize({ type: "payload_ref", id: "p1", size: 100 }));
+		socket.trigger(
+			"message",
+			serialize({ type: "vdom_update", path: "/", ops: [] }),
+		);
+		await waitForEffects();
+		expect(events).toEqual([]);
+
+		resolveFetch(messageResponse({ type: "vdom_init", path: "/", vdom: [] }));
+		await waitForEffects();
+		await waitForEffects();
+
+		expect(events).toEqual(["init", "update"]);
+		fetchMock.mockRestore();
+	});
+
+	it("retries a payload ref fetch then applies the message", async () => {
+		const events: string[] = [];
+		const client = await makeClient(undefined, payloadDirectives());
+		const connected = client.connect();
+		client.attach("/", {
+			routeInfo,
+			onInit: vi.fn(() => events.push("init")),
+			onUpdate: vi.fn(),
+			onJsExec: vi.fn(),
+			onServerError: vi.fn(),
+		});
+		socket.trigger("connect");
+		await connected;
+
+		const fetchMock = vi
+			.spyOn(globalThis, "fetch")
+			.mockRejectedValueOnce(new Error("network down"))
+			.mockResolvedValueOnce(messageResponse({ type: "vdom_init", path: "/", vdom: [] }));
+
+		socket.trigger("message", serialize({ type: "payload_ref", id: "p1", size: 100 }));
+		await wait(20);
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		const url = fetchMock.mock.calls[0]![0] as URL;
+		expect(url.pathname).toBe("/_pulse/payloads/render-1/p1");
+		expect(url.searchParams.get("pulse_deployment")).toBe("dep-1");
+		expect(events).toEqual(["init"]);
+		fetchMock.mockRestore();
+	});
+
+	it("reloads after permanent payload ref failure", async () => {
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		const reload = vi.fn();
+		Object.defineProperty(window.location, "reload", {
+			configurable: true,
+			value: reload,
+		});
+		const client = await makeClient(undefined, payloadDirectives());
+		const connected = client.connect();
+		client.attach("/", view);
+		socket.trigger("connect");
+		await connected;
+
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("missing", { status: 404 }) as any,
+		);
+
+		socket.trigger("message", serialize({ type: "payload_ref", id: "p1", size: 100 }));
+		await waitForEffects();
+		await waitForEffects();
+
+		expect(reload).toHaveBeenCalled();
+		expect(consoleError).toHaveBeenCalled();
+		fetchMock.mockRestore();
+		consoleError.mockRestore();
 	});
 });
 

--- a/packages/pulse/js/src/client.tsx
+++ b/packages/pulse/js/src/client.tsx
@@ -12,10 +12,12 @@ import type {
 	ServerError,
 	ServerJsExecMessage,
 	ServerMessage,
+	ServerPayloadRefMessage,
 } from "./messages";
 import type { PulsePrerenderView } from "./pulse";
 import { extractEvent } from "./serialize/events";
 import { deserialize, serialize } from "./serialize/serializer";
+import type { Serialized } from "./serialize/serializer";
 import type { VDOMUpdate } from "./vdom";
 
 function documentIsHidden(): boolean {
@@ -24,6 +26,12 @@ function documentIsHidden(): boolean {
 
 function browserIsOnline(): boolean {
 	return typeof navigator === "undefined" || navigator.onLine !== false;
+}
+
+const PAYLOAD_FETCH_BACKOFF_MS = [5, 10, 20];
+
+function wait(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export interface SocketIODirectives {
@@ -69,6 +77,7 @@ export class PulseSocketIOClient {
 	#pendingCallbacks: Map<string, ClientCallbackMessage[]>;
 	#socket: Socket | null = null;
 	#messageQueue: ClientMessage[];
+	#serverMessageQueue: Promise<void> = Promise.resolve();
 	#connectionListeners: Set<ConnectionStatusListener> = new Set();
 	#channels: Map<string, { bridge: ChannelBridge; refCount: number }> = new Map();
 	#url: string;
@@ -197,6 +206,7 @@ export class PulseSocketIOClient {
 				query: this.#directives.socketio?.query,
 			});
 			this.#socket = socket;
+			this.#serverMessageQueue = Promise.resolve();
 
 			socket.on("connect", () => {
 				if (this.#socket !== socket) return;
@@ -240,7 +250,14 @@ export class PulseSocketIOClient {
 			// Wrap in an arrow function to avoid losing the `this` reference
 			socket.on("message", (data) => {
 				if (this.#socket !== socket) return;
-				this.#handleServerMessage(deserialize(data, { coerceNullsToUndefined: true }));
+				this.#serverMessageQueue = this.#serverMessageQueue
+					.then(
+						() => this.#processServerMessage(socket, data),
+						() => this.#processServerMessage(socket, data),
+					)
+					.catch((err) => {
+						console.error("[PulseClient] Failed to process server message", err);
+					});
 			});
 		});
 	}
@@ -342,6 +359,85 @@ export class PulseSocketIOClient {
 		this.#socket = null;
 		this.#handleTransportDisconnect();
 		socket.disconnect();
+	}
+
+	async #processServerMessage(socket: Socket, data: unknown): Promise<void> {
+		const message = deserialize<ServerMessage>(data as any, {
+			coerceNullsToUndefined: true,
+		});
+		if (message.type !== "payload_ref") {
+			this.#handleServerMessage(message);
+			return;
+		}
+
+		const payload = await this.#fetchPayloadRef(socket, message);
+		if (payload === null || this.#socket !== socket) return;
+		this.#handleServerMessage(
+			deserialize<ServerMessage>(payload, { coerceNullsToUndefined: true }),
+		);
+	}
+
+	async #fetchPayloadRef(
+		socket: Socket,
+		message: ServerPayloadRefMessage,
+	): Promise<Serialized | null> {
+		const renderId =
+			this.#directives.socketio?.auth?.render_id ??
+			this.#directives.headers?.["X-Pulse-Render-Id"];
+		if (!renderId) {
+			this.#recoverPayloadFetch(socket, new Error("Missing Pulse render id"));
+			return null;
+		}
+
+		let lastError: unknown = null;
+		for (let attempt = 0; attempt <= PAYLOAD_FETCH_BACKOFF_MS.length; attempt++) {
+			if (this.#socket !== socket) return null;
+			let retry = true;
+			try {
+				const url = new URL(
+					`/_pulse/payloads/${encodeURIComponent(renderId)}/${encodeURIComponent(message.id)}`,
+					this.#url,
+				);
+				for (const [key, value] of Object.entries(this.#directives.query ?? {})) {
+					url.searchParams.set(key, value);
+				}
+				const response = await fetch(url, {
+					method: "GET",
+					headers: this.#directives.headers,
+					credentials: "include",
+				});
+				if (this.#socket !== socket) return null;
+				if (response.status === 404) {
+					lastError = new Error(`Payload ${message.id} was not found`);
+					retry = false;
+				} else if (!response.ok) {
+					lastError = new Error(
+						`Payload ${message.id} failed with HTTP ${response.status}`,
+					);
+				} else {
+					const payload = (await response.json()) as Serialized;
+					if (this.#socket !== socket) return null;
+					return payload;
+				}
+			} catch (err) {
+				lastError = err;
+			}
+
+			if (!retry || attempt === PAYLOAD_FETCH_BACKOFF_MS.length) {
+				this.#recoverPayloadFetch(socket, lastError);
+				return null;
+			}
+			await wait(PAYLOAD_FETCH_BACKOFF_MS[attempt]);
+		}
+		return null;
+	}
+
+	#recoverPayloadFetch(socket: Socket, err: unknown): void {
+		if (this.#socket !== socket) return;
+		// The server considers the message delivered, so the missed update cannot be
+		// replayed; a full reload is the only way back to consistent state.
+		console.error("[PulseClient] Failed to fetch server payload; reloading", err);
+		window.location.reload();
 	}
 
 	#handleServerMessage(message: ServerMessage) {

--- a/packages/pulse/js/src/messages.ts
+++ b/packages/pulse/js/src/messages.ts
@@ -90,6 +90,12 @@ export interface ServerJsExecMessage {
 	expr: VDOMNode;
 }
 
+export interface ServerPayloadRefMessage {
+	type: "payload_ref";
+	id: string;
+	size: number;
+}
+
 export type ServerMessage =
 	| ServerInitMessage
 	| ServerUpdateMessage
@@ -100,7 +106,8 @@ export type ServerMessage =
 	| ServerAttachAckMessage
 	| ServerChannelRequestMessage
 	| ServerChannelResponseMessage
-	| ServerJsExecMessage;
+	| ServerJsExecMessage
+	| ServerPayloadRefMessage;
 
 export interface ClientCallbackMessage {
 	type: "callback";

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -6,8 +6,11 @@ to define routes and configure their Pulse application.
 """
 
 import asyncio
+import gzip
+import json
 import logging
 import os
+import uuid
 from collections import defaultdict
 from collections.abc import Awaitable, Sequence
 from contextlib import asynccontextmanager
@@ -88,6 +91,7 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 FRAMEWORK_API_PREFIX = "/_pulse"
 MAX_PENDING_SOCKET_MESSAGES = 100
+PAYLOAD_STASH_TTL = 60.0
 PULSE_ENDPOINT_UNWRAP_MARKER = "__pulse_endpoint_unwrap__"
 
 
@@ -267,6 +271,7 @@ class App:
 	_socket_to_render: dict[str, str]
 	_connecting_sockets: set[str]
 	_pending_socket_messages: dict[str, list[Serialized]]
+	_payload_stashes: dict[str, dict[str, tuple[bytes, TimerHandleLike]]]
 	_render_cleanups: dict[str, TimerHandleLike]
 	_render_message_locks: dict[str, asyncio.Lock]
 	_tasks: TaskRegistry
@@ -278,6 +283,7 @@ class App:
 	render_loop_limit: int
 	prerender_queue_timeout: float
 	disconnect_queue_timeout: float
+	large_message_threshold: int | None
 
 	def __init__(
 		self,
@@ -299,9 +305,12 @@ class App:
 		session_timeout: float = 60.0,
 		prerender_queue_timeout: float = 60.0,
 		disconnect_queue_timeout: float = 300.0,
+		large_message_threshold: int | None = 256 * 1024,
 		connection_status: ConnectionStatusConfig | None = None,
 		render_loop_limit: int = 50,
 	):
+		if large_message_threshold is not None and large_message_threshold < 0:
+			raise ValueError("large_message_threshold must be >= 0 or None")
 		# Resolve mode from environment and expose on the app instance
 		self.env = envvars.pulse_env
 		self.mode = mode
@@ -348,6 +357,7 @@ class App:
 		self._socket_to_render = {}
 		self._connecting_sockets = set()
 		self._pending_socket_messages = {}
+		self._payload_stashes = {}
 		# Map render_id -> cleanup timer handle for timeout-based expiry
 		self._render_cleanups = {}
 		self._render_message_locks = {}
@@ -357,6 +367,7 @@ class App:
 		self.session_timeout = session_timeout
 		self.prerender_queue_timeout = prerender_queue_timeout
 		self.disconnect_queue_timeout = disconnect_queue_timeout
+		self.large_message_threshold = large_message_threshold
 		self.connection_status = connection_status or ConnectionStatusConfig()
 		self.render_loop_limit = render_loop_limit
 
@@ -746,6 +757,36 @@ class App:
 
 			return await render.forms.handle_submit(form_id, request, session)
 
+		@self.fastapi.get(f"{prefix}/payloads/{{render_id}}/{{payload_id}}")
+		async def get_payload(  # pyright: ignore[reportUnusedFunction]
+			render_id: str, payload_id: str
+		) -> Response:
+			session = PulseContext.get().session
+			if session is None:
+				raise RuntimeError("Internal error: couldn't resolve user session")
+
+			render = self._get_render_for_session(render_id, session)
+			if render is None:
+				raise HTTPException(status_code=404, detail="Payload not found")
+
+			stash = self._payload_stashes.get(render.id)
+			if stash is None:
+				raise HTTPException(status_code=404, detail="Payload not found")
+			stash_entry = stash.pop(payload_id, None)
+			if stash_entry is None:
+				raise HTTPException(status_code=404, detail="Payload not found")
+			payload, handle = stash_entry
+			if not handle.cancelled():
+				handle.cancel()
+			self._timers.discard(handle)
+			if len(stash) == 0:
+				self._payload_stashes.pop(render.id, None)
+			return Response(
+				content=payload,
+				media_type="application/json",
+				headers={"Content-Encoding": "gzip"},
+			)
+
 		# Call on_setup hooks after FastAPI routes/middleware are in place
 		for plugin in self.plugins:
 			plugin.on_setup(self)
@@ -829,9 +870,7 @@ class App:
 					)
 
 			def on_message(message: ServerMessage):
-				payload = serialize(message)
-				# `serialize` returns a tuple, which socket.io will mistake for multiple arguments
-				payload = list(payload)
+				payload = self._serialize_server_message(render.id, message)
 				self._tasks.create_task(self.sio.emit("message", list(payload), to=sid))
 
 			render.connect(on_message)
@@ -885,6 +924,38 @@ class App:
 			await self._handle_socket_message(sid, data)
 
 		self.status = AppStatus.initialized
+
+	def _serialize_server_message(
+		self, render_id: str, message: ServerMessage
+	) -> Serialized:
+		payload = serialize(message)
+		threshold = self.large_message_threshold
+		if threshold is None:
+			return payload
+		encoded = json.dumps(payload, separators=(",", ":"))
+		encoded_bytes = encoded.encode("utf-8")
+		size = len(encoded_bytes)
+		if size <= threshold:
+			return payload
+
+		payload_id = uuid.uuid4().hex
+		compressed = gzip.compress(encoded_bytes)
+		handle = self._timers.later(
+			PAYLOAD_STASH_TTL, self._evict_payload_stash, render_id, payload_id
+		)
+		self._payload_stashes.setdefault(render_id, {})[payload_id] = (
+			compressed,
+			handle,
+		)
+		return serialize({"type": "payload_ref", "id": payload_id, "size": size})
+
+	def _evict_payload_stash(self, render_id: str, payload_id: str) -> None:
+		stash = self._payload_stashes.get(render_id)
+		if stash is None:
+			return
+		stash.pop(payload_id, None)
+		if len(stash) == 0:
+			self._payload_stashes.pop(render_id, None)
 
 	def _cancel_render_cleanup(self, rid: str):
 		"""Cancel any pending cleanup task for a render session."""
@@ -1179,6 +1250,12 @@ class App:
 		# Cancel any pending cleanup task
 		self._cancel_render_cleanup(rid)
 		self._render_message_locks.pop(rid, None)
+		stash = self._payload_stashes.pop(rid, None)
+		if stash is not None:
+			for _, handle in stash.values():
+				if not handle.cancelled():
+					handle.cancel()
+				self._timers.discard(handle)
 
 		render = self.render_sessions.pop(rid, None)
 		if not render:

--- a/packages/pulse/python/src/pulse/messages.py
+++ b/packages/pulse/python/src/pulse/messages.py
@@ -101,6 +101,12 @@ class ServerJsExecMessage(TypedDict):
 	expr: VDOMNode
 
 
+class ServerPayloadRefMessage(TypedDict):
+	type: Literal["payload_ref"]
+	id: str
+	size: int
+
+
 # ====================
 # Client messages
 # ====================
@@ -176,6 +182,7 @@ ServerMessage = (
 	| ServerAttachAckMessage
 	| ServerChannelMessage
 	| ServerJsExecMessage
+	| ServerPayloadRefMessage
 )
 
 

--- a/packages/pulse/python/tests/test_payload_ref.py
+++ b/packages/pulse/python/tests/test_payload_ref.py
@@ -1,0 +1,277 @@
+# pyright: reportPrivateUsage=false
+
+import asyncio
+import gzip
+import json
+
+import httpx
+import pulse as ps
+import pulse.app as pulse_app
+import pytest
+from pulse.messages import ServerMessage
+from pulse.serializer import Serialized, deserialize, serialize
+
+
+def _server_message(text: str) -> ServerMessage:
+	return {
+		"type": "server_error",
+		"path": "/",
+		"error": {"message": text, "phase": "server"},
+	}
+
+
+def _global_message(text: str) -> ServerMessage:
+	return {
+		"type": "api_call",
+		"id": "api-1",
+		"url": f"/api/{text}",
+		"method": "GET",
+		"headers": {},
+		"body": None,
+		"credentials": "include",
+	}
+
+
+def _encoded(message: ServerMessage) -> str:
+	return json.dumps(serialize(message), separators=(",", ":"))
+
+
+def _decoded(payload: Serialized) -> dict[str, object]:
+	decoded = deserialize(payload)
+	assert isinstance(decoded, dict)
+	return decoded
+
+
+async def _client_with_render(app: ps.App) -> tuple[httpx.AsyncClient, str]:
+	transport = httpx.ASGITransport(app=app.fastapi)
+	client = httpx.AsyncClient(transport=transport, base_url="http://localhost:8000")
+	response = await client.get("/_pulse/health")
+	assert response.status_code == 200
+	session = next(iter(app.user_sessions.values()))
+	render = app.create_render("render-1", session)
+	return client, render.id
+
+
+def test_payload_under_threshold_uses_socket_payload():
+	message = _server_message("x" * 64)
+	encoded = _encoded(message)
+	app = ps.App(large_message_threshold=len(encoded))
+
+	payload = app._serialize_server_message("render-1", message)
+
+	assert deserialize(payload) == message
+	assert app._payload_stashes == {}
+
+
+@pytest.mark.asyncio
+async def test_payload_over_threshold_emits_ref_and_stashes_exact_json():
+	message = _server_message("x" * 64)
+	encoded = _encoded(message)
+	app = ps.App(large_message_threshold=len(encoded) - 1)
+
+	try:
+		payload = app._serialize_server_message("render-1", message)
+		ref = _decoded(payload)
+
+		assert ref["type"] == "payload_ref"
+		assert ref["size"] == len(encoded.encode())
+		stash_value = app._payload_stashes["render-1"][str(ref["id"])]
+		assert gzip.decompress(stash_value[0]).decode() == encoded
+	finally:
+		await app.close()
+
+
+@pytest.mark.asyncio
+async def test_payload_get_is_one_shot_and_404s_unknown_ids(
+	monkeypatch: pytest.MonkeyPatch,
+):
+	monkeypatch.setenv("PULSE_REACT_SERVER_ADDRESS", "http://localhost:3000")
+	message = _server_message("x" * 64)
+	encoded = _encoded(message)
+	app = ps.App(large_message_threshold=len(encoded) - 1)
+	app.setup("http://localhost:8000")
+	client, render_id = await _client_with_render(app)
+	try:
+		payload = app._serialize_server_message(render_id, message)
+		ref = _decoded(payload)
+
+		unknown_render = await client.get(f"/_pulse/payloads/unknown/{ref['id']}")
+		assert unknown_render.status_code == 404
+
+		unknown_payload = await client.get(f"/_pulse/payloads/{render_id}/unknown")
+		assert unknown_payload.status_code == 404
+
+		response = await client.get(f"/_pulse/payloads/{render_id}/{ref['id']}")
+		assert response.status_code == 200
+		assert response.text == encoded
+
+		again = await client.get(f"/_pulse/payloads/{render_id}/{ref['id']}")
+		assert again.status_code == 404
+	finally:
+		await client.aclose()
+		await app.close()
+
+
+@pytest.mark.asyncio
+async def test_payload_stash_ttl_expires_to_404(monkeypatch: pytest.MonkeyPatch):
+	monkeypatch.setenv("PULSE_REACT_SERVER_ADDRESS", "http://localhost:3000")
+	monkeypatch.setattr(pulse_app, "PAYLOAD_STASH_TTL", 0.01)
+	message = _server_message("x" * 64)
+	encoded = _encoded(message)
+	app = ps.App(large_message_threshold=len(encoded) - 1)
+	app.setup("http://localhost:8000")
+	client, render_id = await _client_with_render(app)
+	try:
+		payload = app._serialize_server_message(render_id, message)
+		ref = _decoded(payload)
+
+		await asyncio.sleep(0.03)
+
+		assert render_id not in app._payload_stashes
+		response = await client.get(f"/_pulse/payloads/{render_id}/{ref['id']}")
+		assert response.status_code == 404
+	finally:
+		await client.aclose()
+		await app.close()
+
+
+@pytest.mark.asyncio
+async def test_payload_fetch_cancels_timer(monkeypatch: pytest.MonkeyPatch):
+	monkeypatch.setenv("PULSE_REACT_SERVER_ADDRESS", "http://localhost:3000")
+	monkeypatch.setattr(pulse_app, "PAYLOAD_STASH_TTL", 0.01)
+	message = _server_message("x" * 64)
+	encoded = _encoded(message)
+	app = ps.App(large_message_threshold=len(encoded) - 1)
+	app.setup("http://localhost:8000")
+	client, render_id = await _client_with_render(app)
+	try:
+		payload = app._serialize_server_message(render_id, message)
+		ref = _decoded(payload)
+		_, handle = app._payload_stashes[render_id][str(ref["id"])]
+
+		response = await client.get(f"/_pulse/payloads/{render_id}/{ref['id']}")
+		assert response.status_code == 200
+		assert response.text == encoded
+		assert render_id not in app._payload_stashes
+		assert handle not in app._timers._handles
+
+		await asyncio.sleep(0.03)
+		assert render_id not in app._payload_stashes
+	finally:
+		await client.aclose()
+		await app.close()
+
+
+@pytest.mark.asyncio
+async def test_payload_get_returns_gzip(monkeypatch: pytest.MonkeyPatch):
+	monkeypatch.setenv("PULSE_REACT_SERVER_ADDRESS", "http://localhost:3000")
+	message = _server_message("x" * 64)
+	encoded = _encoded(message)
+	app = ps.App(large_message_threshold=len(encoded) - 1)
+	app.setup("http://localhost:8000")
+	client, render_id = await _client_with_render(app)
+	try:
+		payload = app._serialize_server_message(render_id, message)
+		ref = _decoded(payload)
+		stash_value = app._payload_stashes[render_id][str(ref["id"])]
+		assert gzip.decompress(stash_value[0]).decode() == encoded
+
+		response = await client.get(f"/_pulse/payloads/{render_id}/{ref['id']}")
+		assert response.status_code == 200
+		assert response.headers["content-encoding"] == "gzip"
+		assert response.text == encoded
+	finally:
+		await client.aclose()
+		await app.close()
+
+
+@pytest.mark.asyncio
+async def test_payload_get_denies_other_sessions(monkeypatch: pytest.MonkeyPatch):
+	monkeypatch.setenv("PULSE_REACT_SERVER_ADDRESS", "http://localhost:3000")
+	message = _server_message("x" * 64)
+	encoded = _encoded(message)
+	app = ps.App(large_message_threshold=len(encoded) - 1)
+	app.setup("http://localhost:8000")
+	client, render_id = await _client_with_render(app)
+	try:
+		payload = app._serialize_server_message(render_id, message)
+		ref = _decoded(payload)
+
+		other_transport = httpx.ASGITransport(app=app.fastapi)
+		other = httpx.AsyncClient(
+			transport=other_transport, base_url="http://localhost:8000"
+		)
+		try:
+			stolen = await other.get(f"/_pulse/payloads/{render_id}/{ref['id']}")
+			assert stolen.status_code == 404
+		finally:
+			await other.aclose()
+
+		response = await client.get(f"/_pulse/payloads/{render_id}/{ref['id']}")
+		assert response.status_code == 200
+	finally:
+		await client.aclose()
+		await app.close()
+
+
+def test_threshold_none_never_offloads():
+	message = _server_message("x" * 1024)
+	app = ps.App(large_message_threshold=None)
+
+	payload = app._serialize_server_message("render-1", message)
+
+	assert deserialize(payload) == message
+	assert app._payload_stashes == {}
+
+
+@pytest.mark.asyncio
+async def test_payload_stash_cleared_on_render_close(
+	monkeypatch: pytest.MonkeyPatch,
+):
+	monkeypatch.setenv("PULSE_REACT_SERVER_ADDRESS", "http://localhost:3000")
+	message = _server_message("x" * 64)
+	encoded = _encoded(message)
+	app = ps.App(large_message_threshold=len(encoded) - 1)
+	app.setup("http://localhost:8000")
+	session = await app.get_or_create_session(None)
+	render = app.create_render("render-1", session)
+
+	payload = app._serialize_server_message(render.id, message)
+	ref = _decoded(payload)
+	_, handle = app._payload_stashes[render.id][str(ref["id"])]
+	app.close_render(render.id)
+
+	assert render.id not in app._payload_stashes
+	assert handle not in app._timers._handles
+	await app.close()
+
+
+@pytest.mark.asyncio
+async def test_disconnected_queue_payload_ref_fetchable_after_reconnect(
+	monkeypatch: pytest.MonkeyPatch,
+):
+	monkeypatch.setenv("PULSE_REACT_SERVER_ADDRESS", "http://localhost:3000")
+	message = _global_message("x" * 64)
+	encoded = _encoded(message)
+	app = ps.App(large_message_threshold=len(encoded) - 1)
+	app.setup("http://localhost:8000")
+	client, render_id = await _client_with_render(app)
+	try:
+		render = app.render_sessions[render_id]
+		render.send(message)
+
+		sent: list[Serialized] = []
+		render.connect(
+			lambda msg: sent.append(app._serialize_server_message(render.id, msg))
+		)
+
+		assert len(sent) == 1
+		ref = _decoded(sent[0])
+		assert ref["type"] == "payload_ref"
+
+		response = await client.get(f"/_pulse/payloads/{render_id}/{ref['id']}")
+		assert response.status_code == 200
+		assert response.text == encoded
+	finally:
+		await client.aclose()
+		await app.close()

--- a/skills/pulse/references/app.md
+++ b/skills/pulse/references/app.md
@@ -38,6 +38,7 @@ app = ps.App(
 | `cors` | `CORSOptions` | Auto | CORS configuration |
 | `fastapi` | `dict` | `None` | FastAPI constructor options |
 | `session_timeout` | `float` | `60.0` | Session cleanup timeout (seconds) |
+| `large_message_threshold` | `int \| None` | `256 * 1024` | Byte size above which server→client messages are offloaded to HTTP. `None` disables. |
 
 ## Deployment Modes
 
@@ -179,6 +180,29 @@ app = ps.App(
     ),
 )
 ```
+
+## Large Message Offloading
+
+Large server→client messages block every other message behind them on the ordered WebSocket (including heartbeats). Pulse transparently offloads them to HTTP using a claim-check pattern.
+
+```python
+app = ps.App(
+    routes=[...],
+    large_message_threshold=512 * 1024,  # Default: 256 * 1024 (256 KiB)
+)
+
+# Disable offloading entirely (send everything over the socket)
+app = ps.App(routes=[...], large_message_threshold=None)
+```
+
+When an outgoing message's JSON encoding exceeds the threshold, the server gzip-compresses it, stashes it, and sends a tiny `payload_ref` over the socket. The client fetches `GET /_pulse/payloads/{render_id}/{payload_id}` and processes it in order with other messages.
+
+- Payloads are gzip-compressed (served with `Content-Encoding: gzip`).
+- One-shot: each payload is deleted on first fetch.
+- Scoped to the owning user's session (ownership is validated on fetch).
+- Unfetched stash entries expire after 60 seconds.
+- If a fetch fails after retries, the client reloads the page to recover.
+- Must be `>= 0` or `None`; a negative value raises `ValueError`.
 
 ## Middleware
 


### PR DESCRIPTION
## Summary

Transparently offloads large server→client WebSocket messages to HTTP using a claim-check pattern. When an outgoing message's JSON encoding exceeds `App(large_message_threshold=...)` (new option, default 256 KiB, `None` disables), the server stashes the gzip-compressed payload and sends a tiny `payload_ref` over the socket instead. The client fetches `GET /_pulse/payloads/{render_id}/{payload_id}` and processes it in order with other messages.

### Why

A single multi-megabyte message on Pulse's one ordered socket blocks every message queued behind it — including Engine.IO heartbeats, risking a ping-timeout disconnect/reconnect loop that resends the whole payload. Moving large payloads to HTTP keeps the socket free for small interactive updates, and HTTP requests retry independently instead of resending the entire message on a drop.

## What's included

**Server** (`packages/pulse/python`)
- New `App(large_message_threshold=...)` option (default `256 * 1024`, `None` disables).
- At the single send choke point, messages over threshold are gzip-compressed once, stashed per render session, and replaced with a `payload_ref` on the socket.
- `GET /_pulse/payloads/{render_id}/{payload_id}`: one-shot (second GET 404s), session-authenticated, served with `Content-Encoding: gzip`.
- Stash entries evict after 60s if unfetched; timers cancelled on fetch and render-session close.

**Client** (`packages/pulse/js`)
- Incoming socket messages flow through a strictly-ordered promise chain, so a message arriving while a payload fetch is in flight waits its turn.
- `payload_ref` fetches with retry/backoff (carrying affinity query params for multi-deployment routing); permanent failure recovers via `window.location.reload()`.

**Docs** — new `advanced/large-messages.mdx` page, App reference entries, glossary term.

## Testing

- `make all` passes (full pytest, 86 bun tests, lint, typecheck).
- `test_payload_ref.py` covers offload threshold, one-shot semantics, cross-session 404, TTL expiry→404, fetch-cancels-timer, gzip round-trip, render cleanup.
- Client tests cover ordered processing, fetch retries, affinity params, and reload recovery.

## Notes

- Socket-level compression is already active (uvicorn's `websockets` impl negotiates per-message-deflate by default), so this PR adds no socket-compression config — the HTTP win is head-of-line avoidance + independent retries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
