### PR TITLE
Expand skills: latency guidance, QueryParam, form gotchas, Dropzone, AG Grid

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -8,6 +8,7 @@ AI coding assistant skills for Pulse development. These files help AI tools unde
 |-------|-------------|
 | [pulse](./pulse/SKILL.md) | Complete Pulse framework reference with reactive state, components, routing, queries, channels, and JS interop |
 | [pulse-mantine](./pulse-mantine/SKILL.md) | Mantine UI components for Pulse |
+| [pulse-ag-grid](./pulse-ag-grid/SKILL.md) | AG Grid data tables for Pulse via the `AgGridReact` wrapper — JSON-only props, reactive `rowData`/`columnDefs`, pagination, and theming |
 | [pulse-railway](./pulse-railway/SKILL.md) | Railway deployment utilities for Pulse apps, including `RailwayPlugin`, `RailwaySessionStore`, and `pulse-railway scaffold` / `ensure` / `deploy` / `redeploy` |
 | [pulse-aws](./pulse-aws/SKILL.md) | AWS ECS Fargate deployment utilities for Pulse apps |
 

--- a/skills/pulse-ag-grid/SKILL.md
+++ b/skills/pulse-ag-grid/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: pulse-ag-grid
+description: Python bindings for the AG Grid React data grid. Use when building data tables with pulse-ag-grid, passing rowData/columnDefs from server state, paginating large datasets, theming the grid, or debugging grids that render stale data or silently lack features.
+---
+
+# Pulse AG Grid
+
+Thin Python wrapper around [AG Grid](https://www.ag-grid.com/react-data-grid/). It exposes one component, `AgGridReact`, defined as an untyped `@ps.react_component` over `ps.Import("AgGridReact", "ag-grid-react")`. Every keyword argument passes straight through as a React prop on the grid. Only JSON-serializable props are supported, and it takes no children.
+
+## Quick Reference
+
+```python
+import pulse as ps
+from pulse_ag_grid import AgGridReact
+
+ps.div(style={"height": "400px"})[      # container needs explicit height
+    AgGridReact(
+        rowData=rows,                    # list of plain dicts
+        columnDefs=[{"field": "name"}],  # JSON-compatible values only
+        defaultColDef={"sortable": True, "filter": True},
+    )
+]
+```
+
+## Setup
+
+```bash
+uv add pulse-ag-grid
+```
+
+The package imports `ag-grid-react` without an npm version pin and registers no npm requirement with Pulse's dependency sync, so make sure `ag-grid-react` and `ag-grid-community` are installed in the app's web directory (e.g. `bun add ag-grid-react ag-grid-community`).
+
+AG Grid v33+ also requires one-time module registration on the JS side. A local side-effect import handles it:
+
+```python
+ps.Import("./ag_grid_setup.js", side_effect=True)
+```
+
+```js
+// ag_grid_setup.js
+import { ModuleRegistry, AllCommunityModule } from "ag-grid-community";
+ModuleRegistry.registerModules([AllCommunityModule]);
+```
+
+The grid needs a container with explicit height, or `domLayout="autoHeight"` to size to row count.
+
+## Core Limitation: JSON-Serializable Props Only
+
+The current implementation only supports JSON-compatible props:
+
+- row data must be plain dicts; column definitions must use JSON-compatible values
+- function props (`valueGetter`, `cellRenderer`, `valueFormatter` as functions) are not supported
+- custom cell components are not supported, and the component takes no children
+- per the package contract this covers event callbacks too (`onCellClicked`, `onSelectionChanged`, ...): the wrapper can render and configure the grid, but grid events cannot reach server state yet
+
+Function and component prop support is planned but not implemented. Workarounds, in order of preference:
+
+1. **Compute server-side.** Derive, format, and filter in Python before passing `rowData`: formatted strings, precomputed flags, joined display fields.
+2. **AG Grid expression strings.** Wherever AG Grid accepts a string expression instead of a function, it is just a string and passes through fine, e.g. `{"field": "total", "valueGetter": "data.price * data.qty"}` or `"cellClassRules": {"negative": "x < 0"}`.
+3. **Own wrapper with local JS.** For behavior that genuinely needs functions or components, write your own `@ps.react_component` around a local JS component that wraps `AgGridReact` and defines the functions on the JS side (see the pulse skill's JS interop reference).
+
+## Reactive Updates: Pass Data as Top-Level Props
+
+Wrapper props map one-to-one to AG Grid React props, and AG Grid React only reacts to changes in top-level props. Anything nested inside a `gridOptions` dict is read once at grid initialization and never re-read.
+
+```python
+# CORRECT: grid re-renders when state.rows changes
+AgGridReact(rowData=state.rows, columnDefs=state.columns)
+
+# WRONG: grid initializes with the first value and freezes there
+AgGridReact(gridOptions={"rowData": state.rows, "columnDefs": state.columns})
+```
+
+Symptom of getting this wrong: the grid renders once, then stays frozen on stale data while server state moves on. Forcing a remount by changing `key` is not a reliable fix; move the values to top-level props instead. Reserve `gridOptions` for truly static configuration, and prefer top-level props even then.
+
+## Pagination
+
+`pagination=True` only pages rows already sent to the client; it is presentation, not data loading. Fine for moderate row counts. For large tables, paginate server-side and pass only the current page:
+
+```python
+class GridState(ps.State):
+    page: int = 0
+    page_size: int = 100
+    rows: list[dict] = []
+
+    def load_page(self):
+        # SQL LIMIT/OFFSET (or equivalent) on the server
+        self.rows = fetch_rows(limit=self.page_size, offset=self.page * self.page_size)
+
+    def next_page(self):
+        self.page += 1
+        self.load_page()
+```
+
+Render your own pager controls next to the grid. AG Grid's infinite and server-side row models need a JS datasource callback (and the server-side row model is Enterprise-only), so this wrapper cannot use them.
+
+## Enterprise-Only Features
+
+`ag-grid-community` silently ignores Enterprise options instead of erroring. If a grid option does nothing, check its edition in the AG Grid docs first. Notable Enterprise-only features:
+
+- cell range selection and range clipboard copy/paste (drag-select a block of cells, copy, paste) — Community has no built-in clipboard/range support
+- row grouping, pivoting, aggregation
+- set filters (`agSetColumnFilter`), Excel export, master/detail, server-side row model
+
+The wrapper does not pin an AG Grid edition or version. Installing `ag-grid-enterprise`, registering its modules, and setting the license key are JS-side steps (use the same side-effect JS file as module registration).
+
+## Theming
+
+The wrapper imports no AG Grid CSS and configures no theme; what you need depends on the AG Grid version installed in the web app:
+
+- **v33+ (Theming API):** the bundled default (Quartz) theme applies with no CSS imports. Custom theme objects (`themeQuartz.withParams(...)`) are JS values the wrapper cannot pass; the only `theme` value expressible from Python is the string `"legacy"`.
+- **Legacy CSS themes** (v32 and earlier, or `theme="legacy"` on v33+): side-effect import the CSS from Python and put the theme class on the sized container:
+
+```python
+ps.Import("ag-grid-community/styles/ag-grid.css", side_effect=True)
+ps.Import("ag-grid-community/styles/ag-theme-quartz.css", side_effect=True)
+
+ps.div(className="ag-theme-quartz", style={"height": "400px"})[AgGridReact(...)]
+```
+
+With legacy themes, dark mode is a separate container class (`ag-theme-quartz-dark`), not a grid prop. If the app has a dark-mode toggle, switch the container's `className` from state; a grid whose headers stay light in dark mode usually has the wrong (or missing) theme class on the container.
+
+## Complete Example
+
+```python
+import pulse as ps
+from pulse_ag_grid import AgGridReact
+
+class EmployeesState(ps.State):
+    # e.g. loaded from a DataFrame: df.to_dict("records")
+    rows: list[dict] = [
+        {"id": 1, "name": "Alice Johnson", "department": "Engineering", "salary": 95000},
+        {"id": 2, "name": "Bob Smith", "department": "Marketing", "salary": 75000},
+        {"id": 3, "name": "Carol Williams", "department": "Engineering", "salary": 105000},
+    ]
+
+@ps.component
+def EmployeeTable():
+    with ps.init():
+        state = EmployeesState()
+
+    columns = [
+        {"field": "id", "headerName": "ID", "width": 80, "pinned": "left"},
+        {"field": "name", "headerName": "Name", "flex": 1},
+        {"field": "department", "headerName": "Department", "filter": True},
+        {"field": "salary", "headerName": "Salary", "type": "numericColumn"},
+    ]
+
+    return ps.div(style={"height": "400px", "width": "100%"})[
+        AgGridReact(
+            rowData=state.rows,          # top-level prop: updates propagate
+            columnDefs=columns,
+            defaultColDef={"sortable": True, "resizable": True},
+            rowSelection="single",
+            pagination=True,             # client-side paging of loaded rows
+            paginationPageSize=20,
+        )
+    ]
+
+app = ps.App([ps.Route("/", EmployeeTable)])
+```
+
+## Gotchas
+
+- **Invisible grid:** no explicit container height and no `domLayout="autoHeight"` renders a 0px-tall grid.
+- **Non-JSON values:** `NaN`, `datetime`, `Decimal`, and numpy scalars in row dicts do not serialize. With pandas, convert first (e.g. cast dates to strings, replace `NaN` with `None`) before `df.to_dict("records")`.
+- **Frozen grid:** reactive values buried in `gridOptions`; move them to top-level props.
+- **Feature does nothing:** it is probably Enterprise-only; Community ignores it silently.
+- **Grid errors on load with v33+:** community modules not registered; add the side-effect setup JS from Setup above.

--- a/skills/pulse-mantine/SKILL.md
+++ b/skills/pulse-mantine/SKILL.md
@@ -71,6 +71,17 @@ Recharts wrappers. See `references/charts.md`.
 LineChart(h=300, data=data, dataKey="date", series=[{"name": "value", "color": "blue"}])
 ```
 
+### Dropzone (`@mantine/dropzone`)
+Drag-and-drop file uploads. See `references/dropzone.md`.
+
+```python
+Dropzone(name="attachments", accept=PDF_MIME_TYPE, maxSize=5 * 1024**2)[
+    DropzoneIdle()[Text("Drop PDFs here")],
+]
+# Inside a MantineForm, files arrive as ps.UploadFile on submit.
+# onDrop/onReject callbacks receive metadata only, never file bytes.
+```
+
 ## Common Patterns
 
 **Wrap app with provider:**
@@ -110,11 +121,13 @@ notifications.show(title="Success", message="Done", color="green")
 **Dynamic form lists:**
 ```python
 form = MantineForm(
-    initialValues={"items": [{"name": ""}]},
+    initialValues={"items": [{"id": uuid.uuid4().hex, "name": ""}]},
     syncMode="change",  # enables form.values access
+    onSyncValues=on_sync,  # optional: called with values dict on every sync
 )
 # Use form.insert_list_item(), form.remove_list_item()
 # Access via form.values.get("items")
+# Use the per-item id as the row key (index keys go stale in uncontrolled mode)
 ```
 
 **Nested field paths:**
@@ -143,7 +156,8 @@ TextInput(name="members.0.pets.1.name")  # deeply nested
 
 For detailed API docs:
 - `references/core.md` - All core components by category
-- `references/forms.md` - MantineForm, validators, form actions
+- `references/forms.md` - MantineForm, validators, form actions, sync, file uploads
 - `references/dates.md` - Date/time picker components
 - `references/charts.md` - Chart components and data format
+- `references/dropzone.md` - Drag-and-drop file uploads
 - `references/notifications.md` - Notifications imperative API

--- a/skills/pulse-mantine/references/dropzone.md
+++ b/skills/pulse-mantine/references/dropzone.md
@@ -1,0 +1,83 @@
+# Dropzone
+
+`@mantine/dropzone` wrapper: drag-and-drop file uploads. Available since pulse-mantine 0.1.34.
+
+```python
+from pulse_mantine import (
+    Dropzone, DropzoneAccept, DropzoneReject, DropzoneIdle, DropzoneFullScreen,
+    MIME_TYPES, IMAGE_MIME_TYPE, PDF_MIME_TYPE,
+    MS_WORD_MIME_TYPE, MS_EXCEL_MIME_TYPE, MS_POWERPOINT_MIME_TYPE,
+)
+```
+
+The `@mantine/dropzone` npm package (`^8.0.0`) is registered automatically via `ps.require` when `pulse_mantine` is imported, and its stylesheet is auto-imported after `@mantine/core` styles — no manual setup.
+
+## Basic Usage
+
+```python
+Dropzone(
+    onDrop=handle_drop,
+    onReject=handle_reject,
+    accept=IMAGE_MIME_TYPE,
+    maxSize=5 * 1024**2,
+)[
+    Group(justify="center", gap="xl", mih=180, style={"pointerEvents": "none"})[
+        DropzoneAccept()[Text("Drop it")],
+        DropzoneReject()[Text("Not accepted")],
+        DropzoneIdle()[Text("Drag files here or click to select")],
+    ],
+]
+```
+
+`DropzoneAccept` / `DropzoneReject` / `DropzoneIdle` render their children only in the matching drag state.
+
+## Accepted Files
+
+```python
+accept=["image/png", "application/pdf"]        # list of mime types
+accept={"image/*": [".png", ".jpg", ".jpeg"]}  # mime type -> allowed extensions
+accept=IMAGE_MIME_TYPE                         # predefined groups (see imports above)
+accept=[MIME_TYPES["csv"], MIME_TYPES["xlsx"]] # by extension name
+```
+
+Limits: `maxFiles` (count), `maxSize` / `minSize` (bytes per file), `multiple=False` (single file). Behavior: `disabled`, `loading` (overlay), `activateOnClick` / `activateOnDrag` / `activateOnKeyboard`.
+
+## Callbacks
+
+- `onDrop(files)` — fires with the accepted files after a drop or file-picker selection.
+- `onReject(rejections)` — fires with rejected files; each rejection is `{"file": ..., "errors": [{"code": ..., "message": ...}]}`.
+- Also: `onDragEnter`, `onDragLeave`, `onDragOver`, `onFileDialogOpen`, `onFileDialogCancel`, `onError`.
+
+**The server never receives file contents through these callbacks.** Callback args cross the wire through the Pulse serializer, which only sends JSON-compatible data — a browser `File` arrives as a small metadata dict (its `path`/`relativePath`; `name`/`size`/`type` live on the `File` prototype and don't survive serialization). Use `onDrop`/`onReject` for UX (counts, error messages), not for reading files.
+
+## Receiving Files: Use a Form
+
+Give the Dropzone a `name=` and render it inside a `MantineForm`. Dropped files are written into form state and arrive as `ps.UploadFile` on submit:
+
+```python
+form = MantineForm(initialValues={"notes": "", "attachments": []})
+
+async def handle_submit(values):
+    for file in values["attachments"]:  # list[ps.UploadFile]
+        data = await file.read()
+
+return form.render(onSubmit=handle_submit)[
+    Textarea(name="notes"),
+    Dropzone(name="attachments", accept=PDF_MIME_TYPE)[
+        DropzoneIdle()[Text("Drop PDFs here")],
+    ],
+    Button("Upload", type="submit"),
+]
+```
+
+Each drop replaces the field value with the newly dropped files (it is a `set_field_value`, not an append). Files are stripped from value-sync payloads, so a synced form (`syncMode="change"`) is safe — `form.values` shows the field as `[]`; the files arrive only on submit. See File Uploads in `references/forms.md`.
+
+## Fullscreen Variant
+
+```python
+DropzoneFullScreen(active=True, accept=IMAGE_MIME_TYPE)[
+    Text("Drop files anywhere on the page"),
+]
+```
+
+`DropzoneFullScreen` is the plain Mantine component — it has no `name=` form integration, so use it for UX only; receive files through a regular `Dropzone(name=...)` in a form.

--- a/skills/pulse-mantine/references/forms.md
+++ b/skills/pulse-mantine/references/forms.md
@@ -44,6 +44,7 @@ MantineForm(
     touchTrigger="change",  # "change" | "focus"
     syncMode="none",  # "none" | "blur" | "change"
     debounceMs=300,  # debounce for text inputs
+    onSyncValues=handler,  # called with values dict on every sync (see Synced Values)
 )
 ```
 
@@ -59,6 +60,8 @@ form.render(
     Select(name="country"),
 ]
 ```
+
+All inputs with `name=` participate in form state, sync, and validation — including `Autocomplete` (connected since pulse-mantine 0.1.39).
 
 ## Validation
 
@@ -185,7 +188,7 @@ form.set_values({"email": "new@example.com", "name": "John"})
 form.set_field_value("email", "updated@example.com")
 ```
 
-Both methods update visible inputs in controlled and uncontrolled modes.
+Both methods update visible inputs in controlled and uncontrolled modes (see Server Write-Backs).
 
 ### List Operations (Dynamic Forms)
 ```python
@@ -224,13 +227,103 @@ Button(
 )
 ```
 
+## Server Write-Backs
+
+`form.set_values()` and `form.set_field_value()` update the visible inputs in both `mode="controlled"` and `mode="uncontrolled"`:
+
+- Controlled inputs update in place through React state.
+- Uncontrolled inputs remount: every `name=`-connected input is keyed with Mantine's `form.key(path)`, which changes after a programmatic update, so the input re-reads the new value on mount. Custom JS inputs get the same behavior via `useField` / `createConnectedField` (see JS Exports).
+
+**Before pulse-mantine 0.1.42**, uncontrolled inputs did NOT visually update from server `set_values` / `set_field_value` — form state changed but the DOM kept the old text. On older versions, use `mode="controlled"` for any form the server writes back to (or force a remount yourself with a fresh `key` on the input).
+
+### Dynamic list rows need identity keys (uncontrolled)
+
+`insert_list_item` / `remove_list_item` / `reorder_list_item` do not bump Mantine's input keys. In uncontrolled mode, index-based row keys (`key=f"item-{i}"`) leave stale text in the remaining inputs after a remove or reorder: React reuses the old row's DOM while form state has shifted. Store a stable id in each item and use it as the row key:
+
+```python
+import uuid
+
+def add_item():
+    form.insert_list_item("items", {"id": uuid.uuid4().hex, "name": ""})
+
+items = form.values.get("items") or []  # requires syncMode="change"/"blur"
+return form.render(onSubmit=handle)[
+    ps.For(
+        list(range(len(items))),
+        lambda i: Group(key=items[i]["id"])[
+            TextInput(name=f"items.{i}.name"),
+        ],
+    ),
+    Button("Add", onClick=add_item),
+]
+```
+
+With identity row keys, inputs remount with the right values after a shift because their field path (and therefore `form.key`) changes.
+
+### NumberInput and programmatic writes
+
+Mantine's `NumberInput` manages its displayed text internally; in practice a programmatic write that coincides with a remount (e.g. a paste-fill that also changes row keys) can fail to show up. When programmatic writes must land reliably, prefer `TextInput(name=..., inputMode="numeric")` and coerce to a number on the server.
+
+## Async Initial Values
+
+`initialValues` are captured when `MantineForm` is constructed, and the client form initializes once per mount. A form created with empty `initialValues` before async data arrives stays empty — recreating the Python instance alone (e.g. `ps.init(key=...)`) does not help, because the already-mounted client form keeps its values. Two robust patterns:
+
+```python
+# 1. Mount the form only once data is loaded (first mount sees real values)
+@ps.component
+def Page():
+    record = load_record()
+    if record is None:
+        return Loader()
+    return RecordForm(record)
+
+@ps.component
+def RecordForm(record: dict):
+    with ps.init():
+        form = MantineForm(initialValues=record)
+    ...
+
+# 2. Create the form empty, write values when data arrives
+#    (uncontrolled needs pulse-mantine >= 0.1.42 to show the update)
+form.set_values(record)
+```
+
+To swap `initialValues` wholesale, recreate the form with `ps.init(key=...)` AND pass the same key to `form.render(key=...)` so the client form remounts and re-initializes.
+
+## File Uploads
+
+`FileInput(name=...)` (or `Dropzone(name=...)`, see `references/dropzone.md`) inside a MantineForm submits files with the rest of the form. On submit, the handler receives them as `ps.UploadFile` at their field path:
+
+```python
+form = MantineForm(initialValues={"title": "", "attachment": None}, syncMode="change")
+
+async def handle_submit(values):
+    file: ps.UploadFile = values["attachment"]
+    data = await file.read()
+
+return form.render(onSubmit=handle_submit)[
+    TextInput(name="title"),
+    FileInput(name="attachment", label="Attachment"),
+    Button("Submit", type="submit"),
+]
+```
+
+- Files are stripped from value-sync payloads, so file fields don't break `syncMode="change"`/`"blur"`. `form.values` never contains files (a multi-file field syncs as `[]`); files arrive only on submit. Requires pulse-mantine >= 0.1.41 with pulse >= 0.1.99 — before that, file values in a synced form broke sync and submission.
+- Multi-file fields (`FileInput(multiple=True)`, Dropzone) submit as a list of `UploadFile`.
+- Validate with `AllowedFileTypes` / `MaxFileSize` (run client-side).
+
 ## Synced Values (Dynamic Forms)
 
 Access form values on server with `syncMode`:
 
 ```python
+import uuid
+
+def new_item():
+    return {"id": uuid.uuid4().hex, "name": ""}
+
 form = MantineForm(
-    initialValues={"items": [{"name": ""}]},
+    initialValues={"items": [new_item()]},
     syncMode="change",  # sync on every change
     debounceMs=300,
 )
@@ -239,7 +332,7 @@ form = MantineForm(
 items = form.values.get("items") or []
 
 def add_item():
-    form.insert_list_item("items", {"name": ""})
+    form.insert_list_item("items", new_item())
 
 def remove_item(i):
     form.remove_list_item("items", i)
@@ -247,7 +340,7 @@ def remove_item(i):
 return form.render(onSubmit=handle)[
     ps.For(
         list(range(len(items))),
-        lambda i: Group(key=f"item-{i}")[
+        lambda i: Group(key=items[i]["id"])[  # identity key, see Server Write-Backs
             TextInput(name=f"items.{i}.name"),
             Button("Remove", onClick=lambda: remove_item(i)),
         ],
@@ -255,6 +348,26 @@ return form.render(onSubmit=handle)[
     Button("Add Item", onClick=add_item),
 ]
 ```
+
+### Sync Transport
+
+Value sync travels over the Pulse WebSocket channel, not HTTP. A `POST /_pulse/forms/{render_id}/{form_id}` in the network tab is a native form submission (multipart/form-data) — a submit button, or Enter pressed in a text input, which submits the form by default HTML behavior. It is not the sync path and fires regardless of `syncMode`.
+
+### `onSyncValues` Callback
+
+```python
+def on_sync(values: dict):
+    print("synced:", values)
+
+form = MantineForm(
+    initialValues={"items": []},
+    syncMode="change",
+    debounceMs=300,
+    onSyncValues=on_sync,
+)
+```
+
+Called with the full values dict every time the client pushes a sync: after the (debounced) change or on blur per `syncMode`, and after server write-backs (`set_values`, `set_field_value`, list operations, `reset` — the client echoes the resulting values back). Fires after `form.values` has been updated, as a background task. Does nothing with `syncMode="none"`. File values are stripped (see File Uploads). Added in pulse-mantine 0.1.40.
 
 ## Field Name Paths
 

--- a/skills/pulse-railway/SKILL.md
+++ b/skills/pulse-railway/SKILL.md
@@ -73,6 +73,8 @@ Use `RailwaySessionStore()` when the app needs server-backed sessions that survi
 
 ## CLI Workflow
 
+Many repos run `pulse-railway ensure`/`deploy` from CI (e.g. GitHub Actions) rather than locally; check the repo's deployment instructions before running deploy commands manually.
+
 Use `RAILWAY_API_TOKEN` for local user/workspace tokens. Reserve `RAILWAY_TOKEN` for Railway project tokens, especially in CI. If neither is set, `pulse-railway` falls back to the local Railway CLI login session from `~/.railway/config*.json`. CLI login tokens are allowed for local API calls, but `scaffold` and `ensure` will not write them into the long-lived router or janitor services; set `RAILWAY_TOKEN` or `RAILWAY_API_TOKEN` when initializing or repairing runtime credentials.
 
 First-time setup:

--- a/skills/pulse/SKILL.md
+++ b/skills/pulse/SKILL.md
@@ -52,6 +52,7 @@ app = ps.App([ps.Route("/", App)])
 | Global state | `@ps.global_state` decorator | State |
 | Lists | `ps.For(items, lambda item, i: ...)` | Rendering |
 | Conditionals | `ps.If(cond, then=..., else_=...)` | Rendering |
+| URL query param state | `field: ps.QueryParam[T] = default` on State | Routing |
 | Session data | `ps.session()` | Runtime |
 | WebSocket ID | `ps.websocket_id()` | Runtime |
 | NPM packages | `ps.require("package")` | JS Interop |
@@ -300,6 +301,26 @@ async def handle_click():
 ps.button("Load", onClick=handle_click)
 ```
 
+#### ⚠️ Latency: server handlers vs. transpiled callbacks
+
+A handler bound to `ps.State` runs **on the server** — every invocation is a WebSocket round-trip. That is fine for deliberate, infrequent actions (button clicks, submitting a form, changing an explicit filter). It is **not** viable for callbacks that fire frequently or rapidly:
+
+- map pan/zoom (`moveend`), scroll, drag, pointer-move
+- per-keystroke handling (beyond what `ps.debounced` smooths)
+- anything driving an animation or a "feels-instant" UI response
+
+For those, do the work **client-side in transpiled code** (`@ps.javascript` / `@ps.javascript(jsx=True)`) or a hand-written react_component, and keep the server out of the hot path. Pass server data in as props; compute and apply the effect locally.
+
+```python
+# BAD — server round-trip on every map move; panning lags
+MapView(onBoundsChange=state.set_bounds)  # state.set_bounds filters a list server-side
+
+# GOOD — map filters the list in the browser; server never sees the move
+# (see references/js-interop.md → "Latency-sensitive interactions")
+```
+
+Rule of thumb: **if it fires faster than a human clicks, it belongs in transpiled JS.** See `references/js-interop.md` for the full pattern (incl. coordinating two client components via a `window` `CustomEvent`).
+
 ### Lists & Conditionals
 
 #### `ps.For` — Iterate with keys
@@ -373,7 +394,7 @@ ps.navigate("/path")                    # Programmatic, ignored if source route 
 ps.redirect("/login")                   # Server redirect (throws)
 ```
 
-See `references/routing.md` for layouts, nested routes, and path parameters.
+See `references/routing.md` for layouts, nested routes, path parameters, and `ps.QueryParam` (typed URL query-param state).
 
 ### Forms
 
@@ -631,7 +652,8 @@ def DataTable():
 7. **Use `ps.Link`** for internal navigation, not `ps.a`
 8. **Access route params** via `ps.route()["pathParams"]`
 9. **Clean up** in `on_dispose()` method or effect return
-10. **Run `make all`** before committing
+10. **Keep latency-sensitive callbacks off the server** — state handlers are WebSocket round-trips; rapid/frequent interactions (pan, scroll, drag, resize) belong in transpiled code (see Events → Latency)
+11. **Run `make all`** before committing
 
 ## Working with JavaScript
 

--- a/skills/pulse/references/errors.md
+++ b/skills/pulse/references/errors.md
@@ -365,6 +365,21 @@ Server errors sent to client include:
 - `phase` - "render", "callback", "effect", "navigate", "unmount"
 - `details` - Additional context (callback name, effect name, etc.)
 
+## Dev-Server Errors
+
+Errors seen while iterating with the dev server, usually stale client/server state rather than bugs in your code.
+
+**`[Pulse] Unknown registry key: <N>`** (browser console / error overlay)
+- The browser is running a stale client bundle: server code added/removed imports, transpiled functions, or components, so the registry keys the server references no longer match the loaded JS.
+- Fix: fully reload the tab. A normal refresh can still serve cached JS — close and reopen the tab if the error persists, and/or restart the dev server.
+
+**`rerender called before init for '<path>'`** (server log, `RuntimeError`)
+- A live WebSocket session hit a server worker that reloaded underneath it: the session tries to update a route mount that no longer exists in the fresh process.
+- Fix: hard refresh the page to establish a fresh session.
+
+**Queries stuck loading forever, no error**
+- If a query never resolves and never errors, suspect the WebSocket transport (proxy, load balancer, dropped connection) before the query code — a query whose fetch fails reports `is_error`; one whose messages never arrive just spins.
+
 ## Render Interrupts
 
 Special exceptions for flow control (not errors):

--- a/skills/pulse/references/js-interop.md
+++ b/skills/pulse/references/js-interop.md
@@ -25,11 +25,14 @@ def Button(
 # Named export
 ps.Import("Button", "@mantine/core")
 
-# Default export
-ps.Import("DatePicker", "react-datepicker", kind="default")
+# Default export — single argument (name == src ⇒ default import)
+ps.Import("react-datepicker")
 
-# Local file
-ps.Import("MyComponent", "~/components/my-component", kind="default")
+# Local file, named export
+ps.Import("MyComponent", "~/components/my-component")
+
+# Local file, default export
+ps.Import("~/components/my-component")
 ```
 
 ### Lazy Loading with `@ps.react_component`
@@ -78,7 +81,7 @@ def Dashboard():
 
 ```python
 @ps.react_component(
-    ps.Import("DatePicker", "react-datepicker", kind="default"),
+    ps.Import("react-datepicker"),  # default export
     lazy=True,
 )
 def DatePicker(
@@ -111,6 +114,34 @@ def DateForm():
         ),
         ps.p(f"Selected: {state.date}"),
     )
+```
+
+## Render Props: Callables Are Server Callbacks
+
+A Python callable passed as a prop (or child) is registered as a **server callback**: the client receives a stub function that serializes its arguments, sends them over the WebSocket, and returns nothing. This is exactly right for event handlers — and exactly wrong for render props:
+
+- The stub's return value is `undefined`; whatever your Python function returns is **never rendered**.
+- Arguments are serialized event payloads; the callable cannot receive live client-side objects (functions, class instances) that render-prop APIs pass.
+
+For render-prop APIs — components that call `children(args)` and render the result — pass a **transpiled** `@ps.javascript(jsx=True)` function instead. It runs fully client-side, receives the real render args, and its return value is rendered:
+
+```python
+@ps.react_component(ps.Import("CopyButton", "@mantine/core"))
+def CopyButton(*children: ps.Node, value: str) -> ps.Element: ...
+# Mantine calls children({copied, copy}) and renders the result
+
+# BAD — server callback: returns nothing to render, args aren't live client objects
+CopyButton(lambda state: ps.button("Copy", onClick=state["copy"]), value=text)
+
+# GOOD — transpiled render prop, runs entirely in the browser
+@ps.javascript(jsx=True)
+def CopyLabel(state):
+    return ps.button(
+        "Copied" if state.copied else "Copy",
+        onClick=state.copy,
+    )
+
+CopyButton(CopyLabel, value=text)
 ```
 
 ## `@ps.javascript` — Transpile Python to JS
@@ -250,6 +281,74 @@ def create_config():
         items=[1, 2, 3],
     )
 ```
+
+## Latency-sensitive interactions
+
+Handlers bound to `ps.State` execute **on the server**: each call is a WebSocket round-trip (event up, re-render diff back). Deliberate, infrequent actions absorb that latency fine. Rapid or frequent callbacks do not — routing them through the server makes the UI feel laggy.
+
+**Keep on the server (round-trip is fine):** button clicks, form submits, changing an explicit filter/toggle, navigation, opening a modal.
+
+**Keep client-side in transpiled code:** `moveend`/pan/zoom, scroll, drag, resize, pointer-move, animation frames, and per-keystroke work beyond what `ps.debounced` smooths. Rule of thumb: *if it fires faster than a human clicks, it belongs in transpiled JS.*
+
+The shape that works: the server renders the page and passes data down as props; a client component (`@ps.javascript(jsx=True)` or a hand-written react_component) owns the hot interaction and applies the effect locally, never touching the server.
+
+### Coordinating two client components without the server
+
+A server-rendered parent can't hand a shared mutable object to two sibling client components. Bridge them with a `window` `CustomEvent` — pure browser, no round-trip. One component dispatches; the other subscribes with `useEffect` + `addEventListener`.
+
+```python
+from pulse.js import window
+from pulse.js.react import useEffect, useState
+
+VIEWPORT_EVENT = "app:viewport"  # keep in sync with the dispatcher
+
+@ps.javascript(jsx=True)
+def GallerySection(*, photos: list[dict] | None = None, filterByMap: bool = True):
+    photos = photos or []
+    state = useState(None)          # visible IDs; None = "no viewport info yet"
+    visible_ids, set_visible_ids = state[0], state[1]
+
+    def subscribe():
+        def handle(event):
+            set_visible_ids(event.detail.itemIds)
+        window.addEventListener(VIEWPORT_EVENT, handle)
+        return lambda: window.removeEventListener(VIEWPORT_EVENT, handle)
+
+    useEffect(subscribe, [])
+
+    shown = (
+        [p for p in photos if p["item_id"] in visible_ids]
+        if filterByMap and visible_ids is not None
+        else photos
+    )
+    return Gallery(photos=shown)
+```
+
+The dispatcher side (here a hand-written react_component map) computes the payload from local state and broadcasts on the rapid event:
+
+```ts
+// The payload is a pure derivation of (viewport, points): string[] when points
+// are loaded, or null = "no answer yet" (the listener shows everything). Emit on
+// BOTH the rapid event AND whenever the data changes, so the listener updates the
+// moment points load instead of waiting for a move it can't predict.
+function emitViewport() {
+  const itemIds =
+    points.length === 0
+      ? null
+      : points.filter(p => bounds.contains([p.lng, p.lat])).map(p => p.itemId);
+  window.dispatchEvent(new CustomEvent("app:viewport", { detail: { itemIds } }));
+}
+map.on("moveend", emitViewport);
+// ...and call emitViewport() again right after the point data is (re)loaded.
+```
+
+A server-owned **toggle** (clicked rarely) can still gate the client behavior — pass it as a prop (`filterByMap` above); the one round-trip per click is acceptable.
+
+**Gotchas:**
+- Give the payload an explicit **"unknown" value** (`null`) distinct from **"known-empty"** (`[]`): `null` ⇒ listener shows everything; `[]` ⇒ genuinely nothing in view. Broadcasting `[]` before the data has loaded makes the listener flash empty.
+- Treat the broadcast as a **pure function of its inputs** and re-emit when *either* input changes (viewport **or** data) — not only on the rapid event. Pushing updates "at lifecycle moments" (a one-time `load`, the first `moveend`) races async data: a late data load leaves the listener stale until the next move.
+- A **virtualized** list (`@tanstack/react-virtual`) can't be filtered by hiding DOM nodes — only the rendered window exists. Filter the **data array** you feed the virtualizer.
+- Shareable URL state (query params) can also be synced client-side with `history.replaceState` inside the component — no navigation, no server hop. (Server-synced `ps.QueryParam` is for deliberate state changes, not per-frame viewport updates; see `routing.md`.)
 
 ## `ps.require()` — Declare npm Dependencies
 
@@ -556,6 +655,38 @@ def PersistentInput():
         onChange=lambda e: save(e.target.value),
     )
 ```
+
+### Reading Clipboard on Paste
+
+Serialized paste events include only `clipboardData` **metadata** (item kinds and MIME types) — never the pasted contents, so a server-side `onPaste` handler cannot read what was pasted. Read the clipboard client-side and forward the text to a Python callback prop:
+
+```python
+from pulse.js.react import useEffect, useRef
+
+@ps.javascript(jsx=True)
+def PasteCapture(*children, onPasteText):
+    ref = useRef(None)
+
+    def attach():
+        def handle(event):
+            text = event.clipboardData.getData("text/plain")
+            if "\t" in text or "\n" in text:  # multi-cell paste → handle in Python
+                event.preventDefault()
+                onPasteText(text)
+            # single values fall through to the browser default paste
+
+        node = ref.current
+        node.addEventListener("paste", handle, True)  # capture phase
+        return lambda: node.removeEventListener("paste", handle, True)
+
+    useEffect(attach, [])
+    return ps.div(ref=ref)[children]
+
+# Server side: onPasteText is a regular server callback receiving the text
+PasteCapture(grid_inputs, onPasteText=state.apply_pasted_rows)
+```
+
+The capture-phase listener sees the paste before any nested input consumes it; only multi-value pastes are intercepted, so typing and single-value pastes keep native behavior.
 
 ## Limitations
 

--- a/skills/pulse/references/queries.md
+++ b/skills/pulse/references/queries.md
@@ -149,6 +149,21 @@ def UserProfile():
     )
 ```
 
+### Loading UX
+
+- **Scope loading indicators to the region that is loading.** Returning a whole-page spinner on `is_loading` blanks unrelated, already-rendered UI; render the loading state only where the data goes.
+- **Prefer skeletons/placeholders with stable layout** over swapping the page for a spinner — the surrounding layout should not jump when data arrives.
+- **Use `keep_previous_data=True` for pagination/filter changes** so the previous page stays visible instead of flashing back to a loading state:
+
+```python
+@ps.query(keep_previous_data=True)
+async def page_data(self) -> list[dict]:
+    return await api.fetch_page(self.page)
+
+# In the component: render state.page_data.data as usual;
+# dim or badge with state.page_data.is_fetching while the next page loads.
+```
+
 ## `@ps.mutation`
 
 Non-cached operations (create, update, delete). No auto-caching.

--- a/skills/pulse/references/routing.md
+++ b/skills/pulse/references/routing.md
@@ -262,6 +262,48 @@ ps.Link("Page 2", to="/search?q=test&page=2")
 ps.Link("Dynamic", to=f"/dynamic/example?q1=x&q2=y")
 ```
 
+### `ps.QueryParam` — Typed Two-Way Query-Param State
+
+Bind a State field to a URL query parameter. The param name is the attribute name. At type-check time `ps.QueryParam[T]` is just `T`; at runtime the field becomes a synced property.
+
+```python
+class SearchState(ps.State):
+    q: ps.QueryParam[str] = ""
+    page: ps.QueryParam[int] = 1
+    tags: ps.QueryParam[list[str]] = []
+    since: ps.QueryParam[date | None] = None
+
+@ps.component
+def SearchPage():
+    with ps.init():
+        state = SearchState()  # must be created during a route render
+    return ps.div(f"q={state.q} page={state.page}")
+```
+
+**Sync behavior (two-way):**
+- On load / URL change (including back/forward), the param is parsed into the field; a missing param yields the default. Parse failures raise `ValueError` with the param name.
+- Assigning the field updates the URL via a `replace` navigation (no new history entry). Other query params in the URL are preserved.
+- A value equal to the default — or `None` — is **omitted** from the URL. (`None` round-trips only when the default is `None`; an empty param value parses as `None` for optional types.)
+
+**Supported types (codecs):**
+
+| Type | URL form |
+|------|----------|
+| `str` | as-is |
+| `int`, `float` | `str(value)` |
+| `bool` | `true`/`false` (parses `1`/`0` too) |
+| `date` | `YYYY-MM-DD` |
+| `datetime` | ISO 8601; naive values assumed UTC (with warning); UTC rendered with `Z` |
+| `T \| None` | empty value ⇒ `None`; `None` ⇒ param omitted |
+| `list[T]` | one param, comma-separated; `,` and `\` in items backslash-escaped; no nested lists |
+
+**Lists** are stored as reactive lists: in-place mutation (`state.tags.append(...)`) also syncs the URL. A non-default empty list serializes as an empty param value.
+
+**Constraints:**
+- Requires a route render context — creating the state outside a component render raises `RuntimeError`.
+- One binding per param name per route; a duplicate raises `ValueError`.
+- Server-synced by design: every change is a round-trip. For rapid URL updates (map viewport, scroll position), sync client-side with `history.replaceState` in transpiled code instead — see `js-interop.md` → "Latency-sensitive interactions".
+
 ## Path Parameters
 
 ### Defining Dynamic Segments

--- a/skills/pulse/references/state.md
+++ b/skills/pulse/references/state.md
@@ -34,6 +34,7 @@ class MyState(ps.State):
 - Public type-annotated attributes become reactive
 - Private attributes (underscore prefix) stay plain Python
 - Cannot add new public attributes after init (raises `AttributeError`)
+- Annotate a field as `ps.QueryParam[T]` to two-way sync it with a URL query parameter (see `routing.md`)
 
 ### Constructor Arguments
 

--- a/skills/pulse/references/transpiler.md
+++ b/skills/pulse/references/transpiler.md
@@ -49,9 +49,9 @@ Use `Import` for npm packages and local files.
 useState = ps.Import("useState", "react")
 useEffect = ps.Import("useEffect", "react")
 
-# Default export
+# Default export — single argument (name == src ⇒ default import)
 React = ps.Import("react")
-lodash = ps.Import("lodash", kind="default")
+lodash = ps.Import("lodash")
 
 # Namespace import (import * as X)
 utils = ps.Import("*", "lodash")


### PR DESCRIPTION
Upstreams battle-tested guidance from downstream consumer usage and fills documentation gaps found by auditing the skills against the current source. All API claims were verified against `packages/` source (file/line checks; the serializer question below was verified with a runtime round-trip).

## pulse
- **Latency: server handlers vs. transpiled callbacks** — Events callout + best-practice rule + full js-interop section (server/client split table, CustomEvent coordination between client components, gotchas).
- **Render props** — a Python callable prop becomes a registered *server callback* (`$cb` → `invokeCallback`, returns `undefined`); render-prop APIs need a transpiled `@ps.javascript(jsx=True)` function. With a `CopyButton` example.
- **Clipboard on paste** — event serialization sends `clipboardData` metadata only (`getData()` never called), so server `onPaste` can't read contents; documents the capture-phase transpiled listener pattern.
- **`ps.QueryParam`** — full reference (codecs, defaults/omission, list escaping, replace-navigation, error cases) written from `state/query_param.py` + tests; previously undocumented in skills.
- **Dev-server errors** — `[Pulse] Unknown registry key` (stale bundle) and `rerender called before init` (worker reload) triage, plus a WS-transport heuristic for queries stuck loading.
- **Loading UX** — scoped indicators, stable-layout skeletons, `keep_previous_data=True` for pagination.
- **Fix:** `ps.Import(..., kind="default")` documented a parameter that doesn't exist — a default import is single-arg `ps.Import("pkg")`.

## pulse-mantine
- **Server write-backs** — how `set_values`/`set_field_value` reach uncontrolled inputs since 0.1.42 (`form.key(path)` remounts), pre-0.1.42 behavior called out for consumers on older pins; uncontrolled dynamic lists need stable identity keys (Mantine list ops bump no keys).
- **Async initial values** — conditional mount / post-load `set_values` / dual-key remount patterns.
- **Sync transport** — sync rides the WebSocket channel; `POST /_pulse/forms/...` is native submit (Enter), not sync.
- **`onSyncValues`** — documented (semantics verified against `form.tsx` sendSync paths).
- **File uploads** — `FileInput` → `UploadFile` on submit; `stripFilesForSync` (0.1.41+) keeps files out of sync payloads.
- **Dropzone** — new reference written from source (previously documented nowhere): accept specs, status components, and the key gotcha that `onDrop` payloads carry metadata, not bytes.
- `NumberInput` programmatic-write caveat, Autocomplete form participation note.

## pulse-ag-grid (new skill)
JSON-props-only contract and workarounds (server-side compute, expression strings, own wrapper), reactive top-level props vs read-once `gridOptions`, client-side pagination limits, Enterprise features silently ignored by Community, v33+ module registration and theming, gotchas.

## pulse-railway
One-line note that many repos deploy from CI — check repo instructions before running deploy commands manually.

## Dropped after verification
The downstream "prop deduplication pitfall" (shared dict across props renders only once) was a real serializer bug fixed by ffd4ec9; verified fixed with a runtime round-trip of the exact scenario, so it was intentionally **not** ported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)