### PR TITLE
Fix named form property shadowing

### DIFF
--- a/docs/content/docs/reference/pulse-client/serialization.mdx
+++ b/docs/content/docs/reference/pulse-client/serialization.mdx
@@ -50,6 +50,7 @@ A tuple containing:
 | `Object` | Recursively processed |
 | Circular refs | Tracked and restored |
 | `function`, `symbol` | Coerced to null (e.g. a stray React element won't crash the payload) |
+| DOM nodes | Throws; extract the event or element data before serializing |
 | `bigint`, other | Throws a contextual error naming the type and path |
 
 ### Example
@@ -100,6 +101,10 @@ serialize({ onClick: () => {}, label: "Save" });
 // bigint (and any other genuinely unsupported type) throws a contextual error
 serialize({ amount: 10n });
 // Error: Cannot serialize value of type 'bigint' in 'amount'.
+
+// Raw DOM nodes throw instead of traversing browser or React internals
+serialize({ input: document.querySelector("input") });
+// Error: Cannot serialize a DOM node in 'input'. Extract DOM events/elements before serializing.
 ```
 
 ---

--- a/packages/pulse-mantine/js/src/form/integration.test.tsx
+++ b/packages/pulse-mantine/js/src/form/integration.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it, mock } from "bun:test";
 import { MantineProvider } from "@mantine/core";
 import { fireEvent, render } from "@testing-library/react";
 import { useField } from "./connect";
-import { Checkbox, CheckboxGroup, MultiSelect, TagsInput } from "./fields";
+import { Checkbox, CheckboxGroup, MultiSelect, TagsInput, TextInput } from "./fields";
 
 const channel = {
 	on: () => () => {},
@@ -195,6 +195,39 @@ describe("MantineForm list-valued fields", () => {
 		fireEvent.submit(view.container.querySelector("form")!);
 		expect(submittedValues()).toEqual({
 			privileges: ["admin", "editor"],
+		});
+	});
+});
+
+describe("MantineForm submit values", () => {
+	it("submits shadowable field names as values", () => {
+		submitForm.mockClear();
+		const view = render(
+			<MantineProvider>
+				<Form
+					channelId="form-name-field"
+					initialValues={{ name: "qgis", action: "save", method: "post", id: "record-1" }}
+					id="profile-form"
+					method="post"
+					target="_blank"
+					action="/submit"
+				>
+					<TextInput name="name" label="Name" />
+					<TextInput name="action" label="Action" />
+					<TextInput name="method" label="Method" />
+					<TextInput name="id" label="Record ID" />
+					<button type="submit">Submit</button>
+				</Form>
+			</MantineProvider>,
+		);
+
+		fireEvent.submit(view.container.querySelector("form")!);
+
+		expect(submittedValues()).toEqual({
+			name: "qgis",
+			action: "save",
+			method: "post",
+			id: "record-1",
 		});
 	});
 });

--- a/packages/pulse/js/src/serialize/elements.ts
+++ b/packages/pulse/js/src/serialize/elements.ts
@@ -195,7 +195,29 @@ const HTML_FORM_KEYS = [
 	"target",
 	"rel",
 ] as const satisfies readonly (keyof HTMLFormElement)[];
-const formExtractor = withBase<HTMLFormElement>(HTML_FORM_KEYS);
+const FORM_KEYS = [
+	...ELEMENT_KEYS,
+	...HTML_OR_SVG_KEYS,
+	...HTML_ELEMENT_BASE_KEYS,
+	...HTML_FORM_KEYS,
+] as const satisfies readonly (keyof HTMLFormElement)[];
+
+function formExtractor(form: HTMLFormElement): object {
+	const prototype = Object.getPrototypeOf(form);
+	const out: Record<string, unknown> = {};
+
+	// HTMLFormElement exposes controls as named properties, and those controls
+	// override even inherited IDL properties such as name, action, and tagName.
+	// Start every form read at the prototype to bypass named-property lookup.
+	for (const key of FORM_KEYS) {
+		const value = Reflect.get(prototype, key, form);
+		if (value !== undefined) {
+			out[key] = value;
+		}
+	}
+	out.tagName = String(out.tagName).toLowerCase();
+	return out;
+}
 
 const HTML_IFRAME_KEYS = [
 	"allow",
@@ -920,14 +942,37 @@ const elementExtractors: Record<string, (elt: any) => object> = {
 	MASK: maskExtractor,
 };
 
-export function extractHTMLElement(elt: HTMLElement): object {
+function extractHTMLElementByTagName(elt: HTMLElement): object {
 	const tagName = elt.tagName.toUpperCase();
-
 	const extractor = elementExtractors[tagName];
 	if (extractor) {
 		return extractor(elt);
 	}
-	throw new Error(`Unexpected HTML element tag: ${elt.tagName} (update .web/custom/serialize.ts)`);
+	throw new Error(`Unexpected HTML element tag: ${tagName} (update .web/custom/serialize.ts)`);
+}
+
+function isSameRealmHTMLFormElement(elt: Element): elt is HTMLFormElement {
+	// The constructor is absent when this browser-oriented module is imported
+	// during SSR, in a worker, or in a test process without a DOM implementation.
+	return typeof HTMLFormElement !== "undefined" && elt instanceof HTMLFormElement;
+}
+
+function isCrossRealmHTMLFormElement(elt: Element): elt is HTMLFormElement {
+	return Object.prototype.toString.call(elt) === "[object HTMLFormElement]";
+}
+
+export function extractHTMLElement(elt: HTMLElement): object {
+	if (isSameRealmHTMLFormElement(elt)) {
+		return formExtractor(elt);
+	}
+	// A form from an iframe fails this realm's instanceof checks.
+	if (
+		(typeof HTMLElement === "undefined" || !(elt instanceof HTMLElement)) &&
+		isCrossRealmHTMLFormElement(elt)
+	) {
+		return formExtractor(elt);
+	}
+	return extractHTMLElementByTagName(elt);
 }
 
 export function extractSVGElement(elt: SVGElement): object {
@@ -942,10 +987,16 @@ export function extractSVGElement(elt: SVGElement): object {
 }
 
 export function extractElement(elt: Element): object {
-	if (elt instanceof HTMLElement) {
-		return extractHTMLElement(elt);
+	if (typeof HTMLElement !== "undefined" && elt instanceof HTMLElement) {
+		if (isSameRealmHTMLFormElement(elt)) {
+			return formExtractor(elt);
+		}
+		return extractHTMLElementByTagName(elt);
 	}
-	if (elt instanceof SVGElement) {
+	if (isCrossRealmHTMLFormElement(elt)) {
+		return formExtractor(elt);
+	}
+	if (typeof SVGElement !== "undefined" && elt instanceof SVGElement) {
 		return extractSVGElement(elt);
 	}
 	// Fallback for other Element types - use base element extractor

--- a/packages/pulse/js/src/serialize/events.test.ts
+++ b/packages/pulse/js/src/serialize/events.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "bun:test";
+import { render } from "@testing-library/react";
+import React from "react";
+import { extractEvent } from "./events";
+import { serialize } from "./serializer";
+
+describe("form event extraction", () => {
+	it("does not let named controls shadow form properties", () => {
+		const form = document.createElement("form");
+		form.id = "profile-form";
+		form.name = "profile";
+		form.action = "/submit";
+		form.method = "post";
+		form.target = "_blank";
+
+		for (const property of [
+			"id",
+			"name",
+			"action",
+			"method",
+			"target",
+			"tagName",
+			"accessKeyLabel",
+		]) {
+			const control = document.createElement("input");
+			control.name = property;
+			Object.defineProperty(form, property, {
+				configurable: true,
+				value: control,
+			});
+			form.append(control);
+		}
+
+		const extracted = extractEvent({
+			type: "submit",
+			target: form,
+			nativeEvent: {},
+			isDefaultPrevented: () => false,
+		});
+
+		expect(extracted.target).toMatchObject({
+			id: "profile-form",
+			name: "profile",
+			method: "post",
+			target: "_blank",
+			tagName: "form",
+		});
+		expect(typeof extracted.target.action).toBe("string");
+		expect(extracted.target.id).not.toBe(controlFor(form, "id"));
+		expect(extracted.target.name).not.toBe(controlFor(form, "name"));
+		expect(extracted.target.action).not.toBe(controlFor(form, "action"));
+		expect(extracted.target.method).not.toBe(controlFor(form, "method"));
+		expect(extracted.target.target).not.toBe(controlFor(form, "target"));
+		expect(extracted.target.tagName).not.toBe(controlFor(form, "tagName"));
+		expect(extracted.target.accessKeyLabel).toBeUndefined();
+		expect(Object.hasOwn(extracted.target, "accessKeyLabel")).toBe(false);
+		expect(extracted.target.accessKeyLabel).not.toBe(controlFor(form, "accessKeyLabel"));
+
+		const [, payload] = serialize(extracted) as [[number[], number[], number[], number[]], any];
+		expect(payload.target).toMatchObject({
+			id: "profile-form",
+			name: "profile",
+			method: "post",
+			target: "_blank",
+			tagName: "form",
+		});
+		expect(typeof payload.target.action).toBe("string");
+	});
+
+	it("does not traverse React internals on a large form", () => {
+		const view = render(
+			React.createElement(
+				"form",
+				{ name: "profile" },
+				React.createElement("input", { name: "name", defaultValue: "qgis" }),
+				...Array.from({ length: 3000 }, (_, index) =>
+					React.createElement("span", { key: index }, index),
+				),
+			),
+		);
+		const form = view.container.querySelector("form")!;
+		const control = controlFor(form, "name");
+
+		// happy-dom gives IDL properties precedence over named controls, unlike browsers.
+		// Simulate the browser's named-property result on a real React-mounted DOM tree.
+		expect(Object.keys(control).some((key) => key.startsWith("__reactFiber$"))).toBe(true);
+		Object.defineProperty(form, "name", {
+			configurable: true,
+			value: control,
+		});
+
+		const extracted = extractEvent({
+			type: "submit",
+			target: form,
+			nativeEvent: {},
+			isDefaultPrevented: () => false,
+		});
+
+		expect(extracted.target.name).toBe("profile");
+		expect(() => serialize(extracted)).not.toThrow();
+	});
+});
+
+function controlFor(form: HTMLFormElement, name: string): HTMLInputElement {
+	return form.querySelector(`input[name="${name}"]`)!;
+}

--- a/packages/pulse/js/src/serialize/serializer.test.ts
+++ b/packages/pulse/js/src/serialize/serializer.test.ts
@@ -195,6 +195,133 @@ describe("v4 serialization", () => {
 		expect(fromSymbol).toEqual({ x: null, keep: 2 });
 	});
 
+	it("rejects DOM nodes before traversing their React internals", () => {
+		const input = document.createElement("input");
+		Object.defineProperty(input, "__reactFiber$test", {
+			enumerable: true,
+			get: () => {
+				throw new Error("React internals were traversed");
+			},
+		});
+
+		expect(() => serialize({ input } as any)).toThrow(
+			"Cannot serialize a DOM node in 'input'. Extract DOM events/elements before serializing.",
+		);
+	});
+
+	it("rejects cross-realm-like DOM nodes without invoking IDL getters", () => {
+		const nodePrototype = Object.create(Object.prototype);
+		Object.defineProperties(nodePrototype, {
+			[Symbol.toStringTag]: { value: "Node" },
+			nodeType: {
+				get() {
+					throw new Error("IDL getter was invoked");
+				},
+			},
+			nodeName: {
+				get() {
+					throw new Error("IDL getter was invoked");
+				},
+			},
+			ownerDocument: {
+				get() {
+					throw new Error("IDL getter was invoked");
+				},
+			},
+			cloneNode: { value() {} },
+		});
+		const form = Object.create(Object.create(nodePrototype));
+		Object.defineProperty(form, "ownerDocument", { value: {} });
+		Object.defineProperty(form, "__reactFiber$test", {
+			enumerable: true,
+			get: () => {
+				throw new Error("React internals were traversed");
+			},
+		});
+
+		expect(() => serialize({ form } as any)).toThrow(
+			"Cannot serialize a DOM node in 'form'. Extract DOM events/elements before serializing.",
+		);
+	});
+
+	it("does not mistake an inherited DOM-shaped application model for a Node", () => {
+		class DomShapedRecord {
+			payload = "keep";
+
+			get ownerDocument(): never {
+				throw new Error("application getter was invoked");
+			}
+		}
+		Object.assign(DomShapedRecord.prototype, {
+			nodeType: 1,
+			nodeName: "record",
+			addEventListener() {},
+		});
+
+		const parsed: any = deserialize(serialize({ record: new DomShapedRecord() }));
+		expect(parsed).toEqual({ record: { payload: "keep" } });
+	});
+
+	it("rejects React fiber objects before recursively walking them", () => {
+		const fiber = {
+			tag: 0,
+			key: null,
+			elementType: null,
+			type: null,
+			stateNode: null,
+			return: null,
+			child: null,
+			sibling: null,
+			index: 0,
+			ref: null,
+			pendingProps: null,
+			memoizedProps: null,
+			updateQueue: null,
+			memoizedState: null,
+			dependencies: null,
+			mode: 0,
+			flags: 0,
+			subtreeFlags: 0,
+			deletions: null,
+			lanes: 0,
+			childLanes: 0,
+			alternate: null,
+		};
+
+		expect(() => serialize({ fiber } as any)).toThrow(
+			"Cannot serialize a React Fiber in 'fiber'. Extract DOM events/elements before serializing.",
+		);
+	});
+
+	it("does not mistake Fiber-like application records for React internals", () => {
+		class ApplicationModel {
+			payload = "keep";
+
+			get tag(): never {
+				throw new Error("inherited tag getter was invoked");
+			}
+		}
+		const data = {
+			shape: {
+				tag: 0,
+				return: null,
+				child: null,
+				sibling: null,
+				stateNode: null,
+				memoizedProps: null,
+			},
+			expandoNamedData: { "__reactFiber$business": "keep" },
+			model: new ApplicationModel(),
+		};
+
+		const parsed: any = deserialize(serialize(data));
+		expect(parsed).toEqual({
+			shape: data.shape,
+			expandoNamedData: data.expandoNamedData,
+			model: { payload: "keep" },
+		});
+	});
+
 	it("keeps indices aligned when a dropped leaf sits among shared refs and Dates", () => {
 		// The serializer tracks refs/dates by positional node index, so a coerced leaf
 		// must consume an index just like the primitive it becomes. This interleaves a

--- a/packages/pulse/js/src/serialize/serializer.ts
+++ b/packages/pulse/js/src/serialize/serializer.ts
@@ -5,6 +5,77 @@ export type Serializable = any;
 
 export type Serialized = [[number[], number[], number[], number[]], PlainJSON];
 
+function isDomNode(value: object): boolean {
+	if (typeof Node !== "undefined" && value instanceof Node) {
+		return true;
+	}
+	for (
+		let prototype = Object.getPrototypeOf(value);
+		prototype !== null && prototype !== Object.prototype;
+		prototype = Object.getPrototypeOf(prototype)
+	) {
+		const tag = Object.getOwnPropertyDescriptor(prototype, Symbol.toStringTag);
+		if (
+			tag?.value === "Node" &&
+			typeof Object.getOwnPropertyDescriptor(prototype, "nodeType")?.get === "function" &&
+			typeof Object.getOwnPropertyDescriptor(prototype, "nodeName")?.get === "function" &&
+			typeof Object.getOwnPropertyDescriptor(prototype, "ownerDocument")?.get === "function" &&
+			typeof Object.getOwnPropertyDescriptor(prototype, "cloneNode")?.value === "function"
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
+const REACT_FIBER_KEYS = [
+	"tag",
+	"key",
+	"elementType",
+	"type",
+	"stateNode",
+	"return",
+	"child",
+	"sibling",
+	"index",
+	"ref",
+	"pendingProps",
+	"memoizedProps",
+	"updateQueue",
+	"memoizedState",
+	"dependencies",
+	"mode",
+	"flags",
+	"subtreeFlags",
+	"deletions",
+	"lanes",
+	"childLanes",
+	"alternate",
+] as const;
+
+const CHECK_REACT_FIBER =
+	import.meta.env?.DEV ??
+	(typeof process !== "undefined" && process.env.NODE_ENV !== "production");
+
+function isReactFiber(value: object): boolean {
+	const candidate = value as Record<string, unknown>;
+	if (!REACT_FIBER_KEYS.every((key) => Object.hasOwn(candidate, key))) {
+		return false;
+	}
+	if (
+		typeof candidate.tag !== "number" ||
+		typeof candidate.index !== "number" ||
+		typeof candidate.mode !== "number" ||
+		typeof candidate.flags !== "number" ||
+		typeof candidate.subtreeFlags !== "number" ||
+		typeof candidate.lanes !== "number" ||
+		typeof candidate.childLanes !== "number"
+	) {
+		return false;
+	}
+	return true;
+}
+
 export function serialize(data: Serializable): Serialized {
 	const seen = new Map<any, number>();
 	const refs: number[] = [];
@@ -44,6 +115,23 @@ export function serialize(data: Serializable): Serialized {
 		// primitive and the ref/date/set/map indices stay aligned with `deserialize`.
 		if (typeof value === "function" || typeof value === "symbol") {
 			return null;
+		}
+
+		if (typeof value === "object") {
+			const ctx = context ? ` in '${context}'` : "";
+			if (isDomNode(value)) {
+				throw new Error(
+					`Cannot serialize a DOM node${ctx}. Extract DOM events/elements before serializing.`,
+				);
+			}
+			// A raw DOM node is always invalid serializer input, including in production.
+			// Fiber has no public brand, so keep its heuristic diagnostic out of the hot
+			// production path; DOM nodes are rejected before their expandos are traversed.
+			if (CHECK_REACT_FIBER && isReactFiber(value)) {
+				throw new Error(
+					`Cannot serialize a React Fiber${ctx}. Extract DOM events/elements before serializing.`,
+				);
+			}
 		}
 
 		const prevRef = seen.get(value);

--- a/skills/pulse/references/js-interop.md
+++ b/skills/pulse/references/js-interop.md
@@ -122,6 +122,7 @@ A Python callable passed as a prop (or child) is registered as a **server callba
 
 - The stub's return value is `undefined`; whatever your Python function returns is **never rendered**.
 - Arguments are serialized event payloads; the callable cannot receive live client-side objects (functions, class instances) that render-prop APIs pass.
+- Raw DOM nodes are rejected. React event arguments are extracted into serializable dictionaries before they cross the wire.
 
 For render-prop APIs — components that call `children(args)` and render the result — pass a **transpiled** `@ps.javascript(jsx=True)` function instead. It runs fully client-side, receives the real render args, and its return value is rendered:
 


### PR DESCRIPTION
## Summary

- read `HTMLFormElement` properties through the prototype so named controls cannot shadow form metadata
- reject raw DOM nodes and React Fiber objects before the serializer traverses browser internals
- cover same-realm, cross-realm, large React form, and Mantine form submission cases
- document DOM-node serialization errors in the client reference and JavaScript interop skill

## Why

Browsers expose named form controls as properties on the form. Inputs named `name`, `action`, `method`, or similar can therefore replace the corresponding form property during event extraction. If a shadowing control carries React internals, serialization may recursively traverse a large Fiber graph instead of sending the form metadata.

## Impact

Form callbacks now receive the actual form metadata even when controls use shadowable names. Raw DOM nodes fail early with a clear serialization error instead of traversing browser or React internals.

## Validation

- `make test`: 1,956 Python tests passed; 111 JavaScript tests passed
- 40 focused serializer, event, and Mantine integration tests passed
- affected TypeScript packages typechecked
- full JavaScript package build passed
- docs generation, MDX compilation, and TypeScript checking passed
- real headless Chrome verified named-property bypass and cross-realm handling