### PR TITLE
Split RouteInfo at the session boundary

### DIFF
--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -129,7 +129,7 @@ class RouteMount:
 	) -> None:
 		self.render = render
 		self.path = ensure_absolute_path(path)
-		self.route = RouteContext(route_info, route, render, self.path)
+		self.route = RouteContext(route_info, route, self.path)
 		self.effect = None
 		self._pulse_ctx = None
 		self.tree = RenderTree(route.render())
@@ -499,6 +499,9 @@ class RenderSession:
 		for path in normalized:
 			route = self.routes.find(path)
 			info = route_info or route.default_route_info()
+			# Session-scoped URL data is split off at the message boundary;
+			# mounts only ever receive it, never report it back up.
+			self.set_url(info)
 			mount = self.route_mounts.get(path)
 
 			if mount is None:
@@ -545,6 +548,7 @@ class RenderSession:
 			self.send({"type": "reload"})
 			return False
 
+		self.set_url(route_info)
 		mount.update_route(route_info)
 		if mount.state == "suspended":
 			return self._resume_mount(mount, path)
@@ -580,6 +584,7 @@ class RenderSession:
 			# the authoritative RouteInfo, so replaying/stashing is unnecessary.
 			return
 		try:
+			self.set_url(route_info)
 			mount.update_route(route_info)
 			if mount.state == "pending" and self._send_message:
 				mount.activate(self._send_message)
@@ -745,8 +750,10 @@ class RenderSession:
 	def set_url(self, info: RouteInfo) -> None:
 		"""Record the URL the client is currently displaying.
 
-		Called by every `RouteContext` on creation and on route updates. All
-		mounts report the same URL, so this is last-writer-wins by design.
+		Called at the session's message boundaries (prerender/attach/
+		update_route) before the info is handed to a mount. Every client
+		message reports the same URL for the same navigation, so this is
+		last-writer-wins by design.
 		"""
 		self.url.update(
 			{

--- a/packages/pulse/python/src/pulse/routing.py
+++ b/packages/pulse/python/src/pulse/routing.py
@@ -1,14 +1,11 @@
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, TypedDict, cast, override
+from typing import TypedDict, cast, override
 
 from pulse.component import Component
 from pulse.env import env
 from pulse.reactive_extensions import ReactiveDict
-
-if TYPE_CHECKING:
-	from pulse.render_session import RenderSession
 
 # angle brackets cannot appear in a regular URL path, this ensures no name conflicts
 LAYOUT_INDICATOR = "<layout>"
@@ -548,22 +545,16 @@ class RouteContext:
 	info: RouteInfo
 	pulse_route: Route | Layout
 	route_path: str
-	render: "RenderSession"
 
 	def __init__(
 		self,
 		info: RouteInfo,
 		pulse_route: Route | Layout,
-		render: "RenderSession",
 		route_path: str | None = None,
 	):
 		self.info = cast(RouteInfo, cast(object, ReactiveDict(info)))
 		self.pulse_route = pulse_route
 		self.route_path = ensure_absolute_path(route_path or pulse_route.unique_path())
-		self.render = render
-		# The session, not the mount, owns URL-derived state (query param
-		# bindings outlive any single mount).
-		render.set_url(info)
 
 	def update(self, info: RouteInfo) -> None:
 		"""Update the route info with new values.
@@ -572,7 +563,6 @@ class RouteContext:
 			info: New route info to apply.
 		"""
 		self.info.update(info)
-		self.render.set_url(info)
 
 	@property
 	def pathname(self) -> str:

--- a/packages/pulse/python/tests/test_hooks.py
+++ b/packages/pulse/python/tests/test_hooks.py
@@ -48,7 +48,8 @@ def make_route_context(route_info: RouteInfo):
 	route = Route("/", ps.component(render))
 	routes = RouteTree([route])
 	session = RenderSession("test", routes)
-	route_ctx = RouteContext(route_info, route, session)
+	session.set_url(route_info)
+	route_ctx = RouteContext(route_info, route)
 	app = ps.App(routes=[route])
 	return app, session, route_ctx, route
 

--- a/packages/pulse/python/tests/test_query_param.py
+++ b/packages/pulse/python/tests/test_query_param.py
@@ -139,7 +139,7 @@ class TestQueryParam:
 			state = QState()
 			assert state.q == "hello"
 			messages.clear()
-			route_ctx.update(make_route_info("/", query_params={"q": "world"}))
+			session.update_route("/", make_route_info("/", query_params={"q": "world"}))
 			flush_effects()
 			assert state.q == "world"
 		assert messages == []


### PR DESCRIPTION
## Overview

[PR #122](https://github.com/erwinkn/pulse-ui/pull/122) is the first pull request in a two-part stack that makes the session URL the single owner of route state. It moves the `set_url` calls from `RouteContext` to the `RenderSession` message boundaries.

> [!IMPORTANT]
> Review [PR #122](https://github.com/erwinkn/pulse-ui/pull/122) first. Then, review [PR #123](https://github.com/erwinkn/pulse-ui/pull/123).

After this pull request, URL data flows only down the ownership tree: `RenderSession` → `RouteContext`.

### Decision map

| # | Decision | Result |
|---:|---|---|
| 1 | Record the URL at the message boundary | `RenderSession.prerender`, `RenderSession.attach`, and `RenderSession.update_route` call `RenderSession.set_url` before they touch a mount. |
| 2 | Remove the upward pointer | `RouteContext` loses its `render` attribute and no longer calls `set_url`. |
| 3 | Tests drive URL changes through the boundary | `test_url_to_state_updates` calls `session.update_route` instead of `RouteContext.update`. |

## Review walkthrough

Review Steps 1 through 3. The order follows the data flow from the client message to the mount.

> [!TIP]
> Each file panel links to the GitHub diff. Inline diffs show literal excerpts only. Use Files changed for comments.

| Changed files | Diff | Focused tests | Stack position |
|---:|---:|---:|---:|
| 4 | +14 / −16 | `pytest tests/` 1693 passed | 1 of 2 |

`WHY` gives the problem. `PRINCIPLE` gives the design rule. `STEP` gives the review order. `KEPT` gives deliberate non-changes.

<details>
<summary><kbd>WHY</kbd> <strong>0: Starting point</strong> - <code>RouteContext</code> held a <code>RenderSession</code> pointer only to push session data upward.</summary>

<br />

- PR #120 gave `RenderSession` a reactive `url` attribute for `QueryParamSync`.
- `RouteContext.__init__` and `RouteContext.update` called `render.set_url(info)` to keep that attribute current.
- The `pathname`, `hash`, and `queryParams` fields in `RouteInfo` are session data. They arrived through mount-level messages, so a mount-level object forwarded them back up to its owner.
- A back-pointer that exists only to forward data upward signals that the data enters the system at the wrong level.

</details>

<details>
<summary><kbd>PRINCIPLE</kbd> <strong>Design rule</strong> - Split mixed-scope payloads at the boundary where they enter the system.</summary>

<br />

- `RenderSession` owns session-scoped URL data and records it when a client message arrives.
- `RouteContext` owns mount-scoped route data and only receives data from its owner.

</details>

<details>
<summary><kbd>STEP 1</kbd> <strong>The session records the URL at its message boundaries</strong> - <code>set_url</code> runs before any mount code.</summary>

<br />

**Before this PR.** `RenderSession.set_url` ran inside `RouteContext.__init__` and `RouteContext.update`, through the back-pointer.

**This PR.** `RenderSession.prerender`, `RenderSession.attach`, and `RenderSession.update_route` call `self.set_url(...)` directly. The `RouteMount` constructor call drops the `render` argument for `RouteContext`.

<details>
<summary><kbd>MODIFIED</kbd> <strong>packages/pulse/python/src/pulse/render_session.py</strong> - <code>prerender</code>, <code>attach</code>, and <code>update_route</code> call <code>set_url</code>.</summary>

<br />

`prerender` records the URL once per path, before it creates or reuses the mount:

```diff
 		for path in normalized:
 			route = self.routes.find(path)
 			info = route_info or route.default_route_info()
+			# Session-scoped URL data is split off at the message boundary;
+			# mounts only ever receive it, never report it back up.
+			self.set_url(info)
 			mount = self.route_mounts.get(path)
```

`attach` and `update_route` record the URL after the mount-existence checks, which preserves the prior no-op behavior for unknown mounts:

```diff
+		self.set_url(route_info)
 		mount.update_route(route_info)
 		if mount.state == "suspended":
```

```diff
 		try:
+			self.set_url(route_info)
 			mount.update_route(route_info)
 			if mount.state == "pending" and self._send_message:
```

[Open the `render_session.py` diff](https://github.com/erwinkn/pulse-ui/pull/122/files#diff-263bcf52ab01cc66ac78d1d6bb9f9e072f48d6eb72fc2d915fad34243eac3026)

</details>

</details>

<details>
<summary><kbd>STEP 2</kbd> <strong><code>RouteContext</code> loses the back-pointer</strong> - the mount keeps only mount-scoped state.</summary>

<br />

**Before this PR.** `RouteContext` stored `render: "RenderSession"` and called `render.set_url(info)` in `__init__` and `update`.

**This PR.** `RouteContext` keeps `info`, `pulse_route`, and `route_path`. The `TYPE_CHECKING` import of `RenderSession` in `routing.py` is gone, so `routing.py` no longer references `render_session.py` at all.

<details>
<summary><kbd>MODIFIED</kbd> <strong>packages/pulse/python/src/pulse/routing.py</strong> - remove the <code>render</code> attribute and both <code>set_url</code> calls.</summary>

<br />

```diff
 	info: RouteInfo
 	pulse_route: Route | Layout
 	route_path: str
-	render: "RenderSession"

 	def __init__(
 		self,
 		info: RouteInfo,
 		pulse_route: Route | Layout,
-		render: "RenderSession",
 		route_path: str | None = None,
 	):
 		self.info = cast(RouteInfo, cast(object, ReactiveDict(info)))
 		self.pulse_route = pulse_route
 		self.route_path = ensure_absolute_path(route_path or pulse_route.unique_path())
-		self.render = render
-		# The session, not the mount, owns URL-derived state (query param
-		# bindings outlive any single mount).
-		render.set_url(info)
```

[Open the `routing.py` diff](https://github.com/erwinkn/pulse-ui/pull/122/files#diff-fa5aa9f586a082010cc3d2151dc0ff10fe2a94737af1b82a73eb144f39311c27)

</details>

</details>

<details>
<summary><kbd>STEP 3</kbd> <strong>Tests use the boundary</strong> - mounts can no longer push URL state upward.</summary>

<br />

**Before this PR.** `test_url_to_state_updates` called `route_ctx.update(...)` and relied on the back-pointer to refresh the session URL. `make_route_context` in `test_hooks.py` passed `session` into `RouteContext`.

**This PR.** `test_url_to_state_updates` calls `session.update_route("/", ...)`. `make_route_context` calls `session.set_url(route_info)` itself and constructs `RouteContext` without the session.

<details>
<summary><kbd>MODIFIED</kbd> <strong>packages/pulse/python/tests/test_query_param.py</strong> - drive the URL change through <code>session.update_route</code>.</summary>

<br />

```diff
-			route_ctx.update(make_route_info("/", query_params={"q": "world"}))
+			session.update_route("/", make_route_info("/", query_params={"q": "world"}))
```

[Open the `test_query_param.py` diff](https://github.com/erwinkn/pulse-ui/pull/122/files#diff-d3979fd642ab2750b26238db82d9a406ca97dd84942744a6cda23fb4b5909533)

</details>

<details>
<summary><kbd>MODIFIED</kbd> <strong>packages/pulse/python/tests/test_hooks.py</strong> - set the session URL in the test helper.</summary>

<br />

```diff
 	session = RenderSession("test", routes)
-	route_ctx = RouteContext(route_info, route, session)
+	session.set_url(route_info)
+	route_ctx = RouteContext(route_info, route)
```

[Open the `test_hooks.py` diff](https://github.com/erwinkn/pulse-ui/pull/122/files#diff-9366eb01edfbf1e7f36b3fe4051151bf1fd250d22fad8fc26b52e3b3de2d5576)

</details>

</details>

<details>
<summary><kbd>KEPT</kbd> <strong>Deliberately unchanged</strong> - per-mount route info still exists.</summary>

<br />

- `RouteContext.info` still holds a full per-mount `RouteInfo` copy, fed by `RouteMount.update_route`. [PR #123](https://github.com/erwinkn/pulse-ui/pull/123) replaces this copy with server-side derivation.
- `RenderSession.set_url` still copies only `pathname`, `hash`, and `queryParams` into the session URL.
- `QueryParamSync` still reads `RenderSession.url`. This pull request does not modify it.

</details>

## Decision record

<details>
<summary><strong>1. Split the payload at the boundary instead of keeping the back-pointer</strong></summary>

<br />

**Decision.** `RenderSession` records session-scoped URL data at `prerender`, `attach`, and `update_route`, before any mount code runs.

**Before this PR.** `RouteContext` forwarded the URL upward through a `render` back-pointer on every construction and update.

**Reason.** The owner should receive its data directly. A child that exists inside the session should not be the delivery path for session state.

**Alternatives not selected.** Keep the back-pointer (status quo, leaves the coupling in place). Pass a narrow reference to the session `url` dict into `RouteContext` (unnecessary, because `RouteContext` never reads the session URL in this pull request).

**Result.** `routing.py` no longer imports `render_session.py`. Data flows one way: `RenderSession` → `RouteContext`.

**Review questions.** Do `prerender`, `attach`, and `update_route` call `set_url` on every path that previously reached `RouteContext.__init__` or `RouteContext.update`?

[Open the `render_session.py` diff](https://github.com/erwinkn/pulse-ui/pull/122/files#diff-263bcf52ab01cc66ac78d1d6bb9f9e072f48d6eb72fc2d915fad34243eac3026)

</details>

<details>
<summary><strong>2. Keep the no-op behavior for unknown mounts</strong></summary>

<br />

**Decision.** `attach` and `update_route` call `set_url` after their mount-existence checks.

**Before this PR.** A message for an unknown mount returned early and never touched `RouteContext`, so the session URL did not change.

**Reason.** This pull request only moves the call site. It does not change when the session URL updates.

**Alternatives not selected.** Call `set_url` before the mount check. This would update the session URL for messages the server otherwise ignores, which is a behavior change out of scope here.

**Result.** The session URL updates on exactly the same messages as before.

**Review questions.** Is the placement of `self.set_url(route_info)` in `attach` and `update_route` behavior-preserving for the `mount is None` path?

</details>

## Deliberate non-goals

- This pull request does not change the client↔server wire format. `attach`, `update`, and the prerender payload still carry the full `RouteInfo`.
- This pull request does not derive `pathParams` or `catchall` on the server. [PR #123](https://github.com/erwinkn/pulse-ui/pull/123) does that.
- This pull request does not change `ps.route()` or any component-facing API.

## Evidence and verification

| Boundary | Evidence |
|---|---|
| `RenderSession.set_url` at the boundaries | `tests/test_query_param.py::test_url_to_state_updates` covers URL→state sync through `session.update_route`. |
| `RouteContext` without the back-pointer | `tests/test_hooks.py::test_route_returns_route_info` and `test_pulse_route_returns_definition` construct `RouteContext` without a session. |
| Session URL behavior | `tests/test_query_param.py` and `tests/test_render_session.py` pass unchanged except for the `session.update_route` and `session.set_url` call sites shown above. |

These checks passed on `a8afe37f42c7d466161315d1a0b8fe95b9ddb519`:

- `make all` (ruff, biome, basedpyright, tsc, pytest, bun test): all checks passed, 1693 Python tests and 120 JS tests
- GitHub Actions `lint-and-test`: pass

Checks not run:

- None

[Open the live pull request checks](https://github.com/erwinkn/pulse-ui/pull/122/checks)

## Stack

- GitHub stack #122 uses `main` as its base.
- Position 1: [PR #122](https://github.com/erwinkn/pulse-ui/pull/122), `pulse-session-url-ownership` → `main`
- Position 2: [PR #123](https://github.com/erwinkn/pulse-ui/pull/123), `pulse-url-single-source` → `pulse-session-url-ownership`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/erwinkn/pulse-ui/pull/122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->