### PR TITLE
Fix uncontrolled MantineForm updates

### DIFF
--- a/.claude/skills/pulse-mantine/references/forms.md
+++ b/.claude/skills/pulse-mantine/references/forms.md
@@ -330,7 +330,7 @@ Create custom inputs that integrate with forms:
 
 ```tsx
 // In JS:
-import { createConnectedField, useFieldProps } from "pulse-mantine";
+import { createConnectedField, useField } from "pulse-mantine";
 
 // HOC approach:
 const ConnectedCustomInput = createConnectedField(CustomInput, {
@@ -340,10 +340,12 @@ const ConnectedCustomInput = createConnectedField(CustomInput, {
 
 // Hook approach:
 function MyInput(props) {
-    const fieldProps = useFieldProps(props, { debounceOnChange: true });
-    return <input {...fieldProps} />;
+    const { inputProps, key } = useField(props, { debounceOnChange: true });
+    return <input key={key} {...inputProps} />;
 }
 ```
+
+The returned `key` keeps custom uncontrolled inputs in sync after programmatic form actions. `createConnectedField` applies it automatically.
 
 Options:
 - `inputType`: "input" | "checkbox"

--- a/bun.lock
+++ b/bun.lock
@@ -133,8 +133,10 @@
     },
     "packages/pulse-mantine/js": {
       "name": "pulse-mantine",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
         "@types/bun": "latest",
         "@types/node": "^24.6.0",
         "@types/react": "^19.1.16",

--- a/docs/content/docs/packages/pulse-mantine/forms.mdx
+++ b/docs/content/docs/packages/pulse-mantine/forms.mdx
@@ -397,6 +397,7 @@ form = MantineForm(
 - **Uncontrolled:** For large forms, performance-critical applications, or when you only need values on submit.
 
 Both modes work with all Pulse Mantine features including validation and dynamic forms.
+Programmatic actions such as `set_field_value` update the visible input in both modes.
 
 ---
 

--- a/docs/content/docs/packages/pulse-mantine/js-exports.mdx
+++ b/docs/content/docs/packages/pulse-mantine/js-exports.mdx
@@ -44,17 +44,17 @@ createConnectedField(Component, {
 - `coerceEmptyString: true` — for text inputs to prevent uncontrolled/controlled warnings
 - `debounceOnChange: true` — for text inputs to avoid server calls on every keystroke
 
-## useFieldProps
+## useField
 
 A hook that returns form-connected props. Use this when you need more control than `createConnectedField` provides.
 
 ```tsx
-import { useFieldProps } from "pulse-mantine";
+import { useField } from "pulse-mantine";
 
 function CustomInput(props) {
-  const fieldProps = useFieldProps(props, { debounceOnChange: true });
+  const { inputProps, key } = useField(props, { debounceOnChange: true });
 
-  // fieldProps now includes:
+  // inputProps now includes:
   // - value from form state
   // - onChange that updates form + triggers server validation
   // - onBlur that triggers server validation
@@ -62,8 +62,8 @@ function CustomInput(props) {
 
   return (
     <div>
-      <input {...fieldProps} />
-      {fieldProps.error && <span className="error">{fieldProps.error}</span>}
+      <input key={key} {...inputProps} />
+      {inputProps.error && <span className="error">{inputProps.error}</span>}
     </div>
   );
 }
@@ -73,9 +73,11 @@ The hook:
 1. Reads the form context (provided by `MantineForm.render()`)
 2. Merges your props with Mantine's `getInputProps()` result
 3. Wraps `onChange` and `onBlur` to trigger server validation
-4. Returns the merged props
+4. Returns the merged `inputProps` and field `key`
 
-If there's no form context or no `name` prop, it returns the original props unchanged—so your component works both inside and outside forms.
+The returned `key` keeps custom uncontrolled inputs in sync after programmatic updates such as `set_field_value`. Pass it to the input's React `key`, as shown above. `createConnectedField` does this automatically.
+
+If there's no form context or no `name` prop, `inputProps` contains the original props and `key` is undefined—so your component works both inside and outside forms.
 
 ## Full example: Currency input
 
@@ -84,7 +86,7 @@ Here's a complete example of a custom currency input that integrates with Pulse 
 ```tsx
 // components/CurrencyInput.tsx
 import { TextInput } from "@mantine/core";
-import { useFieldProps } from "pulse-mantine";
+import { useField } from "pulse-mantine";
 import type { TextInputProps } from "@mantine/core";
 
 interface CurrencyInputProps extends Omit<TextInputProps, "onChange"> {
@@ -95,14 +97,14 @@ interface CurrencyInputProps extends Omit<TextInputProps, "onChange"> {
 
 export function CurrencyInput({ currency = "USD", onChange, ...props }: CurrencyInputProps) {
   // Connect to form context
-  const fieldProps = useFieldProps(props, {
+  const { inputProps, key } = useField(props, {
     debounceOnChange: true,
     coerceEmptyString: true,
   });
 
   // Format display value
-  const displayValue = fieldProps.value != null
-    ? new Intl.NumberFormat("en-US", { minimumFractionDigits: 2 }).format(fieldProps.value)
+  const displayValue = inputProps.value != null
+    ? new Intl.NumberFormat("en-US", { minimumFractionDigits: 2 }).format(inputProps.value)
     : "";
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -110,13 +112,14 @@ export function CurrencyInput({ currency = "USD", onChange, ...props }: Currency
     const parsed = raw ? parseFloat(raw) : null;
 
     // Call the form's onChange with the numeric value
-    fieldProps.onChange?.(parsed);
+    inputProps.onChange?.(parsed);
     onChange?.(parsed);
   };
 
   return (
     <TextInput
-      {...fieldProps}
+      key={key}
+      {...inputProps}
       value={displayValue}
       onChange={handleChange}
       leftSection={currency}
@@ -151,7 +154,7 @@ When a `MantineForm` renders, it wraps its children with a React context contain
 - The Mantine `useForm` instance
 - Callbacks for server-side validation (`serverOnChange`, `serverOnBlur`)
 
-`useFieldProps` reads this context and merges:
+`useField` reads this context and returns a `key` plus input props that merge:
 1. Your component's props
 2. Mantine's `getInputProps(name)` result (value, onChange, error)
 3. Wrapped handlers that trigger server validation

--- a/packages/pulse-mantine/TUTORIAL.md
+++ b/packages/pulse-mantine/TUTORIAL.md
@@ -283,6 +283,7 @@ This is difference impacts how the form works in React:
 - Uncontrolled: the form values are not kept in React state and the inputs do not receive `value=...`. Blur and change events can still be handled for validation, but this avoids React rerenders and is generally much more performant.
 
 All the features described above should work for both controlled and uncontrolled forms, including client-server synchronization.
+Programmatic form actions update visible inputs in both modes.
 
 Dynamic forms will require a little special attention, as all your dynamic form items should have unique keys. Otherwise, you may see inputs getting mixed up when you add/remove/reorder form items.
 

--- a/packages/pulse-mantine/js/README.md
+++ b/packages/pulse-mantine/js/README.md
@@ -21,7 +21,7 @@ src/
 │
 └── form/                 # Form state management
     ├── form.tsx          # MantineFormProvider
-    ├── connect.tsx       # createConnectedField, useFieldProps
+    ├── connect.tsx       # createConnectedField, useField
     ├── context.tsx       # Form context
     ├── fields.tsx        # Field components
     └── validators.ts     # Client-side validators
@@ -74,7 +74,7 @@ Client-side date handling with dayjs integration for DatesProvider, DatePicker, 
 
 **Form**:
 - `createConnectedField(Component)` - wrap input for form binding
-- `useFieldProps(name)` - get field props from form context
+- `useField(props)` - get field props and key from form context
 
 **Notifications**:
 - `notifications` - notification API

--- a/packages/pulse-mantine/js/package.json
+++ b/packages/pulse-mantine/js/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pulse-mantine",
-	"version": "0.1.41",
+	"version": "0.1.42",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/erwinkn/pulse-ui",
@@ -33,6 +33,8 @@
 		"@types/node": "^24.6.0",
 		"@types/react": "^19.1.16",
 		"@types/react-dom": "^19.1.9",
+		"@testing-library/dom": "^10.4.1",
+		"@testing-library/react": "^16.3.0",
 		"esbuild": "^0.25.10",
 		"pulse-ui-client": "workspace:*",
 		"tsdown": "^0.15.7",

--- a/packages/pulse-mantine/js/src/form/connect.test.tsx
+++ b/packages/pulse-mantine/js/src/form/connect.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+import { useForm, type UseFormReturnType } from "@mantine/form";
+import { type ComponentPropsWithoutRef, type ComponentType } from "react";
+import { act, fireEvent, render } from "@testing-library/react";
+import { createConnectedField, useField } from "./connect";
+import { FormProvider } from "./context";
+
+type InputProps = ComponentPropsWithoutRef<"input">;
+
+function Input(props: InputProps) {
+	return <input {...props} />;
+}
+
+const ConnectedInput = createConnectedField(Input);
+
+function HookInput(props: InputProps) {
+	const { inputProps, key } = useField(props);
+	return <input key={key} {...inputProps} />;
+}
+
+function renderForm(
+	mode: "controlled" | "uncontrolled",
+	Field: ComponentType<InputProps> = ConnectedInput,
+) {
+	let form!: UseFormReturnType<{ page: string }>;
+
+	function Harness() {
+		form = useForm({ mode, initialValues: { page: "1" } });
+		return (
+			<FormProvider form={form} serverOnChange={() => {}} serverOnBlur={() => {}}>
+				<Field name="page" />
+			</FormProvider>
+		);
+	}
+
+	const view = render(<Harness />);
+
+	return {
+		form: () => form,
+		input: () => view.getByRole("textbox") as HTMLInputElement,
+		unmount: view.unmount,
+	};
+}
+
+describe("form field connections", () => {
+	it("remounts an uncontrolled input after a programmatic field update", () => {
+		const view = renderForm("uncontrolled");
+		const initialInput = view.input();
+		expect(initialInput.value).toBe("1");
+
+		fireEvent.change(initialInput, { target: { value: "typed" } });
+		expect(view.form().getValues().page).toBe("typed");
+		expect(view.input()).toBe(initialInput);
+
+		act(() => view.form().setFieldValue("page", "2"));
+		expect(view.input().value).toBe("2");
+		expect(view.input()).not.toBe(initialInput);
+
+		view.unmount();
+	});
+
+	it("does not remount a controlled input after a programmatic field update", () => {
+		const view = renderForm("controlled");
+		const initialInput = view.input();
+		expect(initialInput.value).toBe("1");
+
+		act(() => view.form().setFieldValue("page", "2"));
+		expect(view.input().value).toBe("2");
+		expect(view.input()).toBe(initialInput);
+
+		view.unmount();
+	});
+
+	it("returns the key separately for custom uncontrolled inputs", () => {
+		const view = renderForm("uncontrolled", HookInput);
+		const initialInput = view.input();
+
+		act(() => view.form().setFieldValue("page", "2"));
+		expect(view.input().value).toBe("2");
+		expect(view.input()).not.toBe(initialInput);
+
+		view.unmount();
+	});
+});

--- a/packages/pulse-mantine/js/src/form/connect.tsx
+++ b/packages/pulse-mantine/js/src/form/connect.tsx
@@ -23,10 +23,13 @@ function coerceControlledTextValue(props: Record<string, any>, enabled: boolean)
 
 type InputProps = Partial<GetInputPropsReturnType> & { name?: string };
 
-export function useFieldProps<P extends InputProps>(props: P, options?: ConnectedFieldOptions): P {
+export function useField<P extends InputProps>(
+	props: P,
+	options?: ConnectedFieldOptions,
+): { inputProps: P; key: string | undefined } {
 	const ctx = useFormContext();
 	if (!props.name || !ctx) {
-		return props;
+		return { inputProps: props, key: undefined };
 	}
 	const { form, serverOnChange, serverOnBlur } = ctx;
 	const mantineProps = form.getInputProps(props.name, {
@@ -44,7 +47,10 @@ export function useFieldProps<P extends InputProps>(props: P, options?: Connecte
 	};
 	coerceControlledTextValue(merged, !!options?.coerceEmptyString);
 
-	return { ...merged, onChange, onBlur } as P;
+	return {
+		inputProps: { ...merged, onChange, onBlur } as P,
+		key: form.key(name),
+	};
 }
 
 export function createConnectedField<P extends InputProps>(
@@ -52,8 +58,8 @@ export function createConnectedField<P extends InputProps>(
 	options?: ConnectedFieldOptions,
 ): FunctionComponent<P> {
 	const Connected = (props: P) => {
-		const fieldProps = useFieldProps(props, options);
-		return <Component {...fieldProps} />;
+		const { inputProps, key } = useField(props, options);
+		return <Component key={key} {...inputProps} />;
 	};
 
 	Connected.displayName = Component.displayName || Component.name || "Component";

--- a/packages/pulse-mantine/js/src/index.ts
+++ b/packages/pulse-mantine/js/src/index.ts
@@ -1,7 +1,7 @@
 export * from "./dates";
 export * from "./combobox";
 export * from "./dropzone";
-export { createConnectedField, useFieldProps } from "./form/connect";
+export { createConnectedField, useField } from "./form/connect";
 export * from "./form/context";
 export * from "./form/fields";
 export * from "./form/form";

--- a/packages/pulse-mantine/python/pyproject.toml
+++ b/packages/pulse-mantine/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pulse-mantine"
-version = "0.1.41"
+version = "0.1.42"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/skills/pulse-mantine/references/forms.md
+++ b/skills/pulse-mantine/references/forms.md
@@ -185,6 +185,8 @@ form.set_values({"email": "new@example.com", "name": "John"})
 form.set_field_value("email", "updated@example.com")
 ```
 
+Both methods update visible inputs in controlled and uncontrolled modes.
+
 ### List Operations (Dynamic Forms)
 ```python
 form.insert_list_item("members", {"name": ""})  # append
@@ -339,7 +341,7 @@ Create custom inputs that integrate with forms:
 
 ```tsx
 // In JS:
-import { createConnectedField, useFieldProps } from "pulse-mantine";
+import { createConnectedField, useField } from "pulse-mantine";
 
 // HOC approach:
 const ConnectedCustomInput = createConnectedField(CustomInput, {
@@ -349,10 +351,12 @@ const ConnectedCustomInput = createConnectedField(CustomInput, {
 
 // Hook approach:
 function MyInput(props) {
-    const fieldProps = useFieldProps(props, { debounceOnChange: true });
-    return <input {...fieldProps} />;
+    const { inputProps, key } = useField(props, { debounceOnChange: true });
+    return <input key={key} {...inputProps} />;
 }
 ```
+
+The returned `key` keeps custom uncontrolled inputs in sync after programmatic form actions. `createConnectedField` applies it automatically.
 
 Options:
 - `inputType`: "input" | "checkbox"

--- a/uv.lock
+++ b/uv.lock
@@ -1385,7 +1385,7 @@ requires-dist = [{ name = "pulse-framework", editable = "packages/pulse/python" 
 
 [[package]]
 name = "pulse-mantine"
-version = "0.1.41"
+version = "0.1.42"
 source = { editable = "packages/pulse-mantine/python" }
 dependencies = [
     { name = "pulse-framework" },


### PR DESCRIPTION
## Summary

- make uncontrolled MantineForm inputs reflect programmatic form updates
- replace `useFieldProps` with a structured `useField` API that returns `inputProps` and `key`
- add DOM regression coverage and update Pulse Mantine documentation/skills
- bump pulse-mantine from 0.1.41 to 0.1.42

## Root cause

Mantine increments `form.key(path)` after programmatic updates in uncontrolled mode so the input remounts with its new `defaultValue`. Pulse connected fields spread `getInputProps()` but did not apply that key, leaving the visible DOM value stale even though form state changed.

## Validation

- `make all`
- 1,938 Python tests passed
- 91 JavaScript tests passed
- browser check: an uncontrolled input changed from a typed `7` to the server-set value `2`
