### PR TITLE
Detach Railway source uploads

### DIFF
--- a/packages/pulse-railway/README.md
+++ b/packages/pulse-railway/README.md
@@ -27,7 +27,7 @@ Use the commands like this:
 - `pulse-railway scaffold` bootstraps the stable router, env, Redis, and janitor stack into an empty Railway project.
 - `pulse-railway ensure` creates the baseline on an empty project or reconciles mutable runtime and canvas config on a complete baseline.
 - `pulse-railway deploy` builds and rolls out a new backend service on top of an already-initialized stack.
-  By default it uploads source and uses `railway up` to build on Railway. Passing an image repository switches deploy to the local `docker buildx build --push` path.
+  By default it uploads source with detached `railway up` and polls the Railway API for the build result. Passing an image repository switches deploy to the local `docker buildx build --push` path.
 - `pulse-railway redeploy` redeploys the active backend service. Pass `--deployment-id <id>` to redeploy a specific Pulse deployment.
 
 `scaffold <app-file>` bootstraps the baseline from `RailwayPlugin` config and defaults. Stable router, Redis, janitor, and backend service names come from the app plugin. The baseline also includes a stable env service that acts as the canonical source for user-managed deployment variables.

--- a/packages/pulse-railway/pyproject.toml
+++ b/packages/pulse-railway/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pulse-railway"
-version = "0.3.11"
+version = "0.3.12"
 description = "Railway deployment utilities for Pulse applications"
 readme = "README.md"
 authors = [{ name = "Erwin Kuhn", email = "erwin.kuhn@protonmail.com" }]

--- a/packages/pulse-railway/src/pulse_railway/deployment.py
+++ b/packages/pulse-railway/src/pulse_railway/deployment.py
@@ -490,6 +490,7 @@ def railway_up_command(
 		"--service",
 		service_name,
 		"--ci",
+		"--detach",
 	]
 	command.append("--path-as-root")
 	if no_gitignore:

--- a/packages/pulse-railway/tests/test_railway_deployment.py
+++ b/packages/pulse-railway/tests/test_railway_deployment.py
@@ -155,6 +155,7 @@ def test_railway_up_command_targets_service_context() -> None:
 		"--service",
 		"backend",
 		"--ci",
+		"--detach",
 		"--path-as-root",
 	]
 
@@ -1361,6 +1362,7 @@ async def test_deploy_source_happy_path_on_ready_stack(
 				"--service",
 				"prod-260402-120000",
 				"--ci",
+				"--detach",
 				"--path-as-root",
 			),
 			str(tmp_path),

--- a/skills/pulse-railway/SKILL.md
+++ b/skills/pulse-railway/SKILL.md
@@ -144,7 +144,7 @@ Use either the name or ID form for each target, not both.
 - deploy app file is positional: `pulse-railway deploy path/to/app.py`
 - `--context` resolves from the shell invocation directory
 - `--web-root` for deploy overrides must be relative to the deploy context
-- source deploys use `railway up`, so the Railway CLI must be available
+- source deploys use detached `railway up` and poll the Railway API for completion, so the Railway CLI must be available
 - image deploys use `docker buildx build --push`
 
 ## Railway Model

--- a/uv.lock
+++ b/uv.lock
@@ -1418,7 +1418,7 @@ dev = [{ name = "redis", specifier = ">=6.4.0" }]
 
 [[package]]
 name = "pulse-railway"
-version = "0.3.11"
+version = "0.3.12"
 source = { editable = "packages/pulse-railway" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- run `railway up` in detached mode
- let pulse-railway polling determine the actual build result
- release pulse-railway 0.3.12

This prevents a transient Railway build-log subscription failure from failing an otherwise accepted source upload. Registration and promotion still happen only after the Railway deployment reports success and passes router health checks.

## Verification
- `make all`
- 1,975 Python tests passed, 1 skipped
- 120 JavaScript tests passed