### PR TITLE
Release Pulse 0.1.111

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -163,7 +163,7 @@
     },
     "packages/pulse/js": {
       "name": "pulse-ui-client",
-      "version": "0.1.110",
+      "version": "0.1.111",
       "dependencies": {
         "socket.io-client": "^4.8.1",
         "ws": "^8.18.3",

--- a/packages/pulse/js/package.json
+++ b/packages/pulse/js/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pulse-ui-client",
-	"version": "0.1.110",
+	"version": "0.1.111",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/erwinkn/pulse-ui",

--- a/packages/pulse/python/pyproject.toml
+++ b/packages/pulse/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pulse-framework"
-version = "0.1.110"
+version = "0.1.111"
 description = "Pulse - Full-stack framework for building real-time React applications in Python"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1323,7 +1323,7 @@ requires-dist = [
 
 [[package]]
 name = "pulse-framework"
-version = "0.1.110"
+version = "0.1.111"
 source = { editable = "packages/pulse/python" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
0.1.110 was claimed by #119 before #120 merged, so the publish job skipped the session-scoped `global_state` / session-owned `QueryParamSync` changes. This ships them as 0.1.111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)