### PR TITLE
Connect Mantine list fields to forms

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -133,7 +133,7 @@
     },
     "packages/pulse-mantine/js": {
       "name": "pulse-mantine",
-      "version": "0.1.42",
+      "version": "0.1.43",
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.0",

--- a/docs/content/docs/packages/pulse-mantine/forms.mdx
+++ b/docs/content/docs/packages/pulse-mantine/forms.mdx
@@ -11,9 +11,25 @@ Building a form requires three things:
 
 1. A `MantineForm` instance (created inside `ps.init()`)
 2. Calling `form.render()` to set up the form element
-3. Giving a `name` prop to all inputs inside the form
+3. Giving a `name` prop to each form field inside the form
 
-The `name` defines the field's path in the form data structure. Inputs automatically detect they're inside a form and register themselves.
+The `name` defines the field's path in the form data structure. Supported form
+fields automatically detect they're inside a form and register themselves.
+
+This includes list-valued fields such as:
+
+- `MultiSelect`
+- `TagsInput`
+- `CheckboxGroup`
+
+Low-level composition primitives do not define a form-field contract. Examples:
+
+- `PillsInput` and `PillsInputField`
+- `ChipGroup`
+- `ComboboxSearch`
+
+Use a supported field component or connect a custom component with the
+JavaScript `useField`/`createConnectedField` APIs.
 
 ```python
 import pulse as ps

--- a/packages/pulse-mantine/js/package.json
+++ b/packages/pulse-mantine/js/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pulse-mantine",
-	"version": "0.1.42",
+	"version": "0.1.43",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/erwinkn/pulse-ui",

--- a/packages/pulse-mantine/js/src/form/connect.test.tsx
+++ b/packages/pulse-mantine/js/src/form/connect.test.tsx
@@ -1,9 +1,15 @@
 import { describe, expect, it } from "bun:test";
+import { MantineProvider } from "@mantine/core";
 import { useForm, type UseFormReturnType } from "@mantine/form";
-import { type ComponentPropsWithoutRef, type ComponentType } from "react";
+import {
+	type ComponentPropsWithoutRef,
+	type ComponentType,
+	type ReactNode,
+} from "react";
 import { act, fireEvent, render } from "@testing-library/react";
 import { createConnectedField, useField } from "./connect";
 import { FormProvider } from "./context";
+import { MultiSelect, TagsInput } from "./fields";
 
 type InputProps = ComponentPropsWithoutRef<"input">;
 
@@ -39,6 +45,56 @@ function renderForm(
 		form: () => form,
 		input: () => view.getByRole("textbox") as HTMLInputElement,
 		unmount: view.unmount,
+	};
+}
+
+type FormMode = "controlled" | "uncontrolled";
+type ListValues = { tags: string[] };
+
+function renderListField(
+	mode: FormMode,
+	field: (name: string) => ReactNode,
+	initialValues: ListValues,
+	pillSelector: string,
+) {
+	let form!: UseFormReturnType<ListValues>;
+	let submitted: ListValues | undefined;
+	let synced: ListValues | undefined;
+
+	function Harness() {
+		form = useForm({ mode, initialValues });
+		return (
+			<MantineProvider>
+				<FormProvider
+					form={form}
+					serverOnChange={() => {
+						synced = form.getValues();
+					}}
+					serverOnBlur={() => {}}
+				>
+					<form
+						onSubmit={form.onSubmit((values) => {
+							submitted = values;
+						})}
+					>
+						{field("tags")}
+						<button type="submit">Submit</button>
+					</form>
+				</FormProvider>
+			</MantineProvider>
+		);
+	}
+
+	const view = render(<Harness />);
+	return {
+		view,
+		form: () => form,
+		submitted: () => submitted,
+		synced: () => synced,
+		pills: () =>
+			Array.from(view.container.querySelectorAll(pillSelector)).map(
+				(pill) => pill.textContent,
+			),
 	};
 }
 
@@ -81,4 +137,79 @@ describe("form field connections", () => {
 
 		view.unmount();
 	});
+
+	it.each(["controlled", "uncontrolled"] as const)(
+		"round-trips MultiSelect values in %s mode",
+		(mode) => {
+			const listField = renderListField(
+				mode,
+				(name) => (
+					<MultiSelect
+						name={name}
+						data={[
+							{ value: "react", label: "React" },
+							{ value: "vue", label: "Vue" },
+						]}
+						searchable
+					/>
+				),
+				{ tags: ["react"] },
+				".mantine-MultiSelect-pill",
+			);
+			const input = listField.view.getByRole("textbox");
+			expect(listField.pills()).toContain("React");
+
+			fireEvent.click(input);
+			fireEvent.click(listField.view.getByRole("option", { name: "Vue" }));
+			expect(listField.form().getValues()).toEqual({ tags: ["react", "vue"] });
+			expect(listField.synced()).toEqual({ tags: ["react", "vue"] });
+
+			fireEvent.submit(listField.view.container.querySelector("form")!);
+			expect(listField.submitted()).toEqual({ tags: ["react", "vue"] });
+
+			act(() => listField.form().setValues({ tags: ["vue"] }));
+			expect(listField.pills()).toContain("Vue");
+			expect(listField.pills()).not.toContain("React");
+
+			act(() => listField.form().reset());
+			expect(listField.pills()).toContain("React");
+		},
+	);
+
+	it.each(["controlled", "uncontrolled"] as const)(
+		"round-trips TagsInput values in %s mode",
+		(mode) => {
+			const listField = renderListField(
+				mode,
+				(name) => <TagsInput name={name} data={["alpha", "beta", "gamma"]} />,
+				{ tags: ["alpha", "beta"] },
+				".mantine-TagsInput-pill",
+			);
+			const input = listField.view.getByRole("textbox");
+			expect(listField.pills()).toContain("alpha");
+			expect(listField.pills()).toContain("beta");
+
+			fireEvent.change(input, { target: { value: "gamma" } });
+			fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+			expect(listField.form().getValues()).toEqual({
+				tags: ["alpha", "beta", "gamma"],
+			});
+			expect(listField.synced()).toEqual({
+				tags: ["alpha", "beta", "gamma"],
+			});
+
+			fireEvent.submit(listField.view.container.querySelector("form")!);
+			expect(listField.submitted()).toEqual({
+				tags: ["alpha", "beta", "gamma"],
+			});
+
+			act(() => listField.form().setValues({ tags: ["gamma"] }));
+			expect(listField.pills()).toContain("gamma");
+			expect(listField.pills()).not.toContain("alpha");
+
+			act(() => listField.form().reset());
+			expect(listField.pills()).toContain("alpha");
+			expect(listField.pills()).toContain("beta");
+		},
+	);
 });

--- a/packages/pulse-mantine/js/src/form/connect.tsx
+++ b/packages/pulse-mantine/js/src/form/connect.tsx
@@ -56,8 +56,8 @@ export function useField<P extends InputProps>(
 export function createConnectedField<P extends InputProps>(
 	Component: ComponentType<P>,
 	options?: ConnectedFieldOptions,
-): FunctionComponent<P> {
-	const Connected = (props: P) => {
+) {
+	const Connected: FunctionComponent<P & { name?: string }> = (props) => {
 		const { inputProps, key } = useField(props, options);
 		return <Component key={key} {...inputProps} />;
 	};

--- a/packages/pulse-mantine/js/src/form/fields.tsx
+++ b/packages/pulse-mantine/js/src/form/fields.tsx
@@ -2,11 +2,13 @@ import {
 	AngleSlider as MantineAngleSlider,
 	Autocomplete as MantineAutocomplete,
 	Checkbox as MantineCheckbox,
+	CheckboxGroup as MantineCheckboxGroup,
 	Chip as MantineChip,
 	ColorInput as MantineColorInput,
 	ColorPicker as MantineColorPicker,
 	FileInput as MantineFileInput,
 	JsonInput as MantineJsonInput,
+	MultiSelect as MantineMultiSelect,
 	NativeSelect as MantineNativeSelect,
 	NumberInput as MantineNumberInput,
 	PasswordInput as MantinePasswordInput,
@@ -18,6 +20,7 @@ import {
 	Select as MantineSelect,
 	Slider as MantineSlider,
 	Switch as MantineSwitch,
+	TagsInput as MantineTagsInput,
 	Textarea as MantineTextarea,
 	TextInput as MantineTextInput,
 } from "@mantine/core";
@@ -32,6 +35,8 @@ export const Autocomplete = createConnectedField(MantineAutocomplete, {
 	debounceOnChange: true,
 	coerceEmptyString: true,
 });
+export const MultiSelect = createConnectedField(MantineMultiSelect);
+export const TagsInput = createConnectedField(MantineTagsInput);
 export const NumberInput = createConnectedField(MantineNumberInput, {
 	inputType: "input",
 	debounceOnChange: true,
@@ -40,6 +45,7 @@ export const NumberInput = createConnectedField(MantineNumberInput, {
 export const Checkbox = createConnectedField(MantineCheckbox, {
 	inputType: "checkbox",
 });
+export const CheckboxGroup = createConnectedField(MantineCheckboxGroup);
 export const SegmentedControl = createConnectedField(MantineSegmentedControl);
 export const Select = createConnectedField(MantineSelect);
 export const Textarea = createConnectedField(MantineTextarea, {

--- a/packages/pulse-mantine/js/src/form/integration.test.tsx
+++ b/packages/pulse-mantine/js/src/form/integration.test.tsx
@@ -1,0 +1,113 @@
+import { describe, expect, it, mock } from "bun:test";
+import { MantineProvider } from "@mantine/core";
+import { fireEvent, render } from "@testing-library/react";
+import { Checkbox, CheckboxGroup, MultiSelect, TagsInput } from "./fields";
+
+const channel = {
+	on: () => () => {},
+	emit: mock(),
+};
+const client = {
+	acquireChannel: () => channel,
+	releaseChannel: () => {},
+};
+const submitForm = mock((_options: { formData: FormData }) => {});
+
+mock.module("pulse-ui-client", () => ({
+	serialize: (value: unknown) => value,
+	submitForm,
+	usePulseClient: () => client,
+}));
+
+const { Form } = await import("./form");
+
+const listFields = [
+	["MultiSelect", MultiSelect],
+	["TagsInput", TagsInput],
+] as const;
+
+function submittedValues() {
+	const formData = submitForm.mock.calls.at(-1)?.[0]?.formData;
+	return JSON.parse(formData!.get("__data__") as string);
+}
+
+describe("MantineForm list-valued fields", () => {
+	it.each(listFields)("submits %s values as a list", (_label, Field) => {
+		submitForm.mockClear();
+		channel.emit.mockClear();
+		const view = render(
+			<MantineProvider>
+				<Form
+					channelId="form-list-fields"
+					initialValues={{ tags: ["react"] }}
+					initialErrors={{ tags: "At least one tag is required" }}
+					syncMode="change"
+				>
+					<Field
+						name="tags"
+						data={[
+							{ value: "react", label: "React" },
+							{ value: "vue", label: "Vue" },
+						]}
+						searchable={Field === MultiSelect ? true : undefined}
+					/>
+					<button type="submit">Submit</button>
+				</Form>
+			</MantineProvider>,
+		);
+
+		expect(view.getByText("At least one tag is required")).toBeTruthy();
+		const input = view.getByRole("textbox");
+		if (Field === MultiSelect) {
+			fireEvent.click(input);
+			fireEvent.click(view.getByRole("option", { name: "Vue" }));
+		} else {
+			fireEvent.change(input, { target: { value: "vue" } });
+			fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+		}
+
+		expect(channel.emit).toHaveBeenCalledWith("syncValues", {
+			reason: "change",
+			path: "tags",
+			values: { tags: ["react", "vue"] },
+		});
+		fireEvent.submit(view.container.querySelector("form")!);
+		expect(submittedValues()).toEqual({
+			tags: ["react", "vue"],
+		});
+	});
+
+	it("submits CheckboxGroup values as a list", () => {
+		submitForm.mockClear();
+		channel.emit.mockClear();
+		const view = render(
+			<MantineProvider>
+				<Form
+					channelId="form-checkbox-group"
+					initialValues={{ privileges: ["admin"] }}
+					syncMode="change"
+				>
+					<CheckboxGroup name="privileges" label="Privileges">
+						<Checkbox value="admin" label="Admin" />
+						<Checkbox value="editor" label="Editor" />
+					</CheckboxGroup>
+					<button type="submit">Submit</button>
+				</Form>
+			</MantineProvider>,
+		);
+
+		expect((view.getByRole("checkbox", { name: "Admin" }) as HTMLInputElement).checked).toBe(
+			true,
+		);
+		fireEvent.click(view.getByRole("checkbox", { name: "Editor" }));
+		expect(channel.emit).toHaveBeenCalledWith("syncValues", {
+			reason: "change",
+			path: "privileges",
+			values: { privileges: ["admin", "editor"] },
+		});
+		fireEvent.submit(view.container.querySelector("form")!);
+		expect(submittedValues()).toEqual({
+			privileges: ["admin", "editor"],
+		});
+	});
+});

--- a/packages/pulse-mantine/python/pyproject.toml
+++ b/packages/pulse-mantine/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pulse-mantine"
-version = "0.1.42"
+version = "0.1.43"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/packages/pulse-mantine/python/src/pulse_mantine/core/combobox/multi_select.py
+++ b/packages/pulse-mantine/python/src/pulse_mantine/core/combobox/multi_select.py
@@ -3,5 +3,5 @@ from typing import Any
 import pulse as ps
 
 
-@ps.react_component(ps.Import("MultiSelect", "@mantine/core"))
+@ps.react_component(ps.Import("MultiSelect", "pulse-mantine"))
 def MultiSelect(key: str | None = None, **props: Any): ...

--- a/packages/pulse-mantine/python/src/pulse_mantine/core/combobox/tags_input.py
+++ b/packages/pulse-mantine/python/src/pulse_mantine/core/combobox/tags_input.py
@@ -3,5 +3,5 @@ from typing import Any
 import pulse as ps
 
 
-@ps.react_component(ps.Import("TagsInput", "@mantine/core"))
+@ps.react_component(ps.Import("TagsInput", "pulse-mantine"))
 def TagsInput(key: str | None = None, **props: Any): ...

--- a/packages/pulse-mantine/python/src/pulse_mantine/core/inputs/checkbox.py
+++ b/packages/pulse-mantine/python/src/pulse_mantine/core/inputs/checkbox.py
@@ -9,7 +9,7 @@ _Checkbox = ps.Import("Checkbox", "@mantine/core")
 def Checkbox(key: str | None = None, **props: Any): ...
 
 
-@ps.react_component(_Checkbox.Group)
+@ps.react_component(ps.Import("CheckboxGroup", "pulse-mantine"))
 def CheckboxGroup(*children: ps.Node, key: str | None = None, **props: Any): ...
 
 

--- a/packages/pulse-mantine/python/tests/test_connected_fields.py
+++ b/packages/pulse-mantine/python/tests/test_connected_fields.py
@@ -1,0 +1,16 @@
+from pulse.transpiler.imports import Import
+from pulse.transpiler.nodes import Element
+from pulse_mantine import CheckboxGroup, MultiSelect, TagsInput
+
+
+def test_list_and_group_fields_use_pulse_mantine_wrappers():
+	for component, name in (
+		(MultiSelect, "MultiSelect"),
+		(TagsInput, "TagsInput"),
+		(CheckboxGroup, "CheckboxGroup"),
+	):
+		node = component(name="values")
+		assert isinstance(node, Element)
+		assert isinstance(node.tag, Import)
+		assert node.tag.name == name
+		assert node.tag.src == "pulse-mantine"

--- a/skills/pulse-mantine/references/forms.md
+++ b/skills/pulse-mantine/references/forms.md
@@ -61,7 +61,19 @@ form.render(
 ]
 ```
 
-All inputs with `name=` participate in form state, sync, and validation — including `Autocomplete` (connected since pulse-mantine 0.1.39).
+Supported form fields with `name=` participate in form state, sync, and validation. This includes:
+
+- List-valued `MultiSelect`, `TagsInput`, and `CheckboxGroup`
+- `Autocomplete` (connected since pulse-mantine 0.1.39)
+
+Low-level composition primitives are not form fields. Examples:
+
+- `PillsInput` and `PillsInputField`
+- `ChipGroup`
+- `ComboboxSearch`
+
+Connect a custom component explicitly with `useField`/`createConnectedField`
+when needed.
 
 ## Validation
 

--- a/uv.lock
+++ b/uv.lock
@@ -1385,7 +1385,7 @@ requires-dist = [{ name = "pulse-framework", editable = "packages/pulse/python" 
 
 [[package]]
 name = "pulse-mantine"
-version = "0.1.42"
+version = "0.1.43"
 source = { editable = "packages/pulse-mantine/python" }
 dependencies = [
     { name = "pulse-framework" },


### PR DESCRIPTION
## Summary

- Connect `MultiSelect`, `TagsInput`, and `CheckboxGroup` to Mantine form state.
- Preserve list values through initial values, sync, validation, programmatic updates, reset, and submit.
- Update Python bindings, docs, and add integration coverage.
- Bump `pulse-mantine` to `0.1.43`.

## Root cause

`MultiSelect` and `TagsInput` imported raw Mantine components instead of the form-connected `pulse-mantine` wrappers, so `name=` was silently ignored.

## Validation

- `make all`
- Pre-commit hooks passed