### PR TITLE
Make the URL the single source of truth for route state

### DIFF
--- a/docs/content/docs/(core)/advanced/middleware.mdx
+++ b/docs/content/docs/(core)/advanced/middleware.mdx
@@ -40,9 +40,12 @@ With middleware, you write this check once and it protects every route automatic
 class AuthMiddleware(ps.PulseMiddleware):
     PUBLIC_PATHS = {"/", "/login", "/signup", "/about"}
 
-    async def prerender_route(self, *, path, route_info, request, session, next):
+    async def prerender(self, *, payload, request, session, next):
+        # The URL the browser is requesting
+        pathname = payload["location"]["pathname"]
+
         # Allow public routes without authentication
-        if path in self.PUBLIC_PATHS:
+        if pathname in self.PUBLIC_PATHS:
             return await next()
 
         # Protected route: check if user is logged in
@@ -85,7 +88,7 @@ The key pattern is calling `await next()` to pass control to the next middleware
 
 ## Middleware hooks
 
-Middleware can intercept five different points in the request lifecycle. You only need to override the ones you care about.
+Middleware can intercept four different points in the request lifecycle. You only need to override the ones you care about.
 
 ### `prerender`
 
@@ -93,20 +96,13 @@ Called when the browser first requests a page. This happens before any HTML is s
 
 ```python
 async def prerender(self, *, payload, request, session, next):
-    # `payload` contains info about which paths are being requested
-    # Return Redirect or NotFound to short-circuit rendering
-    return await next()
-```
-
-### `prerender_route`
-
-Called for each individual route being rendered. More granular than `prerender` when you need route-specific logic:
-
-```python
-async def prerender_route(self, *, path, route_info, request, session, next):
-    # Protect admin routes
-    if path.startswith("/admin") and not session.get("is_admin"):
+    # payload["paths"] lists the routes being rendered for this request
+    # payload["location"] is the URL the browser is on:
+    #   {"pathname", "hash", "query", "queryParams"}
+    if payload["location"]["pathname"].startswith("/admin") and not session.get("is_admin"):
         return ps.Redirect("/login")
+
+    # Return Redirect or NotFound to short-circuit rendering
     return await next()
 ```
 
@@ -178,9 +174,9 @@ class AuthMiddleware(ps.PulseMiddleware):
     # Routes that don't require authentication
     PUBLIC_PATHS = {"/", "/login", "/signup", "/about"}
 
-    async def prerender_route(self, *, path, route_info, request, session, next):
+    async def prerender(self, *, payload, request, session, next):
         # Public routes are always accessible
-        if path in self.PUBLIC_PATHS:
+        if payload["location"]["pathname"] in self.PUBLIC_PATHS:
             return await next()
 
         # Protected routes require authentication

--- a/docs/content/docs/(core)/concepts/routing.mdx
+++ b/docs/content/docs/(core)/concepts/routing.mdx
@@ -192,13 +192,13 @@ Access the captured path with `route["catchall"]`:
 @ps.component
 def file_browser():
     route = ps.route()
-    file_path = route["catchall"]  # "docs/report.pdf"
+    file_path = "/".join(route["catchall"])  # ["docs", "report.pdf"] -> "docs/report.pdf"
     return ps.p(f"Viewing: {file_path}")
 ```
 
 ## Route information
 
-`ps.route()` returns a `RouteInfo` object with details about the current URL:
+`ps.route()` returns a `RouteInfo` object with details about the current URL. The browser only reports the URL itself—Pulse derives `pathParams` and `catchall` on the server by matching your route's pattern against it:
 
 ```python
 @ps.component

--- a/docs/content/docs/(core)/concepts/sessions.mdx
+++ b/docs/content/docs/(core)/concepts/sessions.mdx
@@ -226,9 +226,10 @@ If you need to check sessions before rendering any page (like for app-wide authe
 
 ```python
 class AuthMiddleware(ps.PulseMiddleware):
-    async def prerender_route(self, *, session, path, **kwargs):
+    async def prerender(self, *, session, payload, **kwargs):
         # Block unauthenticated users from admin pages
-        if path.startswith("/admin") and not session.get("is_admin"):
+        pathname = payload["location"]["pathname"]
+        if pathname.startswith("/admin") and not session.get("is_admin"):
             return ps.Redirect("/login")
         return await kwargs["next"]()
 

--- a/docs/content/docs/(core)/cookbook/auth/auth-middleware.mdx
+++ b/docs/content/docs/(core)/cookbook/auth/auth-middleware.mdx
@@ -21,17 +21,16 @@ class AuthMiddleware(ps.PulseMiddleware):
     # Routes that don't require authentication
     PUBLIC_PATHS = {"/", "/login", "/signup"}
 
-    async def prerender_route(
+    async def prerender(
         self,
         *,
-        path: str,
-        route_info: ps.RouteInfo,
+        payload: ps.PrerenderPayload,
         request: ps.PulseRequest,
         session: dict[str, Any],
-        next: Callable[[], Awaitable[ps.RoutePrerenderResponse]],
-    ) -> ps.RoutePrerenderResponse:
+        next: Callable[[], Awaitable[ps.PrerenderResponse]],
+    ) -> ps.PrerenderResponse:
         """Redirect unauthenticated users to login."""
-        if path in self.PUBLIC_PATHS:
+        if payload["location"]["pathname"] in self.PUBLIC_PATHS:
             return await next()
 
         if not session.get("user_email"):
@@ -65,7 +64,7 @@ app = ps.App(
 
 ## How it works
 
-- `prerender_route` runs before rendering each page. Return `ps.Redirect("/login")` to send unauthenticated users to the login page.
+- `prerender` runs before rendering the page. `payload["location"]["pathname"]` is the URL the browser is requesting. Return `ps.Redirect("/login")` to send unauthenticated users to the login page.
 - `connect` runs when a WebSocket connection is established. Return `ps.Deny()` to reject the connection entirely.
 - The `session` dict persists across requests for the same user. Store auth state here after login.
 

--- a/docs/content/docs/(core)/glossary.mdx
+++ b/docs/content/docs/(core)/glossary.mdx
@@ -177,6 +177,12 @@ Dynamic URL segments like `/users/:id`. The `:id` part matches any value and is 
 **Query Parameters**
 Key-value pairs in the URL after `?`, like `?page=2&sort=name`. Used for filters, pagination, and other optional state.
 
+**Location**
+The URL a browser tab is displaying: pathname, hash, query string, and parsed query parameters. One location per tab—it's the only routing information the client sends to the server.
+
+**Route Info**
+What `ps.route()` returns inside a component: the location plus `pathParams` and `catchall`, which the server derives by matching the route's pattern against the URL.
+
 **Navigation**
 Programmatically changing the URL and rendering a different route. Can be client-side (no page reload) or a full redirect.
 

--- a/docs/content/docs/packages/pulse-js-client.mdx
+++ b/docs/content/docs/packages/pulse-js-client.mdx
@@ -149,7 +149,7 @@ const data = deserialize(wire);
 - `serialize` - Convert data for wire transfer
 - `deserialize` - Parse data from wire format
 - `submitForm` - Programmatic form submission
-- `extractServerRouteInfo` - Extract route information
+- `extractServerLocation` - Extract the browser URL in SSR loaders
 
 **Types:**
 - `VDOM`, `VDOMNode`, `VDOMElement` - Virtual DOM types

--- a/docs/content/docs/reference/pulse-client/hooks.mdx
+++ b/docs/content/docs/reference/pulse-client/hooks.mdx
@@ -87,7 +87,7 @@ interface PulseClient {
   onConnectionChange(listener: ConnectionStatusListener): () => void;
 
   // Route management
-  updateRoute(path: string, routeInfo: RouteInfo): void;
+  updateRoute(path: string, location: PulseLocation): void;
   attach(path: string, view: MountedView): void;
   detach(path: string): void;
 

--- a/docs/content/docs/reference/pulse-client/index.mdx
+++ b/docs/content/docs/reference/pulse-client/index.mdx
@@ -97,7 +97,7 @@ The package exports several categories of APIs:
 ### Utilities
 
 - **serialize** / **deserialize** - Wire format encoding
-- **extractServerRouteInfo** - Extract route info in loaders
+- **extractServerLocation** - Extract the browser URL in loaders
 - **submitForm** - Programmatic form submission
 
 ## Architecture
@@ -107,7 +107,7 @@ The client maintains a persistent WebSocket connection to the Pulse server:
 ```
 React App                          Pulse Server
     |                                   |
-    |-- attach (path, routeInfo) ------>|
+    |-- attach (path, location) ------->|
     |<-------- vdom_init (VDOM) --------|
     |                                   |
     |<------ vdom_update (ops[]) -------|  (on state change)

--- a/docs/content/docs/reference/pulse-client/serialization.mdx
+++ b/docs/content/docs/reference/pulse-client/serialization.mdx
@@ -231,14 +231,14 @@ a.ref = b;  // circular
 
 ---
 
-## extractServerRouteInfo
+## extractServerLocation
 
-Extracts route information from a React Router loader function. Use this in SSR loaders to pass route context to the Pulse server.
+Extracts the request URL from a React Router loader function. Use this in SSR loaders to pass the browser location to the Pulse server. Route-match data (`pathParams`, `catchall`) is derived server-side by matching each route's pattern against the pathname—the client only ever reports the URL.
 
 ```ts
-import { extractServerRouteInfo } from "pulse-ui-client";
+import { extractServerLocation } from "pulse-ui-client";
 
-function extractServerRouteInfo(args: LoaderFunctionArgs): RouteInfo
+function extractServerLocation(args: LoaderFunctionArgs): PulseLocation
 ```
 
 ### Parameters
@@ -250,31 +250,28 @@ function extractServerRouteInfo(args: LoaderFunctionArgs): RouteInfo
 ### Returns
 
 ```ts
-interface RouteInfo {
+interface PulseLocation {
   pathname: string;
   hash: string;
   query: string;
   queryParams: Record<string, string>;
-  pathParams: Record<string, string | undefined>;
-  catchall: string[];
 }
 ```
 
 ### Example
 
 ```ts
-import { extractServerRouteInfo } from "pulse-ui-client";
+import { extractServerLocation } from "pulse-ui-client";
 import type { LoaderFunctionArgs } from "react-router";
 
 export async function loader(args: LoaderFunctionArgs) {
-  const routeInfo = extractServerRouteInfo(args);
+  const location = extractServerLocation(args);
 
-  // routeInfo.pathname = "/users/123"
-  // routeInfo.pathParams = { id: "123" }
-  // routeInfo.queryParams = { tab: "settings" }
+  // location.pathname = "/users/123"
+  // location.queryParams = { tab: "settings" }
 
   // Pass to Pulse server for SSR
-  const prerender = await fetchPulsePrerender(routeInfo);
+  const prerender = await fetchPulsePrerender(location);
   return { prerender };
 }
 ```

--- a/docs/content/docs/reference/pulse-client/types.mdx
+++ b/docs/content/docs/reference/pulse-client/types.mdx
@@ -96,18 +96,16 @@ interface PulseFormProps extends ComponentPropsWithoutRef<"form"> {
 
 ## Route Types
 
-### RouteInfo
+### PulseLocation
 
-Route information extracted from the current URL.
+The URL a browser tab is displaying. There is one location per tab; the client only ever reports the URL. Route-match data (`pathParams`, `catchall`) is derived server-side per mount by matching each route's pattern against `pathname`.
 
 ```ts
-interface RouteInfo {
+interface PulseLocation {
   pathname: string;
   hash: string;
   query: string;
   queryParams: Record<string, string>;
-  pathParams: Record<string, string | undefined>;
-  catchall: string[];
 }
 ```
 
@@ -117,8 +115,6 @@ interface RouteInfo {
 | `hash` | URL hash fragment (e.g., `section`) |
 | `query` | Query string (e.g., `page=1`) |
 | `queryParams` | Parsed query parameters |
-| `pathParams` | Route parameters from path |
-| `catchall` | Segments from catch-all route (`/*`) |
 
 ---
 
@@ -372,7 +368,8 @@ Attaches to a view path.
 interface ClientAttachMessage {
   type: "attach";
   path: string;
-  routeInfo: RouteInfo;
+  location: PulseLocation;
+  attachId: string;
 }
 ```
 
@@ -391,13 +388,13 @@ interface ClientCallbackMessage {
 
 #### ClientUpdateMessage
 
-Updates route info for an attached path.
+Reports the tab's new location for an attached path.
 
 ```ts
 interface ClientUpdateMessage {
   type: "update";
   path: string;
-  routeInfo: RouteInfo;
+  location: PulseLocation;
 }
 ```
 
@@ -586,7 +583,7 @@ interface PulseClient {
   disconnect(): void;
   isConnected(): boolean;
   onConnectionChange(listener: ConnectionStatusListener): () => void;
-  updateRoute(path: string, routeInfo: RouteInfo): void;
+  updateRoute(path: string, location: PulseLocation): void;
   invokeCallback(path: string, callback: string, args: any[]): void;
   attach(path: string, view: MountedView): void;
   detach(path: string): void;
@@ -615,7 +612,7 @@ Callbacks for a mounted view.
 
 ```ts
 interface MountedView {
-  routeInfo: RouteInfo;
+  location: PulseLocation;
   onInit: (view: PulsePrerenderView) => void;
   onUpdate: (ops: VDOMUpdate[]) => void;
   onJsExec: (msg: ServerJsExecMessage) => void;

--- a/docs/content/docs/reference/pulse/app.mdx
+++ b/docs/content/docs/reference/pulse/app.mdx
@@ -370,7 +370,7 @@ ps.Layout(
 
 ## RouteInfo
 
-TypedDict containing current route information.
+TypedDict containing current route information. Returned by `ps.route()` inside components. `pathParams` and `catchall` are derived server-side by matching the route's pattern against the tab's URL.
 
 ```python
 class RouteInfo(TypedDict):
@@ -380,6 +380,20 @@ class RouteInfo(TypedDict):
     queryParams: dict[str, str]   # Parsed query parameters
     pathParams: dict[str, str]    # Dynamic path parameters
     catchall: list[str]  # Catch-all segments
+```
+
+---
+
+## Location
+
+TypedDict containing the URL a browser tab is displaying. This is what the client reports on navigation—one `Location` per tab. Route-match data (`pathParams`, `catchall`) is derived from it server-side, per mount.
+
+```python
+class Location(TypedDict):
+    pathname: str        # Current URL path
+    hash: str            # URL hash (after #)
+    query: str           # Query string (after ?)
+    queryParams: dict[str, str]   # Parsed query parameters
 ```
 
 ---

--- a/docs/content/docs/reference/pulse/hooks.mdx
+++ b/docs/content/docs/reference/pulse/hooks.mdx
@@ -284,7 +284,7 @@ def route() -> RouteInfo
 
 ### Returns
 
-`RouteInfo` with access to route parameters, path, and query.
+`RouteInfo` with access to route parameters, path, and query. `pathParams` and `catchall` are derived server-side from the tab's URL by matching it against the route's pattern.
 
 ### Example
 

--- a/docs/content/docs/reference/pulse/index.mdx
+++ b/docs/content/docs/reference/pulse/index.mdx
@@ -24,7 +24,8 @@ These are the building blocks for creating your application and defining its URL
 | `App` | Main application class |
 | `Route` | Route definition |
 | `Layout` | Layout wrapper for nested routes |
-| `RouteInfo` | TypedDict with current route information |
+| `RouteInfo` | TypedDict with current route information (returned by `ps.route()`) |
+| `Location` | TypedDict with the URL a browser tab is displaying |
 | `PulseMode` | Literal type: `'single-server'` or `'subdomains'` |
 | `FastAPIConfig` | Generated FastAPI docs and OpenAPI configuration |
 | `CodegenConfig` | Code generation configuration |

--- a/docs/content/docs/reference/pulse/middleware.mdx
+++ b/docs/content/docs/reference/pulse/middleware.mdx
@@ -61,40 +61,15 @@ async def prerender(
 ) -> PrerenderResponse
 ```
 
-Handle batch prerender at the top level (HTTP request).
+Handle batch prerender for the full HTTP request. Call `next()` to get the `Prerender` result; you can modify it (views and directives) before returning.
 
 **Parameters:**
-- `payload` - Full prerender payload.
+- `payload` - Full prerender payload (see `PrerenderPayload` below).
 - `request` - Normalized request object.
 - `session` - Session data dictionary.
 - `next` - Callable to continue the middleware chain.
 
 **Returns:** `Ok[Prerender]`, `Redirect`, or `NotFound`.
-
-##### prerender_route
-
-```python
-async def prerender_route(
-    self,
-    *,
-    path: str,
-    request: PulseRequest,
-    route_info: RouteInfo,
-    session: dict[str, Any],
-    next: Callable[[], Awaitable[RoutePrerenderResponse]],
-) -> RoutePrerenderResponse
-```
-
-Handle individual route prerender.
-
-**Parameters:**
-- `path` - Route path being prerendered.
-- `request` - Normalized request object.
-- `route_info` - Route information.
-- `session` - Session data dictionary.
-- `next` - Callable to continue the middleware chain.
-
-**Returns:** `Ok[ServerInitMessage]`, `Redirect`, or `NotFound`.
 
 ##### connect
 
@@ -187,7 +162,6 @@ def __init__(
     self,
     *,
     prerender_ms: float = 80.0,
-    prerender_route_ms: float = 60.0,
     connect_ms: float = 40.0,
     message_ms: float = 25.0,
     channel_ms: float = 20.0,
@@ -196,7 +170,6 @@ def __init__(
 
 **Parameters:**
 - `prerender_ms` - Latency for batch prerender requests. Default: 80ms.
-- `prerender_route_ms` - Latency for individual route prerenders. Default: 60ms.
 - `connect_ms` - Latency for WebSocket connections. Default: 40ms.
 - `message_ms` - Latency for WebSocket messages. Default: 25ms.
 - `channel_ms` - Latency for channel messages. Default: 20ms.
@@ -264,11 +237,17 @@ ConnectResponse = Ok[None] | Deny
 PrerenderResponse = Ok[Prerender] | Redirect | NotFound
 ```
 
-### RoutePrerenderResponse
+### PrerenderPayload
 
 ```python
-RoutePrerenderResponse = Ok[ServerInitMessage] | Redirect | NotFound
+class PrerenderPayload(TypedDict):
+    paths: list[str]
+    location: Location
+    ttlSeconds: NotRequired[float | int]
+    renderId: NotRequired[str]
 ```
+
+The body of a prerender request. `paths` lists the route paths being rendered; `location` is the browser URL (`pathname`, `hash`, `query`, `queryParams`). Per-mount route params are derived server-side by matching each route's pattern against `location["pathname"]`.
 
 ## Example: Auth Middleware
 
@@ -276,16 +255,16 @@ RoutePrerenderResponse = Ok[ServerInitMessage] | Redirect | NotFound
 import pulse as ps
 
 class AuthMiddleware(ps.PulseMiddleware):
-    async def prerender_route(
+    async def prerender(
         self,
         *,
-        path: str,
+        payload: ps.PrerenderPayload,
         request: ps.PulseRequest,
-        route_info: ps.RouteInfo,
         session: dict[str, Any],
         next,
     ):
-        if path.startswith("/admin") and not session.get("is_admin"):
+        pathname = payload["location"]["pathname"]
+        if pathname.startswith("/admin") and not session.get("is_admin"):
             return ps.Redirect("/login")
         return await next()
 

--- a/docs/content/docs/reference/pulse/routing.mdx
+++ b/docs/content/docs/reference/pulse/routing.mdx
@@ -52,13 +52,13 @@ def unique_path(self) -> str
 
 Return absolute path with leading `/`.
 
-##### default_route_info
+##### default_location
 
 ```python
-def default_route_info(self) -> RouteInfo
+def default_location(self) -> Location
 ```
 
-Return default `RouteInfo` for static routes.
+Return a default `Location` for static routes.
 
 **Raises:** `InvalidRouteError` if route or ancestors have dynamic segments.
 
@@ -126,9 +126,21 @@ app = ps.App(
 )
 ```
 
+### Location
+
+TypedDict containing the URL a browser tab is displaying. This is everything the client reports about a navigation: one `Location` per tab.
+
+```python
+class Location(TypedDict):
+    pathname: str       # Current URL path
+    hash: str           # URL hash (without #)
+    query: str          # Query string (without ?)
+    queryParams: dict[str, str]  # Parsed query parameters
+```
+
 ### RouteInfo
 
-TypedDict containing route information from the client.
+TypedDict containing current route information. This is what `ps.route()` returns inside components. The route-match fields (`pathParams`, `catchall`) are derived server-side by matching the route's pattern against the tab's `Location`.
 
 ```python
 class RouteInfo(TypedDict):

--- a/packages/pulse-aws/tests/test_plugin.py
+++ b/packages/pulse-aws/tests/test_plugin.py
@@ -15,7 +15,7 @@ async def test_prerender_adds_affinity_query_directives():
 
 	middleware = AWSECSDirectivesMiddleware(plugin)
 	result = await middleware.prerender(
-		payload={"paths": ["/"], "routeInfo": {}},
+		payload={"paths": ["/"], "location": {}},
 		request=object(),
 		session={},
 		next=lambda: _ok_prerender(),

--- a/packages/pulse-railway/tests/test_railway_plugin.py
+++ b/packages/pulse-railway/tests/test_railway_plugin.py
@@ -33,7 +33,7 @@ async def test_prerender_adds_affinity_query_directives(monkeypatch) -> None:
 
 	middleware = RailwayDirectivesMiddleware(plugin)
 	result = await middleware.prerender(
-		payload={"paths": ["/"], "routeInfo": {}},
+		payload={"paths": ["/"], "location": {}},
 		request=object(),
 		session={},
 		next=lambda: _ok_prerender(),

--- a/packages/pulse/js/README.md
+++ b/packages/pulse/js/README.md
@@ -117,6 +117,6 @@ function Chat() {
 
 **Hooks**: `usePulseClient()`, `usePulseChannel(name)`
 
-**Functions**: `serialize`, `deserialize`, `extractServerRouteInfo`, `submitForm`
+**Functions**: `serialize`, `deserialize`, `extractServerLocation`, `submitForm`
 
 **Types**: `VDOM`, `VDOMNode`, `VDOMElement`, `PulseClient`, `Transport`, `ComponentRegistry`

--- a/packages/pulse/js/src/client.test.ts
+++ b/packages/pulse/js/src/client.test.ts
@@ -38,17 +38,15 @@ const io = vi.fn((_url?: string, _options?: Record<string, any>) => {
 
 mock.module("socket.io-client", () => ({ io }));
 
-const routeInfo = {
+const location = {
 	hash: "",
 	pathname: "/",
 	query: "",
 	queryParams: {},
-	pathParams: {},
-	catchall: [],
 };
 
 const view = {
-	routeInfo,
+	location,
 	onInit: vi.fn(),
 	onUpdate: vi.fn(),
 	onJsExec: vi.fn(),

--- a/packages/pulse/js/src/client.tsx
+++ b/packages/pulse/js/src/client.tsx
@@ -1,7 +1,7 @@
 import type { NavigateFunction } from "react-router";
 import { io, type Socket } from "socket.io-client";
 import { ChannelBridge, createRandomId, PulseChannelResetError } from "./channel";
-import type { RouteInfo } from "./helpers";
+import type { PulseLocation } from "./helpers";
 import { pulseFetch } from "./http";
 import type {
 	ClientApiResultMessage,
@@ -48,7 +48,7 @@ export interface Directives {
 	socketio?: SocketIODirectives;
 }
 export interface MountedView {
-	routeInfo: RouteInfo;
+	location: PulseLocation;
 	onInit: (view: PulsePrerenderView) => void;
 	onUpdate: (ops: VDOMUpdate[]) => void;
 	onJsExec: (msg: ServerJsExecMessage) => void;
@@ -66,7 +66,7 @@ export interface PulseClient {
 	isConnected(): boolean;
 	onConnectionChange(listener: ConnectionStatusListener): () => void;
 	// Messages
-	updateRoute(path: string, routeInfo: RouteInfo): void;
+	updateRoute(path: string, location: PulseLocation): void;
 	invokeCallback(path: string, callback: string, args: any[]): void;
 	// VDOM subscription
 	attach(path: string, view: MountedView): void;
@@ -217,7 +217,7 @@ export class PulseSocketIOClient {
 				console.log("[SocketIOTransport] Connected:", this.#socket?.id);
 				// Send attach for all active views on connect/reconnect
 				for (const [path, route] of this.#activeViews) {
-					this.#sendAttach(path, route.routeInfo, socket);
+					this.#sendAttach(path, route.location, socket);
 				}
 
 				for (const payload of this.#messageQueue) {
@@ -293,17 +293,17 @@ export class PulseSocketIOClient {
 			throw new Error(`Path ${path} is already attached`);
 		}
 		this.#activeViews.set(path, view);
-		this.#sendAttach(path, view.routeInfo);
+		this.#sendAttach(path, view.location);
 	}
 
-	public updateRoute(path: string, routeInfo: RouteInfo) {
+	public updateRoute(path: string, location: PulseLocation) {
 		const view = this.#activeViews.get(path);
 		if (view) {
-			view.routeInfo = routeInfo;
+			view.location = location;
 			this.sendMessage({
 				type: "update",
 				path,
-				routeInfo,
+				location,
 			});
 		}
 	}
@@ -391,11 +391,11 @@ export class PulseSocketIOClient {
 			case "navigate_to": {
 				if (message.sourceRoutePath && message.sourcePath) {
 					const view = this.#activeViews.get(message.sourceRoutePath);
-					if (!view || view.routeInfo.pathname !== message.sourcePath) break;
+					if (!view || view.location.pathname !== message.sourcePath) break;
 				} else if (message.sourcePath) {
 					let sourceActive = false;
 					for (const view of this.#activeViews.values()) {
-						if (view.routeInfo.pathname === message.sourcePath) {
+						if (view.location.pathname === message.sourcePath) {
 							sourceActive = true;
 							break;
 						}
@@ -593,14 +593,14 @@ export class PulseSocketIOClient {
 		}
 	}
 
-	#sendAttach(path: string, routeInfo: RouteInfo, socket?: Socket): void {
+	#sendAttach(path: string, location: PulseLocation, socket?: Socket): void {
 		const attachId = `${path}:${++this.#nextAttachId}`;
 		this.#activeAttachIds.set(path, attachId);
 		this.#ackedAttachIds.delete(path);
 		const message = {
 			type: "attach" as const,
 			path,
-			routeInfo,
+			location,
 			attachId,
 		};
 		if (socket) {

--- a/packages/pulse/js/src/helpers.ts
+++ b/packages/pulse/js/src/helpers.ts
@@ -1,16 +1,15 @@
 import type { LoaderFunctionArgs } from "react-router";
 
-export interface RouteInfo {
+/** The URL this tab is displaying. Route-match data (pathParams/catchall)
+ * is derived server-side per mount; the client only ever reports the URL. */
+export interface PulseLocation {
 	pathname: string;
 	hash: string;
 	query: string;
 	queryParams: Record<string, string>;
-	pathParams: Record<string, string | undefined>;
-	catchall: string[];
 }
 
-export function extractServerRouteInfo({ params, request }: LoaderFunctionArgs) {
-	const { "*": catchall = "", ...pathParams } = params;
+export function extractServerLocation({ request }: LoaderFunctionArgs) {
 	const parsedUrl = new URL(request.url);
 	const query = parsedUrl.search.startsWith("?")
 		? parsedUrl.search.slice(1)
@@ -24,7 +23,5 @@ export function extractServerRouteInfo({ params, request }: LoaderFunctionArgs) 
 		pathname: parsedUrl.pathname,
 		query,
 		queryParams: Object.fromEntries(parsedUrl.searchParams.entries()),
-		pathParams,
-		catchall: catchall.length > 1 ? catchall.split("/") : [],
-	} satisfies RouteInfo;
+	} satisfies PulseLocation;
 }

--- a/packages/pulse/js/src/index.ts
+++ b/packages/pulse/js/src/index.ts
@@ -11,9 +11,9 @@ export type {
 export type { PulseFormProps } from "./form";
 // Form helpers
 export { FormSubmissionError, PulseForm, submitForm } from "./form";
-export type { RouteInfo } from "./helpers";
+export type { PulseLocation } from "./helpers";
 // Server helpers
-export { extractServerRouteInfo } from "./helpers";
+export { extractServerLocation } from "./helpers";
 // Messages (types only)
 export type {
 	ClientApiResultMessage,

--- a/packages/pulse/js/src/messages.ts
+++ b/packages/pulse/js/src/messages.ts
@@ -2,7 +2,7 @@
 // Message Types
 // =================================================================
 
-import type { RouteInfo } from "./helpers";
+import type { PulseLocation } from "./helpers";
 import type { VDOM, VDOMNode, VDOMUpdate } from "./vdom";
 
 // Based on pulse/messages.py
@@ -112,13 +112,13 @@ export interface ClientCallbackMessage {
 export interface ClientAttachMessage {
 	type: "attach";
 	path: string;
-	routeInfo: RouteInfo;
+	location: PulseLocation;
 	attachId: string;
 }
 export interface ClientUpdateMessage {
 	type: "update";
 	path: string;
-	routeInfo: RouteInfo;
+	location: PulseLocation;
 }
 export interface ClientDetachMessage {
 	type: "detach";

--- a/packages/pulse/js/src/pulse.tsx
+++ b/packages/pulse/js/src/pulse.tsx
@@ -9,9 +9,9 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { useLocation, useNavigate, useParams } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { type ConnectionStatus, type Directives, PulseSocketIOClient } from "./client";
-import type { RouteInfo } from "./helpers";
+import type { PulseLocation } from "./helpers";
 import type { ServerError } from "./messages";
 import { VDOMRenderer } from "./renderer";
 import type { VDOM } from "./vdom";
@@ -208,11 +208,8 @@ export function PulseView({ path, registry }: PulseViewProps) {
 	const [serverError, setServerError] = useState<ServerError | null>(null);
 
 	const location = useLocation();
-	const params = useParams();
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: using hacky deep equality for params
-	const routeInfo = useMemo(() => {
-		const { "*": catchall = "", ...pathParams } = params;
+	const pulseLocation = useMemo(() => {
 		const queryParams = new URLSearchParams(location.search);
 		const query = location.search.startsWith("?")
 			? location.search.slice(1)
@@ -225,16 +222,14 @@ export function PulseView({ path, registry }: PulseViewProps) {
 			pathname: location.pathname,
 			query,
 			queryParams: Object.fromEntries(queryParams.entries()),
-			pathParams,
-			catchall: catchall.length > 0 ? catchall.split("/") : [],
-		} satisfies RouteInfo;
-	}, [location.hash, location.pathname, location.search, JSON.stringify(params)]);
+		} satisfies PulseLocation;
+	}, [location.hash, location.pathname, location.search]);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: We don't want to detach on navigation, so another useEffect syncs the routeInfo on navigation.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: We don't want to detach on navigation, so another useEffect syncs the location on navigation.
 	useEffect(() => {
 		if (inBrowser) {
 			client.attach(path, {
-				routeInfo,
+				location: pulseLocation,
 				onInit: (view) => {
 					setTree(renderer.init(view));
 					setServerError(null);
@@ -261,14 +256,14 @@ export function PulseView({ path, registry }: PulseViewProps) {
 				client.detach(path);
 			};
 		}
-		//  routeInfo is NOT included here on purpose
+		//  location is NOT included here on purpose
 	}, [client, renderer, path]);
 
 	useEffect(() => {
 		if (inBrowser) {
-			client.updateRoute(path, routeInfo);
+			client.updateRoute(path, pulseLocation);
 		}
-	}, [client, path, routeInfo]);
+	}, [client, path, pulseLocation]);
 	// Hack for our current prerendering setup on client-side navigation. Will be improved soon
 	const hasRendered = useRef(false);
 	useIsomorphicLayoutEffect(() => {

--- a/packages/pulse/python/src/pulse/__init__.py
+++ b/packages/pulse/python/src/pulse/__init__.py
@@ -1437,6 +1437,7 @@ from pulse.render_session import run_js as run_js
 from pulse.request import PulseRequest as PulseRequest
 from pulse.requirements import require as require
 from pulse.routing import Layout as Layout
+from pulse.routing import Location as Location
 from pulse.routing import Route as Route
 from pulse.routing import RouteInfo as RouteInfo
 from pulse.scheduling import (

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -684,12 +684,12 @@ class App:
 		def set_cookies():  # pyright: ignore[reportUnusedFunction]
 			return {"health": "ok", "message": "Cookies updated"}
 
-		# RouteInfo is the request body
+		# Location is the request body
 		@self.fastapi.post(f"{prefix}/prerender", include_in_schema=False)
 		async def prerender(payload: PrerenderPayload, request: Request):  # pyright: ignore[reportUnusedFunction]
 			"""
 			POST /prerender
-			Body: { paths: string[], routeInfo: RouteInfo, ttlSeconds?: number }
+			Body: { paths: string[], location: Location, ttlSeconds?: number }
 			Headers: X-Pulse-Render-Id (optional, for render session reuse)
 			Returns: { renderId: string, <path>: VDOM, ... }
 			"""
@@ -703,7 +703,7 @@ class App:
 				)
 			paths = [ensure_absolute_path(path) for path in paths]
 			payload["paths"] = paths
-			route_info = payload.get("routeInfo")
+			location = payload.get("location")
 
 			client_addr: str | None = get_client_address(request)
 			# Reuse render session from header (set by middleware) or create new one
@@ -751,7 +751,7 @@ class App:
 						},
 					}
 
-					captured = render.prerender(paths, route_info)
+					captured = render.prerender(paths, location)
 
 					for p in paths:
 						res = _normalize_prerender_result(captured[p])
@@ -1112,7 +1112,7 @@ class App:
 	) -> None:
 		async def _next() -> Ok[None]:
 			if msg["type"] == "attach":
-				attached = render.attach(msg["path"], msg["routeInfo"])
+				attached = render.attach(msg["path"], msg["location"])
 				attach_id = msg.get("attachId")
 				if attached and isinstance(attach_id, str):
 					render.send(
@@ -1123,7 +1123,7 @@ class App:
 						}
 					)
 			elif msg["type"] == "update":
-				render.update_route(msg["path"], msg["routeInfo"])
+				render.update_route(msg["path"], msg["location"])
 			elif msg["type"] == "callback":
 				render.execute_callback(msg["path"], msg["callback"], msg["args"])
 			elif msg["type"] == "detach":

--- a/packages/pulse/python/src/pulse/codegen/templates/layout.py
+++ b/packages/pulse/python/src/pulse/codegen/templates/layout.py
@@ -1,7 +1,7 @@
 from mako.template import Template
 
 LAYOUT_TEMPLATE = Template(
-	"""import { deserialize, extractServerRouteInfo, PulseProvider, type PulseConfig, type PulsePrerender } from "pulse-ui-client";
+	"""import { deserialize, extractServerLocation, PulseProvider, type PulseConfig, type PulsePrerender } from "pulse-ui-client";
 import { Outlet, data, type LoaderFunctionArgs, type ClientLoaderFunctionArgs } from "react-router";
 import { matchRoutes } from "react-router";
 import { rrPulseRouteTree } from "./routes.runtime";
@@ -37,7 +37,7 @@ export async function loader(args: LoaderFunctionArgs) {
   const res = await fetch(`$${"{"}internalServerAddress}$${"{"}config.apiPrefix}/prerender`, {
     method: "POST",
     headers: fwd,
-    body: JSON.stringify({ paths, routeInfo: extractServerRouteInfo(args) }),
+    body: JSON.stringify({ paths, location: extractServerLocation(args) }),
   });
   if (!res.ok) throw new Error("Failed to prerender batch:" + res.status);
   const body = await res.json();
@@ -83,7 +83,7 @@ export async function clientLoader(args: ClientLoaderFunctionArgs) {
     headers,
     credentials: "include",
     redirect: "manual",
-    body: JSON.stringify({ paths, routeInfo: extractServerRouteInfo(args) }),
+    body: JSON.stringify({ paths, location: extractServerLocation(args) }),
   });
   if (res.type === "opaqueredirect" || (res.status >= 300 && res.status < 400)) {
     window.location.assign(args.request.url);

--- a/packages/pulse/python/src/pulse/messages.py
+++ b/packages/pulse/python/src/pulse/messages.py
@@ -1,6 +1,6 @@
 from typing import Any, Literal, NotRequired, TypedDict
 
-from pulse.routing import RouteInfo
+from pulse.routing import Location
 from pulse.transpiler.vdom import VDOM, VDOMNode, VDOMOperation
 
 
@@ -114,14 +114,14 @@ class ClientCallbackMessage(TypedDict):
 class ClientAttachMessage(TypedDict):
 	type: Literal["attach"]
 	path: str
-	routeInfo: RouteInfo
+	location: Location
 	attachId: NotRequired[str]
 
 
 class ClientUpdateMessage(TypedDict):
 	type: Literal["update"]
 	path: str
-	routeInfo: RouteInfo
+	location: Location
 
 
 class ClientDetachMessage(TypedDict):
@@ -193,7 +193,7 @@ ClientMessage = ClientPulseMessage | ClientChannelMessage
 
 class PrerenderPayload(TypedDict):
 	paths: list[str]
-	routeInfo: RouteInfo
+	location: Location
 	ttlSeconds: NotRequired[float | int]
 	renderId: NotRequired[str]
 

--- a/packages/pulse/python/src/pulse/middleware.py
+++ b/packages/pulse/python/src/pulse/middleware.py
@@ -98,16 +98,16 @@ class PulseMiddleware:
 
 	```python
 	class AuthMiddleware(ps.PulseMiddleware):
-	    async def prerender_route(
+	    async def prerender(
 	        self,
 	        *,
-	        path: str,
+	        payload: ps.PrerenderPayload,
 	        request: ps.PulseRequest,
-	        route_info: ps.RouteInfo,
 	        session: dict[str, Any],
 	        next,
 	    ):
-	        if path.startswith("/admin") and not session.get("is_admin"):
+	        pathname = payload["location"]["pathname"]
+	        if pathname.startswith("/admin") and not session.get("is_admin"):
 	            return ps.Redirect("/login")
 	        return await next()
 

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -4,7 +4,7 @@ import traceback
 import uuid
 from asyncio import iscoroutine
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Any, Literal, TypedDict, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast, overload
 
 from pulse.channel import Channel
 from pulse.context import PulseContext
@@ -24,9 +24,9 @@ from pulse.reactive_extensions import ReactiveDict
 from pulse.renderer import RenderTree
 from pulse.routing import (
 	Layout,
+	Location,
 	Route,
 	RouteContext,
-	RouteInfo,
 	RouteTree,
 	ensure_absolute_path,
 )
@@ -89,20 +89,6 @@ MountState = Literal["pending", "active", "suspended", "closed"]
 T_Render = TypeVar("T_Render")
 
 
-class SessionUrl(TypedDict):
-	"""The URL currently displayed by the session's browser tab.
-
-	A render session is one browser tab, so it has exactly one URL. Every
-	mount reports the same pathname/hash/query params (they all derive from
-	the client's single ``location``); only ``pathParams``/``catchall`` are
-	mount-specific, and those live on `RouteContext`.
-	"""
-
-	pathname: str
-	hash: str
-	queryParams: dict[str, str]
-
-
 class RouteMount:
 	render: "RenderSession"
 	path: str
@@ -125,11 +111,11 @@ class RouteMount:
 		render: "RenderSession",
 		path: str,
 		route: Route | Layout,
-		route_info: RouteInfo,
+		location: Location,
 	) -> None:
 		self.render = render
 		self.path = ensure_absolute_path(path)
-		self.route = RouteContext(route_info, route, self.path)
+		self.route = RouteContext(route, location, self.path)
 		self.effect = None
 		self._pulse_ctx = None
 		self.tree = RenderTree(route.render())
@@ -142,9 +128,6 @@ class RouteMount:
 		self.mount_id = uuid.uuid4().hex
 		self.render_batch_id = -1
 		self.render_batch_renders = 0
-
-	def update_route(self, route_info: RouteInfo) -> None:
-		self.route.update(route_info)
 
 	def renew_mount_id(self) -> None:
 		self.mount_id = uuid.uuid4().hex
@@ -265,7 +248,7 @@ class RenderSession:
 	forms: "FormRegistry"
 	query_store: QueryStore
 	route_mounts: dict[str, RouteMount]
-	url: SessionUrl
+	url: Location
 	query_param_sync: QueryParamSync
 	connected: bool
 	prerender_queue_timeout: float
@@ -303,10 +286,12 @@ class RenderSession:
 		self.routes = routes
 		self.route_mounts = {}
 		self.url = cast(
-			SessionUrl,
+			Location,
 			cast(
 				object,
-				ReactiveDict({"pathname": "", "hash": "", "queryParams": {}}),
+				ReactiveDict(
+					{"pathname": "", "hash": "", "query": "", "queryParams": {}}
+				),
 			),
 		)
 		self.query_param_sync = QueryParamSync(self)
@@ -486,7 +471,7 @@ class RenderSession:
 	# ---- Prerendering ----
 
 	def prerender(
-		self, paths: list[str], route_info: RouteInfo | None = None
+		self, paths: list[str], location: Location | None = None
 	) -> dict[str, ServerInitMessage | ServerNavigateToMessage]:
 		"""
 		Synchronous render for SSR. Returns per-path init or navigate_to messages.
@@ -498,21 +483,20 @@ class RenderSession:
 
 		for path in normalized:
 			route = self.routes.find(path)
-			info = route_info or route.default_route_info()
-			# Session-scoped URL data is split off at the message boundary;
-			# mounts only ever receive it, never report it back up.
-			self.set_url(info)
+			loc = location or route.default_location()
+			# The session owns the URL; set_url pushes derived route info
+			# down to every mount. Mounts never receive URL data directly.
+			self.set_url(loc)
 			mount = self.route_mounts.get(path)
 
 			if mount is None:
-				mount = RouteMount(self, path, route, info)
+				mount = RouteMount(self, path, route, loc)
 				self.route_mounts[path] = mount
 				mount.ensure_effect(lazy=True, flush=False)
 			else:
-				mount.update_route(info)
 				if mount.effect is None:
 					mount.ensure_effect(lazy=True, flush=False)
-				if route_info is not None and mount.state == "active":
+				if location is not None and mount.state == "active":
 					mount.start_pending(self.prerender_queue_timeout)
 
 			if mount.state != "active" and mount.queue_timeout is None:
@@ -531,12 +515,12 @@ class RenderSession:
 
 	# ---- Client lifecycle ----
 
-	def attach(self, path: str, route_info: RouteInfo) -> bool:
+	def attach(self, path: str, location: Location) -> bool:
 		"""
 		Client ready to receive updates for path.
 		- PENDING: flush queue, transition to ACTIVE
 		- SUSPENDED: re-render, send a fresh init, transition to ACTIVE
-		- ACTIVE: update route_info
+		- ACTIVE: update the session location
 		- No mount: request reload
 		Returns True when callbacks can be accepted for this path.
 		"""
@@ -548,8 +532,7 @@ class RenderSession:
 			self.send({"type": "reload"})
 			return False
 
-		self.set_url(route_info)
-		mount.update_route(route_info)
+		self.set_url(location)
 		if mount.state == "suspended":
 			return self._resume_mount(mount, path)
 		if mount.state == "pending" and self._send_message:
@@ -574,18 +557,18 @@ class RenderSession:
 		self.send(message)
 		return True
 
-	def update_route(self, path: str, route_info: RouteInfo):
+	def update_route(self, path: str, location: Location):
 		"""Update routing state (query params, etc.) for attached path."""
 		path = ensure_absolute_path(path)
 		mount = self.route_mounts.get(path)
 		if mount is None:
 			# No-op when mount does not exist yet.
-			# Route updates may arrive before prerender; prerender creates the mount with
-			# the authoritative RouteInfo, so replaying/stashing is unnecessary.
+			# Route updates may arrive before prerender; prerender creates the
+			# mount with the authoritative Location, so replaying/stashing is
+			# unnecessary.
 			return
 		try:
-			self.set_url(route_info)
-			mount.update_route(route_info)
+			self.set_url(location)
 			if mount.state == "pending" and self._send_message:
 				mount.activate(self._send_message)
 		except Exception as e:
@@ -747,21 +730,25 @@ class RenderSession:
 			raise ValueError(f"No active route for '{path}'")
 		return mount
 
-	def set_url(self, info: RouteInfo) -> None:
+	def set_url(self, location: Location) -> None:
 		"""Record the URL the client is currently displaying.
 
 		Called at the session's message boundaries (prerender/attach/
-		update_route) before the info is handed to a mount. Every client
-		message reports the same URL for the same navigation, so this is
-		last-writer-wins by design.
+		update_route). The session URL is the single source of truth: every
+		mount's route info is derived from it here, flowing strictly down
+		the ownership tree. Every client message reports the same URL for
+		the same navigation, so this is last-writer-wins by design.
 		"""
 		self.url.update(
 			{
-				"pathname": info["pathname"],
-				"hash": info["hash"],
-				"queryParams": info["queryParams"],
+				"pathname": location["pathname"],
+				"hash": location["hash"],
+				"query": location["query"],
+				"queryParams": location["queryParams"],
 			}
 		)
+		for mount in self.route_mounts.values():
+			mount.route.update(location)
 
 	def get_global_state(self, key: str, factory: Callable[[], Any]) -> Any:
 		"""Return a per-session singleton for the provided key."""

--- a/packages/pulse/python/src/pulse/routing.py
+++ b/packages/pulse/python/src/pulse/routing.py
@@ -2,6 +2,7 @@ import re
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import TypedDict, cast, override
+from urllib.parse import unquote
 
 from pulse.component import Component
 from pulse.env import env
@@ -246,8 +247,8 @@ class Route:
 			+ ")"
 		)
 
-	def default_route_info(self) -> "RouteInfo":
-		"""Return a default RouteInfo for this route.
+	def default_location(self) -> "Location":
+		"""Return a default Location for this route.
 
 		Only valid for non-dynamic routes. Raises InvalidRouteError if the
 		route contains any dynamic (":name"), optional ("segment?"), or
@@ -257,18 +258,79 @@ class Route:
 		# Disallow optional, dynamic, and catch-all segments on self and ancestors
 		if route_or_ancestors_have_dynamic(self):
 			raise InvalidRouteError(
-				f"Cannot build default RouteInfo for dynamic route '{self.path}'."
+				f"Cannot build default Location for dynamic route '{self.path}'."
 			)
 
-		pathname = self.unique_path()
 		return {
-			"pathname": pathname,
+			"pathname": self.unique_path(),
 			"hash": "",
 			"query": "",
 			"queryParams": {},
-			"pathParams": {},
-			"catchall": [],
 		}
+
+
+def url_pattern_segments(route: "Route | Layout") -> list[PathSegment]:
+	"""The URL segments a mount matches, from the root down to this route.
+
+	Layouts contribute no URL segments; only `Route.segments` along the
+	ancestor chain shape the URL.
+	"""
+	chain: list[Route | Layout] = []
+	node: Route | Layout | None = route
+	while node is not None:
+		chain.append(node)
+		node = node.parent
+	segments: list[PathSegment] = []
+	for ancestor in reversed(chain):
+		if isinstance(ancestor, Route):
+			segments.extend(ancestor.segments)
+	return segments
+
+
+def match_route_path(
+	route: "Route | Layout", pathname: str
+) -> tuple[dict[str, str], list[str]] | None:
+	"""Extract pathParams/catchall by matching the route's URL pattern
+	against a concrete pathname.
+
+	Mirrors React Router matching: static segments compare
+	case-insensitively against the raw pathname, matched params are
+	percent-decoded, optional segments are consumed greedily (the
+	expansion that includes them ranks higher), and a trailing splat
+	captures every remaining segment. URL segments beyond the pattern are
+	allowed — children of this route consume them.
+
+	Returns None when the pattern cannot match the pathname.
+	"""
+	segments = url_pattern_segments(route)
+	stripped = pathname.strip("/")
+	url_parts = stripped.split("/") if stripped else []
+
+	def matched_from(
+		seg_idx: int, url_idx: int, params: dict[str, str]
+	) -> tuple[dict[str, str], list[str]] | None:
+		if seg_idx == len(segments):
+			return params, []
+		seg = segments[seg_idx]
+		if seg.is_splat:
+			return params, [unquote(part) for part in url_parts[url_idx:]]
+		if url_idx < len(url_parts):
+			part = url_parts[url_idx]
+			if seg.is_dynamic:
+				result = matched_from(
+					seg_idx + 1, url_idx + 1, {**params, seg.name: unquote(part)}
+				)
+				if result is not None:
+					return result
+			elif part.lower() == seg.name.lower():
+				result = matched_from(seg_idx + 1, url_idx + 1, params)
+				if result is not None:
+					return result
+		if seg.is_optional:
+			return matched_from(seg_idx + 1, url_idx, params)
+		return None
+
+	return matched_from(0, 0, {})
 
 
 def filter_layouts(path_list: list[str]):
@@ -371,8 +433,8 @@ class Layout:
 	def __repr__(self) -> str:
 		return f"Layout(children={len(self.children)})"
 
-	def default_route_info(self) -> "RouteInfo":
-		"""Return a default RouteInfo corresponding to this layout's URL path.
+	def default_location(self) -> "Location":
+		"""Return a default Location corresponding to this layout's URL path.
 
 		The layout itself does not contribute a path segment. The resulting
 		pathname is the URL path formed by its ancestor routes. This method
@@ -382,19 +444,16 @@ class Layout:
 		# Walk up the tree to ensure there are no dynamic segments in ancestor routes
 		if route_or_ancestors_have_dynamic(self):
 			raise InvalidRouteError(
-				"Cannot build default RouteInfo for layout under a dynamic route."
+				"Cannot build default Location for layout under a dynamic route."
 			)
 
 		# Build pathname from ancestor route path segments (exclude layout indicators)
 		path_list = self._path_list(include_layouts=False)
-		pathname = ensure_absolute_path("/".join(path_list))
 		return {
-			"pathname": pathname,
+			"pathname": ensure_absolute_path("/".join(path_list)),
 			"hash": "",
 			"query": "",
 			"queryParams": {},
-			"pathParams": {},
-			"catchall": [],
 		}
 
 
@@ -513,6 +572,20 @@ class RouteInfo(TypedDict):
 	catchall: list[str]
 
 
+class Location(TypedDict):
+	"""The URL a browser tab is displaying.
+
+	This is everything the client reports about a navigation: one Location
+	per tab, sent at the session's message boundaries. Route-match data
+	(`pathParams`/`catchall`) is *derived* from it server-side, per mount.
+	"""
+
+	pathname: str
+	hash: str
+	query: str
+	queryParams: dict[str, str]
+
+
 class RouteContext:
 	"""Runtime context for the current route.
 
@@ -548,21 +621,56 @@ class RouteContext:
 
 	def __init__(
 		self,
-		info: RouteInfo,
 		pulse_route: Route | Layout,
+		location: Location,
 		route_path: str | None = None,
 	):
-		self.info = cast(RouteInfo, cast(object, ReactiveDict(info)))
 		self.pulse_route = pulse_route
 		self.route_path = ensure_absolute_path(route_path or pulse_route.unique_path())
+		matched = match_route_path(pulse_route, location["pathname"])
+		if matched is None:
+			raise ValueError(
+				f"Path '{location['pathname']}' does not match route '{self.route_path}'"
+			)
+		path_params, catchall = matched
+		self.info = cast(
+			RouteInfo,
+			cast(
+				object,
+				ReactiveDict(
+					{
+						"pathname": location["pathname"],
+						"hash": location["hash"],
+						"query": location["query"],
+						"queryParams": location["queryParams"],
+						"pathParams": path_params,
+						"catchall": catchall,
+					}
+				),
+			),
+		)
 
-	def update(self, info: RouteInfo) -> None:
-		"""Update the route info with new values.
+	def update(self, location: Location) -> None:
+		"""Derive fresh route info from the session's new location.
 
-		Args:
-			info: New route info to apply.
+		A location this mount's pattern does not match means the URL moved
+		on to another route and this mount is on its way out: it keeps its
+		last coherent snapshot instead of mixing old params with a new URL.
 		"""
-		self.info.update(info)
+		matched = match_route_path(self.pulse_route, location["pathname"])
+		if matched is None:
+			return
+		path_params, catchall = matched
+		self.info.update(
+			{
+				"pathname": location["pathname"],
+				"hash": location["hash"],
+				"query": location["query"],
+				"queryParams": location["queryParams"],
+				"pathParams": path_params,
+				"catchall": catchall,
+			}
+		)
 
 	@property
 	def pathname(self) -> str:

--- a/packages/pulse/python/tests/test_app_message_order.py
+++ b/packages/pulse/python/tests/test_app_message_order.py
@@ -44,13 +44,11 @@ async def test_socket_messages_for_render_are_serialized(
 				{
 					"type": "attach",
 					"path": "/",
-					"routeInfo": {
+					"location": {
 						"pathname": "/",
 						"hash": "",
 						"query": "",
 						"queryParams": {},
-						"pathParams": {},
-						"catchall": [],
 					},
 				}
 			),
@@ -117,13 +115,11 @@ async def test_attach_sends_ack_after_route_is_attached(
 		{
 			"type": "attach",
 			"path": "/",
-			"routeInfo": {
+			"location": {
 				"pathname": "/",
 				"hash": "",
 				"query": "",
 				"queryParams": {},
-				"pathParams": {},
-				"catchall": [],
 			},
 			"attachId": "attach-1",
 		},
@@ -156,13 +152,11 @@ async def test_attach_does_not_ack_when_route_needs_reload(
 		{
 			"type": "attach",
 			"path": "/",
-			"routeInfo": {
+			"location": {
 				"pathname": "/",
 				"hash": "",
 				"query": "",
 				"queryParams": {},
-				"pathParams": {},
-				"catchall": [],
 			},
 			"attachId": "attach-1",
 		},
@@ -193,13 +187,11 @@ async def test_socket_messages_wait_for_connect_to_finish(
 			{
 				"type": "attach",
 				"path": "/",
-				"routeInfo": {
+				"location": {
 					"pathname": "/",
 					"hash": "",
 					"query": "",
 					"queryParams": {},
-					"pathParams": {},
-					"catchall": [],
 				},
 			}
 		),

--- a/packages/pulse/python/tests/test_codegen.py
+++ b/packages/pulse/python/tests/test_codegen.py
@@ -246,7 +246,7 @@ class TestCodegen:
 
 		layout_content = (pulse_app_dir / "_layout.tsx").read_text()
 		assert (
-			'import { deserialize, extractServerRouteInfo, PulseProvider, type PulseConfig, type PulsePrerender } from "pulse-ui-client";'
+			'import { deserialize, extractServerLocation, PulseProvider, type PulseConfig, type PulsePrerender } from "pulse-ui-client";'
 			in layout_content
 		)
 		assert 'serverAddress: "http://localhost:8000"' in layout_content

--- a/packages/pulse/python/tests/test_forms.py
+++ b/packages/pulse/python/tests/test_forms.py
@@ -143,13 +143,11 @@ async def test_invalid_structured_form_payload_returns_400(
 				"/_pulse/prerender",
 				json={
 					"paths": ["/a"],
-					"routeInfo": {
+					"location": {
 						"pathname": "/a",
 						"hash": "",
 						"query": "",
 						"queryParams": {},
-						"pathParams": {},
-						"catchall": [],
 					},
 				},
 			)

--- a/packages/pulse/python/tests/test_hooks.py
+++ b/packages/pulse/python/tests/test_hooks.py
@@ -8,7 +8,7 @@ from pulse.hooks.stable import stable
 from pulse.hooks.state import state
 from pulse.reactive import Signal
 from pulse.render_session import RenderSession
-from pulse.routing import Route, RouteContext, RouteInfo, RouteTree
+from pulse.routing import Location, Route, RouteContext, RouteTree
 from pulse.state.state import State
 
 
@@ -30,18 +30,16 @@ class DummyState(State):
 
 def make_route_info(
 	pathname: str, *, query_params: dict[str, str] | None = None, hash: str = ""
-) -> RouteInfo:
+) -> Location:
 	return {
 		"pathname": pathname,
 		"hash": hash,
 		"query": "",
 		"queryParams": query_params or {},
-		"pathParams": {},
-		"catchall": [],
 	}
 
 
-def make_route_context(route_info: RouteInfo):
+def make_route_context(route_info: Location):
 	def render():
 		return ps.div()
 
@@ -49,7 +47,7 @@ def make_route_context(route_info: RouteInfo):
 	routes = RouteTree([route])
 	session = RenderSession("test", routes)
 	session.set_url(route_info)
-	route_ctx = RouteContext(route_info, route)
+	route_ctx = RouteContext(route, route_info)
 	app = ps.App(routes=[route])
 	return app, session, route_ctx, route
 

--- a/packages/pulse/python/tests/test_prerender_endpoint.py
+++ b/packages/pulse/python/tests/test_prerender_endpoint.py
@@ -24,13 +24,11 @@ async def test_prerender_normalizes_paths(monkeypatch: pytest.MonkeyPatch):
 			"/_pulse/prerender",
 			json={
 				"paths": ["a"],
-				"routeInfo": {
+				"location": {
 					"pathname": "/a",
 					"hash": "",
 					"query": "",
 					"queryParams": {},
-					"pathParams": {},
-					"catchall": [],
 				},
 			},
 		)

--- a/packages/pulse/python/tests/test_query_param.py
+++ b/packages/pulse/python/tests/test_query_param.py
@@ -8,7 +8,7 @@ import pytest
 from pulse.messages import ServerMessage, ServerNavigateToMessage
 from pulse.reactive import flush_effects
 from pulse.render_session import RenderSession
-from pulse.routing import Route, RouteInfo, RouteTree
+from pulse.routing import Location, Route, RouteTree
 
 
 class MissingType:
@@ -17,18 +17,16 @@ class MissingType:
 
 def make_route_info(
 	pathname: str, *, query_params: dict[str, str] | None = None, hash: str = ""
-) -> RouteInfo:
+) -> Location:
 	return {
 		"pathname": pathname,
 		"hash": hash,
 		"query": "",
 		"queryParams": query_params or {},
-		"pathParams": {},
-		"catchall": [],
 	}
 
 
-def make_context(route_info: RouteInfo):
+def make_context(route_info: Location):
 	def render():
 		return ps.div()
 

--- a/packages/pulse/python/tests/test_render_session.py
+++ b/packages/pulse/python/tests/test_render_session.py
@@ -19,7 +19,7 @@ from pulse.hooks.runtime import NotFoundInterrupt, RedirectInterrupt
 from pulse.messages import ServerMessage
 from pulse.reactive import Effect
 from pulse.render_session import RenderSession
-from pulse.routing import Route, RouteInfo, RouteTree
+from pulse.routing import Location, Route, RouteTree
 from pulse.test_helpers import wait_for
 from pulse.transpiler.nodes import Element, PulseNode
 
@@ -64,16 +64,12 @@ def make_routes() -> RouteTree:
 	return RouteTree([route_a, route_b])
 
 
-def make_route_info(
-	pathname: str, *, path_params: dict[str, str] | None = None
-) -> RouteInfo:
+def make_route_info(pathname: str) -> Location:
 	return {
 		"pathname": pathname,
 		"hash": "",
 		"query": "",
 		"queryParams": {},
-		"pathParams": path_params or {},
-		"catchall": [],
 	}
 
 
@@ -613,7 +609,7 @@ def test_route_bound_navigation_uses_current_path_for_dynamic_routes():
 	session = RenderSession("test-id", routes)
 	messages: list[ServerMessage] = []
 	session.connect(messages.append)
-	route_info = make_route_info("/items/123", path_params={"id": "123"})
+	route_info = make_route_info("/items/123")
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/items/:id"], route_info)
@@ -636,29 +632,33 @@ def test_route_bound_navigation_uses_current_path_for_dynamic_routes():
 
 
 def test_route_bound_navigation_validates_source_route_identity():
-	routes = RouteTree([Route("a", simple_component), Route("b", simple_component)])
+	# Both routes match the pathname "/shared": navigation attribution must
+	# distinguish them by route path, not by pathname alone.
+	routes = RouteTree(
+		[Route("shared", simple_component), Route(":slug", simple_component)]
+	)
 	session = RenderSession("test-id", routes)
 	messages: list[ServerMessage] = []
 	session.connect(messages.append)
 	route_info = make_route_info("/shared")
 
 	with ps.PulseContext.update(render=session):
-		session.prerender(["/a"], route_info)
-		session.attach("/a", route_info)
-		session.prerender(["/b"], route_info)
-		session.attach("/b", route_info)
+		session.prerender(["/shared"], route_info)
+		session.attach("/shared", route_info)
+		session.prerender(["/:slug"], route_info)
+		session.attach("/:slug", route_info)
 
-	mount = session.route_mounts["/a"]
+	mount = session.route_mounts["/shared"]
 	with ps.PulseContext.update(
 		render=session,
 		route=mount.route,
 		source_route_path=mount.route.route_path,
 		source_path=mount.route.pathname,
 	):
-		session.detach("/a")
+		session.detach("/shared")
 		ps.navigate("/after")
 
-	assert "/b" in session.route_mounts
+	assert "/:slug" in session.route_mounts
 	assert not [msg for msg in messages if msg["type"] == "navigate_to"]
 
 	session.close()
@@ -727,8 +727,8 @@ async def test_async_callback_navigation_after_route_update_is_ignored_by_defaul
 	session = RenderSession("test-id", routes)
 	messages: list[ServerMessage] = []
 	session.connect(messages.append)
-	first_info = make_route_info("/items/123", path_params={"id": "123"})
-	next_info = make_route_info("/items/456", path_params={"id": "456"})
+	first_info = make_route_info("/items/123")
+	next_info = make_route_info("/items/456")
 
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/items/:id"], first_info)
@@ -944,13 +944,11 @@ async def test_route_info_updated_on_reconnect():
 	messages: list[ServerMessage] = []
 	session.connect(lambda msg: messages.append(msg))
 
-	route_info1: RouteInfo = {
+	route_info1: Location = {
 		"pathname": "/a",
 		"hash": "",
 		"query": "foo=bar",
 		"queryParams": {"foo": "bar"},
-		"pathParams": {},
-		"catchall": [],
 	}
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"], route_info1)
@@ -965,13 +963,11 @@ async def test_route_info_updated_on_reconnect():
 	# Reconnect with different query params
 	session.connect(lambda msg: messages.append(msg))
 
-	route_info2: RouteInfo = {
+	route_info2: Location = {
 		"pathname": "/a",
 		"hash": "",
 		"query": "baz=qux",
 		"queryParams": {"baz": "qux"},
-		"pathParams": {},
-		"catchall": [],
 	}
 	with ps.PulseContext.update(render=session):
 		session.attach("/a", route_info2)
@@ -1869,13 +1865,11 @@ async def test_update_route_updates_route_context():
 	messages: list[ServerMessage] = []
 	session.connect(lambda msg: messages.append(msg))
 
-	initial_info: RouteInfo = {
+	initial_info: Location = {
 		"pathname": "/a",
 		"hash": "",
 		"query": "x=1",
 		"queryParams": {"x": "1"},
-		"pathParams": {},
-		"catchall": [],
 	}
 	with ps.PulseContext.update(render=session):
 		session.prerender(["/a"], initial_info)
@@ -1885,13 +1879,11 @@ async def test_update_route_updates_route_context():
 	assert mount.route.query == "x=1"
 
 	# Update route
-	updated_info: RouteInfo = {
+	updated_info: Location = {
 		"pathname": "/a",
 		"hash": "section",
 		"query": "y=2",
 		"queryParams": {"y": "2"},
-		"pathParams": {},
-		"catchall": [],
 	}
 	session.update_route("/a", updated_info)
 

--- a/packages/pulse/python/tests/test_route_matching.py
+++ b/packages/pulse/python/tests/test_route_matching.py
@@ -1,0 +1,187 @@
+import pulse as ps
+import pytest
+from pulse.render_session import RenderSession
+from pulse.routing import (
+	Layout,
+	Location,
+	Route,
+	RouteContext,
+	RouteTree,
+	match_route_path,
+)
+
+
+@ps.component
+def Page():
+	return ps.div()
+
+
+def build(*routes: Route | Layout) -> RouteTree:
+	return RouteTree(list(routes))
+
+
+class TestMatchRoutePath:
+	def test_static(self):
+		route = Route("users", Page)
+		build(route)
+		assert match_route_path(route, "/users") == ({}, [])
+		assert match_route_path(route, "/other") is None
+
+	def test_static_case_insensitive(self):
+		route = Route("Users", Page)
+		build(route)
+		assert match_route_path(route, "/users") == ({}, [])
+
+	def test_dynamic_param(self):
+		route = Route("users/:id", Page)
+		build(route)
+		assert match_route_path(route, "/users/123") == ({"id": "123"}, [])
+		assert match_route_path(route, "/users") is None
+
+	def test_param_is_percent_decoded(self):
+		route = Route("files/:name", Page)
+		build(route)
+		assert match_route_path(route, "/files/a%20b") == ({"name": "a b"}, [])
+
+	def test_static_prefix_allows_children_segments(self):
+		child = Route(":id", Page)
+		parent = Route("users", Page, children=[child])
+		build(parent)
+		# The parent mount matches even though the URL goes deeper.
+		assert match_route_path(parent, "/users/123") == ({}, [])
+		assert match_route_path(child, "/users/123") == ({"id": "123"}, [])
+
+	def test_nested_params_accumulate(self):
+		child = Route(":repo", Page)
+		parent = Route("orgs/:org", Page, children=[child])
+		build(parent)
+		assert match_route_path(child, "/orgs/pulse/ui") == (
+			{"org": "pulse", "repo": "ui"},
+			[],
+		)
+
+	def test_layout_contributes_no_segments(self):
+		leaf = Route(":id", Page)
+		layout = Layout(Page, children=[leaf])
+		parent = Route("users", Page, children=[layout])
+		build(parent)
+		assert match_route_path(layout, "/users/123") == ({}, [])
+		assert match_route_path(leaf, "/users/123") == ({"id": "123"}, [])
+
+	def test_optional_dynamic(self):
+		route = Route("posts/:page?", Page)
+		build(route)
+		assert match_route_path(route, "/posts/2") == ({"page": "2"}, [])
+		assert match_route_path(route, "/posts") == ({}, [])
+
+	def test_optional_static(self):
+		route = Route("settings/advanced?", Page)
+		build(route)
+		assert match_route_path(route, "/settings/advanced") == ({}, [])
+		assert match_route_path(route, "/settings") == ({}, [])
+
+	def test_optional_prefers_consuming(self):
+		route = Route("a/:b?/:c?", Page)
+		build(route)
+		# Same expansion ranking as React Router: params present win.
+		assert match_route_path(route, "/a/x") == ({"b": "x"}, [])
+		assert match_route_path(route, "/a/x/y") == ({"b": "x", "c": "y"}, [])
+		assert match_route_path(route, "/a") == ({}, [])
+
+	def test_splat_catchall(self):
+		route = Route("docs/*", Page)
+		build(route)
+		assert match_route_path(route, "/docs/a/b/c") == ({}, ["a", "b", "c"])
+		assert match_route_path(route, "/docs") == ({}, [])
+
+	def test_splat_segments_decoded(self):
+		route = Route("docs/*", Page)
+		build(route)
+		assert match_route_path(route, "/docs/a%20b/c") == ({}, ["a b", "c"])
+
+	def test_root_route(self):
+		route = Route("/", Page)
+		build(route)
+		assert match_route_path(route, "/") == ({}, [])
+		# Root is a prefix of everything.
+		assert match_route_path(route, "/anything") == ({}, [])
+
+	def test_param_and_splat(self):
+		route = Route(":lang/docs/*", Page)
+		build(route)
+		assert match_route_path(route, "/en/docs/api/v2") == (
+			{"lang": "en"},
+			["api", "v2"],
+		)
+
+
+class TestDerivedRouteInfo:
+	"""The session URL is the single source of truth: every mount's route
+	info is derived server-side from it, never supplied by the client."""
+
+	def make_session(self):
+		detail = Route(":id", Page)
+		items = Route("items", Page, children=[detail])
+		docs = Route("docs/*", Page)
+		routes = RouteTree([items, docs])
+		return RenderSession("test", routes)
+
+	def location(
+		self, pathname: str, query_params: dict[str, str] | None = None
+	) -> Location:
+		return {
+			"pathname": pathname,
+			"hash": "",
+			"query": "",
+			"queryParams": query_params or {},
+		}
+
+	def test_path_params_derived_on_prerender(self):
+		session = self.make_session()
+		session.prerender(["/items/:id"], self.location("/items/123"))
+		ctx = session.route_mounts["/items/:id"].route
+		assert ctx.pathParams == {"id": "123"}
+		assert ctx.pathname == "/items/123"
+		session.close()
+
+	def test_catchall_derived_on_prerender(self):
+		session = self.make_session()
+		session.prerender(["/docs/*"], self.location("/docs/a/b"))
+		ctx = session.route_mounts["/docs/*"].route
+		assert ctx.catchall == ["a", "b"]
+		session.close()
+
+	def test_set_url_pushes_to_every_matching_mount(self):
+		session = self.make_session()
+		loc = self.location("/items/123")
+		session.prerender(["/items", "/items/:id"], loc)
+		parent = session.route_mounts["/items"].route
+		child = session.route_mounts["/items/:id"].route
+
+		session.update_route(
+			"/items/:id", self.location("/items/456", {"tab": "specs"})
+		)
+		assert child.pathParams == {"id": "456"}
+		assert child.queryParams == {"tab": "specs"}
+		# The parent mount was updated too, without its own client message.
+		assert parent.pathname == "/items/456"
+		assert parent.queryParams == {"tab": "specs"}
+		session.close()
+
+	def test_non_matching_mount_keeps_last_snapshot(self):
+		session = self.make_session()
+		session.prerender(["/items/:id"], self.location("/items/123"))
+		ctx = session.route_mounts["/items/:id"].route
+
+		# Navigation overlap: the URL moves on to a route this mount does not
+		# match while the mount is still alive.
+		session.prerender(["/docs/*"], self.location("/docs/guide"))
+		assert ctx.pathname == "/items/123"
+		assert ctx.pathParams == {"id": "123"}
+		session.close()
+
+	def test_route_context_rejects_non_matching_pathname(self):
+		detail = Route("items/:id", Page)
+		build(detail)
+		with pytest.raises(ValueError, match="does not match route"):
+			RouteContext(detail, self.location("/other/1"))

--- a/packages/pulse/python/tests/test_socket_lifecycle.py
+++ b/packages/pulse/python/tests/test_socket_lifecycle.py
@@ -43,14 +43,12 @@ def connect_handler(app: ps.App) -> ConnectHandler:
 	return cast(ConnectHandler, app.sio.handlers["/"]["connect"])
 
 
-def make_route_info(pathname: str) -> ps.RouteInfo:
+def make_route_info(pathname: str) -> ps.Location:
 	return {
 		"pathname": pathname,
 		"hash": "",
 		"query": "",
 		"queryParams": {},
-		"pathParams": {},
-		"catchall": [],
 	}
 
 
@@ -136,7 +134,7 @@ async def test_reconnect_before_disconnect_resyncs_mount_and_stale_queries(
 			{
 				"type": "attach",
 				"path": "/",
-				"routeInfo": make_route_info("/"),
+				"location": make_route_info("/"),
 				"attachId": "attach-a",
 			}
 		),
@@ -196,7 +194,7 @@ async def test_reconnect_before_disconnect_resyncs_mount_and_stale_queries(
 			{
 				"type": "attach",
 				"path": "/",
-				"routeInfo": make_route_info("/"),
+				"location": make_route_info("/"),
 				"attachId": "attach-b",
 			}
 		),

--- a/packages/pulse/python/tests/test_user_session.py
+++ b/packages/pulse/python/tests/test_user_session.py
@@ -155,13 +155,11 @@ async def test_prerender_request_retains_user_session(
 			"/_pulse/prerender",
 			json={
 				"paths": ["/a"],
-				"routeInfo": {
+				"location": {
 					"pathname": "/a",
 					"hash": "",
 					"query": "",
 					"queryParams": {},
-					"pathParams": {},
-					"catchall": [],
 				},
 			},
 		)

--- a/skills/pulse/references/context.md
+++ b/skills/pulse/references/context.md
@@ -90,6 +90,8 @@ def user_page():
 - `pathParams` - Dynamic path parameters (e.g., `{"id": "123"}`)
 - `catchall` - Catch-all segments as list
 
+The client only reports the URL (`ps.Location`: pathname, hash, query, queryParams); `pathParams` and `catchall` are derived server-side by matching the route's pattern against the pathname.
+
 ### `ps.pulse_route()`
 
 Get the current route definition.

--- a/skills/pulse/references/middleware.md
+++ b/skills/pulse/references/middleware.md
@@ -10,8 +10,8 @@ Inherit from `ps.PulseMiddleware` and override methods:
 from typing import override
 import pulse as ps
 from pulse.middleware import ConnectResponse, Ok, Redirect, NotFound, Deny
+from pulse.messages import PrerenderPayload
 from pulse.request import PulseRequest
-from pulse.routing import RouteInfo
 
 
 class AuthMiddleware(ps.PulseMiddleware):
@@ -26,22 +26,22 @@ class AuthMiddleware(ps.PulseMiddleware):
         # WebSocket connection handshake
         token = request.headers.get("authorization")
         if not self._validate_token(token):
-            return Deny("Invalid token")
+            return Deny()
         session["user"] = self._decode_token(token)
         return await next()
 
     @override
-    async def prerender_route(
+    async def prerender(
         self,
         *,
-        path: str,
-        route_info: RouteInfo,
+        payload: PrerenderPayload,
         request: PulseRequest,
         session: dict,
         next,
-    ) -> ps.RoutePrerenderResponse:
-        # Before rendering route (SSR)
-        if path.startswith("/admin") and not session.get("is_admin"):
+    ) -> ps.PrerenderResponse:
+        # Before rendering (SSR). payload["location"] is the browser URL.
+        pathname = payload["location"]["pathname"]
+        if pathname.startswith("/admin") and not session.get("is_admin"):
             return Redirect("/login")
         return await next()
 
@@ -61,7 +61,7 @@ class AuthMiddleware(ps.PulseMiddleware):
 
 ### `prerender`
 
-Called before batch SSR prerender for all paths in the request. Modify the payload, inject session data, or return early with redirects.
+Called before batch SSR prerender for all paths in the request. Inject session data, gate access, or modify the result before returning.
 
 ```python
 from pulse.messages import PrerenderPayload, Prerender
@@ -75,8 +75,8 @@ async def prerender(
     session: dict,
     next,
 ) -> ps.PrerenderResponse:
-    # payload.paths: list of paths being prerendered
-    # payload.routeInfo: route metadata
+    # payload["paths"]: list of route paths being prerendered
+    # payload["location"]: browser URL — {"pathname", "hash", "query", "queryParams"}
 
     # Inject data into session before render
     session["user"] = await get_user(request)
@@ -99,9 +99,9 @@ async def prerender(
 
 **Returns:** `await next()`, `Redirect(path)`, `NotFound()`, `Ok(Prerender)`
 
-**Payload fields:**
-- `paths`: List of paths being prerendered
-- `routeInfo`: Route metadata (params, query, etc.)
+**Payload fields (TypedDict):**
+- `paths`: List of route paths being prerendered
+- `location`: The browser URL (`pathname`, `hash`, `query`, `queryParams`). Per-mount `pathParams`/`catchall` are derived server-side from it.
 - `ttlSeconds`: Optional cache TTL
 - `renderId`: Optional render correlation ID
 
@@ -121,7 +121,7 @@ async def connect(
     # Extract auth from headers/cookies
     token = request.cookies.get("auth_token")
     if not token:
-        return Deny("Not authenticated")
+        return Deny()  # Not authenticated
 
     user = await verify_token(token)
     session["user"] = user
@@ -130,39 +130,7 @@ async def connect(
     return await next()  # Continue to app
 ```
 
-**Returns:** `await next()` or `Deny(reason)`
-
-### `prerender_route`
-
-Called before SSR render. Redirect unauthenticated users, inject session data.
-
-```python
-@override
-async def prerender_route(
-    self,
-    *,
-    path: str,
-    route_info: RouteInfo,
-    request: PulseRequest,
-    session: dict,
-    next,
-) -> ps.RoutePrerenderResponse:
-    # Protected routes
-    protected = ["/dashboard", "/settings", "/admin"]
-    if any(path.startswith(p) for p in protected):
-        if not session.get("user"):
-            return Redirect("/login")
-
-    # Admin-only
-    if path.startswith("/admin"):
-        user = session.get("user", {})
-        if not user.get("is_admin"):
-            return NotFound()
-
-    return await next()
-```
-
-**Returns:** `await next()`, `Redirect(path)`, `NotFound()`, `Ok(response)`
+**Returns:** `await next()` or `Deny()`
 
 ### `message`
 
@@ -181,7 +149,7 @@ async def message(
 
     # Rate limiting
     if not self._check_rate_limit(session):
-        return Deny("Rate limited")
+        return Deny()  # Rate limited
 
     # Logging
     print(f"[{session.get('user_id')}] {msg_type}")
@@ -189,7 +157,7 @@ async def message(
     return await next()
 ```
 
-**Returns:** `await next()` or `Deny(reason)`
+**Returns:** `await next()` or `Deny()`
 
 ### `channel`
 
@@ -239,11 +207,10 @@ async def channel(
 ```python
 from pulse.middleware import Ok, Redirect, NotFound, Deny
 
-Ok(response)      # Success with custom response
+Ok(payload)       # Success (Ok(None) for void success)
 Redirect(path)    # Redirect to path
-Redirect(path, replace=True)  # Replace history
 NotFound()        # 404 response
-Deny(reason)      # Reject request
+Deny()            # Reject request
 ```
 
 ## Request Object
@@ -339,9 +306,10 @@ class AuthMiddleware(ps.PulseMiddleware):
         return await next()
 
     @override
-    async def prerender_route(self, *, path, session, **kwargs):
+    async def prerender(self, *, payload, session, **kwargs):
         public = ["/", "/login", "/signup", "/public"]
-        if path not in public and not session.get("user"):
+        pathname = payload["location"]["pathname"]
+        if pathname not in public and not session.get("user"):
             return Redirect("/login")
         return await kwargs["next"]()
 ```
@@ -351,11 +319,12 @@ class AuthMiddleware(ps.PulseMiddleware):
 ```python
 class LoggingMiddleware(ps.PulseMiddleware):
     @override
-    async def prerender_route(self, *, path, request, **kwargs):
+    async def prerender(self, *, payload, request, **kwargs):
         start = time.time()
         result = await kwargs["next"]()
         duration = time.time() - start
-        print(f"[{request.client[0]}] {path} {duration:.3f}s")
+        pathname = payload["location"]["pathname"]
+        print(f"[{request.client[0]}] {pathname} {duration:.3f}s")
         return result
 ```
 
@@ -366,25 +335,26 @@ class RBACMiddleware(ps.PulseMiddleware):
     ADMIN_PATHS = ["/admin", "/settings/admin"]
 
     @override
-    async def prerender_route(self, *, path, session, **kwargs):
-        if any(path.startswith(p) for p in self.ADMIN_PATHS):
+    async def prerender(self, *, payload, session, **kwargs):
+        pathname = payload["location"]["pathname"]
+        if any(pathname.startswith(p) for p in self.ADMIN_PATHS):
             user = session.get("user", {})
             if user.get("role") != "admin":
                 return NotFound()
         return await kwargs["next"]()
 ```
 
-### CORS Headers
+### Custom Connection Directives
 
-Usually handled by FastAPI, but custom headers:
+Modify the prerender result's directives (headers sent on subsequent requests):
 
 ```python
-class CORSMiddleware(ps.PulseMiddleware):
+class DirectivesMiddleware(ps.PulseMiddleware):
     @override
-    async def prerender_route(self, *, request, **kwargs):
+    async def prerender(self, *, request, **kwargs):
         result = await kwargs["next"]()
         if isinstance(result, Ok):
-            result.response.headers["Access-Control-Allow-Origin"] = "*"
+            result.payload["directives"]["headers"]["x-custom"] = "value"
         return result
 ```
 

--- a/skills/pulse/references/sessions.md
+++ b/skills/pulse/references/sessions.md
@@ -288,8 +288,9 @@ class AuthMiddleware(ps.PulseMiddleware):
         return await next()
 
     @override
-    async def prerender_route(self, *, path, session, **kwargs):
-        if path.startswith("/admin") and not session.get("user"):
+    async def prerender(self, *, payload, session, **kwargs):
+        pathname = payload["location"]["pathname"]
+        if pathname.startswith("/admin") and not session.get("user"):
             return Redirect("/login")
         return await kwargs["next"]()
 ```

--- a/web/app/pulse/_layout.tsx
+++ b/web/app/pulse/_layout.tsx
@@ -1,4 +1,4 @@
-import { deserialize, extractServerRouteInfo, PulseProvider, type PulseConfig, type PulsePrerender } from "pulse-ui-client";
+import { deserialize, extractServerLocation, PulseProvider, type PulseConfig, type PulsePrerender } from "pulse-ui-client";
 import { Outlet, data, type LoaderFunctionArgs, type ClientLoaderFunctionArgs } from "react-router";
 import { matchRoutes } from "react-router";
 import { rrPulseRouteTree } from "./routes.runtime";
@@ -34,7 +34,7 @@ export async function loader(args: LoaderFunctionArgs) {
   const res = await fetch(`${internalServerAddress}${config.apiPrefix}/prerender`, {
     method: "POST",
     headers: fwd,
-    body: JSON.stringify({ paths, routeInfo: extractServerRouteInfo(args) }),
+    body: JSON.stringify({ paths, location: extractServerLocation(args) }),
   });
   if (!res.ok) throw new Error("Failed to prerender batch:" + res.status);
   const body = await res.json();
@@ -71,7 +71,7 @@ export async function clientLoader(args: ClientLoaderFunctionArgs) {
     method: "POST",
     headers,
     credentials: "include",
-    body: JSON.stringify({ paths, routeInfo: extractServerRouteInfo(args) }),
+    body: JSON.stringify({ paths, location: extractServerLocation(args) }),
   });
   if (!res.ok) throw new Error("Failed to prerender batch:" + res.status);
   const body = await res.json();


### PR DESCRIPTION
## Overview

[PR #123](https://github.com/erwinkn/pulse-ui/pull/123) is the second pull request in the two-part stack. It makes the session URL the single source of truth for route state. The client stops sending `pathParams` and `catchall`. The server derives them from the URL.

> [!IMPORTANT]
> Review [PR #122](https://github.com/erwinkn/pulse-ui/pull/122) first. Then, review [PR #123](https://github.com/erwinkn/pulse-ui/pull/123).

After this pull request, the client reports one `Location` per tab, and every mount's route info is a server-side derivation from it.

### Decision map

| # | Decision | Result |
|---:|---|---|
| 1 | Match route patterns on the server | `match_route_path` in `routing.py` extracts `pathParams` and `catchall` from a pathname. |
| 2 | Reduce the wire payload to the URL | `ClientAttachMessage`, `ClientUpdateMessage`, and `PrerenderPayload` carry `location: Location` with `pathname`, `hash`, `query`, and `queryParams`. |
| 3 | Make `set_url` the single writer | `RenderSession.set_url` updates the reactive session URL and calls `RouteContext.update` on every mount. |
| 4 | Freeze non-matching mounts | `RouteContext.update` keeps the last snapshot when the new pathname does not match the mount's pattern. |
| 5 | Drop `useParams` on the client | `PulseView` builds `PulseLocation` from `useLocation()` only. `extractServerLocation` replaces `extractServerRouteInfo`. |
| 6 | Keep the raw query string | `Location` and the session URL include `query`, which backs `RouteContext.query`. |

## Review walkthrough

Review Steps 1 through 6. The order follows the data flow from the route matcher to the client.

> [!TIP]
> Each file panel links to the GitHub diff. Inline diffs show literal excerpts only. Use Files changed for comments.

| Changed files | Diff | Focused tests | Stack position |
|---:|---:|---:|---:|
| 45 | +589 / −369 | `pytest tests/` 1698 passed | 2 of 2 |

`WHY` gives the problem. `PRINCIPLE` gives the design rule. `STEP` gives the review order. `KEPT` gives deliberate non-changes.

<details>
<summary><kbd>WHY</kbd> <strong>0: Starting point</strong> - the server stored client-computed route data it could derive itself.</summary>

<br />

- The client sent a full `RouteInfo` per mount on `attach`, `update`, and the prerender POST.
- `pathParams` and `catchall` came from React Router `useParams()` in `PulseView` and from loader `params` in `extractServerRouteInfo`.
- The `catchall` computations disagreed: `pulse.tsx` split on `length > 0` and `helpers.ts` split on `length > 1`. A single-character splat produced different results on the socket path and the loader path.
- The server stored one denormalized `RouteInfo` copy per mount and trusted the client values.
- The server already knows the `RouteTree` and each mount's pattern, so the match data is a pure function of the URL.

</details>

<details>
<summary><kbd>PRINCIPLE</kbd> <strong>Design rule</strong> - one tab has one URL, and route-match data is a derivation of it.</summary>

<br />

- The client reports only `Location`: `pathname`, `hash`, `query`, and `queryParams`.
- `RenderSession.set_url` is the single writer of URL state. Data flows down: `set_url` → session `url` → `RouteContext.info`.
- `match_route_path` computes `pathParams` and `catchall` from the pathname and the route pattern.

</details>

<details>
<summary><kbd>STEP 1</kbd> <strong>The server-side matcher</strong> - <code>match_route_path</code> mirrors React Router matching.</summary>

<br />

**Before this PR.** The server had no pathname matcher. `RouteTree.find` only did an exact dictionary lookup on the route's `unique_path()` key.

**This PR.** `routing.py` adds `url_pattern_segments` and `match_route_path`. The matcher walks the `Route.segments` chain from the root. It compares static segments case-insensitively. It percent-decodes matched parameter values. It consumes optional segments greedily. A trailing splat captures every remaining segment. The matcher permits URL segments beyond the pattern, because child routes consume them.

<details>
<summary><kbd>MODIFIED</kbd> <strong>packages/pulse/python/src/pulse/routing.py</strong> - add <code>Location</code>, <code>url_pattern_segments</code>, and <code>match_route_path</code>.</summary>

<br />

The matcher works on `Route.segments`, not on the mount key. The mount key rewrites `?` to `^` (`unique_path()`), so the key string is not a valid pattern.

```diff
+def match_route_path(
+	route: "Route | Layout", pathname: str
+) -> tuple[dict[str, str], list[str]] | None:
+	"""Extract pathParams/catchall by matching the route's URL pattern
+	against a concrete pathname.
```

`Location` is the new wire type:

```diff
+class Location(TypedDict):
+	"""The URL a browser tab is displaying.
+
+	This is everything the client reports about a navigation: one Location
+	per tab, sent at the session's message boundaries. Route-match data
+	(`pathParams`/`catchall`) is *derived* from it server-side, per mount.
+	"""
+
+	pathname: str
+	hash: str
+	query: str
+	queryParams: dict[str, str]
```

`Route.default_location` and `Layout.default_location` replace `default_route_info`. They return the reduced shape and keep the `InvalidRouteError` guard for dynamic routes.

[Open the `routing.py` diff](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-fa5aa9f586a082010cc3d2151dc0ff10fe2a94737af1b82a73eb144f39311c27)

</details>

<details>
<summary><kbd>NEW</kbd> <strong>packages/pulse/python/tests/test_route_matching.py</strong> - 19 tests for matcher parity and derivation.</summary>

<br />

`TestMatchRoutePath` covers these pattern cases:

- static segments and case-insensitive matching
- dynamic parameters and percent-decoding
- parent-prefix matching, nested parameter accumulation, and layouts
- optional static segments, optional dynamic segments, and greedy optional consumption
- splats, decoded splat segments, the root route, and a parameter combined with a splat

`TestDerivedRouteInfo` covers the session-level behavior in Step 3.

[Open the `test_route_matching.py` diff](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-2cbc7e21dbc4bb6039a6fe5782da1b698ef483c0cea1902eba8a8f6c687640eb)

</details>

</details>

<details>
<summary><kbd>STEP 2</kbd> <strong><code>RouteContext</code> derives its info</strong> - construction matches, updates derive or freeze.</summary>

<br />

**Before this PR.** `RouteContext.__init__` copied the client-sent `RouteInfo` into a `ReactiveDict`. `RouteContext.update` overwrote it with the next client payload.

**This PR.** `RouteContext.__init__` takes `(pulse_route, location, route_path)`. It calls `match_route_path` and raises `ValueError` when the pathname does not match the pattern. `RouteContext.update(location)` re-derives `pathParams` and `catchall`. When the new pathname does not match, `update` returns without changes, so the mount keeps its last coherent snapshot during navigation overlap.

<details>
<summary><kbd>MODIFIED</kbd> <strong>packages/pulse/python/src/pulse/routing.py</strong> - <code>RouteContext.update</code> freezes on a non-matching pathname.</summary>

<br />

```diff
+	def update(self, location: Location) -> None:
+		"""Derive fresh route info from the session's new location.
+
+		A location this mount's pattern does not match means the URL moved
+		on to another route and this mount is on its way out: it keeps its
+		last coherent snapshot instead of mixing old params with a new URL.
+		"""
+		matched = match_route_path(self.pulse_route, location["pathname"])
+		if matched is None:
+			return
```

[Open the `routing.py` diff](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-fa5aa9f586a082010cc3d2151dc0ff10fe2a94737af1b82a73eb144f39311c27)

</details>

</details>

<details>
<summary><kbd>STEP 3</kbd> <strong><code>set_url</code> becomes the single writer</strong> - one call refreshes the session URL and every mount.</summary>

<br />

**Before this PR.** `RenderSession.set_url` only updated the session `url` dict. Each mount refreshed its own info through `RouteMount.update_route`, one client message per mount.

**This PR.** `set_url` updates the session `url` (now including `query`) and calls `RouteContext.update(location)` on every mount. `RouteMount.update_route` is gone. `RenderSession.prerender`, `attach`, and `update_route` take a `Location`. The `SessionUrl` TypedDict is gone, because `Location` replaces it.

<details>
<summary><kbd>MODIFIED</kbd> <strong>packages/pulse/python/src/pulse/render_session.py</strong> - push derived info down from <code>set_url</code>.</summary>

<br />

```diff
-	def update_route(self, route_info: RouteInfo) -> None:
-		self.route.update(route_info)
-
 	def renew_mount_id(self) -> None:
```

```diff
 		try:
-			self.set_url(route_info)
-			mount.update_route(route_info)
+			self.set_url(location)
 			if mount.state == "pending" and self._send_message:
 				mount.activate(self._send_message)
```

`set_url` copies the four `Location` keys explicitly, so a richer dict cannot leak extra keys into the session URL:

```diff
+		self.url.update(
+			{
+				"pathname": location["pathname"],
+				"hash": location["hash"],
+				"query": location["query"],
+				"queryParams": location["queryParams"],
+			}
+		)
+		for mount in self.route_mounts.values():
+			mount.route.update(location)
```

[Open the `render_session.py` diff](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-263bcf52ab01cc66ac78d1d6bb9f9e072f48d6eb72fc2d915fad34243eac3026)

</details>

</details>

<details>
<summary><kbd>STEP 4</kbd> <strong>The wire format</strong> - <code>attach</code>, <code>update</code>, and the prerender payload carry <code>location</code>.</summary>

<br />

**Before this PR.** `ClientAttachMessage`, `ClientUpdateMessage`, and `PrerenderPayload` carried `routeInfo: RouteInfo` with six fields.

**This PR.** The messages carry `location: Location` with four fields. `app.py` reads `payload.get("location")` in the prerender endpoint and `msg["location"]` in the socket handlers. The `PulseMiddleware` docstring example reads `payload["location"]["pathname"]` instead of the removed `prerender_route` hook.

<details>
<summary><kbd>MODIFIED</kbd> <strong>packages/pulse/python/src/pulse/messages.py</strong> - rename the payload field and type.</summary>

<br />

```diff
 class ClientAttachMessage(TypedDict):
 	type: Literal["attach"]
 	path: str
-	routeInfo: RouteInfo
+	location: Location
 	attachId: NotRequired[str]
```

[Open the `messages.py` diff](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-a06626912c6bc5575807ffa0265707e433637ea838f1bf5fb7152beb72d771dc)

</details>

<details>
<summary><kbd>MODIFIED</kbd> <strong>packages/pulse/python/src/pulse/app.py</strong> - read <code>location</code> in the prerender endpoint and socket handlers.</summary>

<br />

`prerender` passes `location` to `render.prerender(paths, location)`. The `attach` and `update` socket handlers pass `msg["location"]`.

[Open the `app.py` diff](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-733cccff4c923ddf435941e78b6741fc63c6ebcfb8c9655cffb493310f914284)

</details>

<details>
<summary><kbd>MODIFIED</kbd> <strong>packages/pulse/python/src/pulse/middleware.py</strong> - fix the stale docstring example.</summary>

<br />

The class docstring showed a `prerender_route` hook that no longer exists in the code. The example now uses the real `prerender` hook and reads `payload["location"]["pathname"]`.

[Open the `middleware.py` diff](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-874a104348774fa88e740f6fc4216b4a10b9595ab784ca38f62043817b080e23)

</details>

<details>
<summary><kbd>MODIFIED</kbd> <strong>packages/pulse/python/src/pulse/__init__.py</strong> - export <code>Location</code> as <code>ps.Location</code>.</summary>

<br />

[Open the `__init__.py` diff](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-aad95bd3bf2ec9c3765f025c41bce60a3cbbfe4d2822bcedf4eb000103cdff00)

</details>

</details>

<details>
<summary><kbd>STEP 5</kbd> <strong>The JS client</strong> - report the URL, stop computing params.</summary>

<br />

**Before this PR.** `PulseView` called `useLocation()` and `useParams()`, destructured the `"*"` key into `catchall`, and memoized with a `JSON.stringify(params)` dependency. `extractServerRouteInfo` did the same from loader `params`, with the divergent `length > 1` splat check.

**This PR.** `PulseView` builds `PulseLocation` from `useLocation()` only. `extractServerLocation` reads only `request.url`. Both `useParams()` call sites and both `catchall` computations are gone. `MountedView.location` replaces `MountedView.routeInfo`, and the `navigate_to` source check reads `view.location.pathname`.

<details>
<summary><kbd>MODIFIED</kbd> <strong>packages/pulse/js/src/helpers.ts</strong> - <code>PulseLocation</code> and <code>extractServerLocation</code>.</summary>

<br />

```diff
-export interface RouteInfo {
+/** The URL this tab is displaying. Route-match data (pathParams/catchall)
+ * is derived server-side per mount; the client only ever reports the URL. */
+export interface PulseLocation {
 	pathname: string;
 	hash: string;
 	query: string;
 	queryParams: Record<string, string>;
-	pathParams: Record<string, string | undefined>;
-	catchall: string[];
 }

-export function extractServerRouteInfo({ params, request }: LoaderFunctionArgs) {
-	const { "*": catchall = "", ...pathParams } = params;
+export function extractServerLocation({ request }: LoaderFunctionArgs) {
 	const parsedUrl = new URL(request.url);
```

[Open the `helpers.ts` diff](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-1718856b036c6345b43869d86afd32a907af5a9679c8b7e56b3eb72471c8c762)

</details>

<details>
<summary><kbd>MODIFIED</kbd> <strong>packages/pulse/js/src/pulse.tsx</strong> - drop <code>useParams</code> and the stringify memo hack.</summary>

<br />

```diff
 	const location = useLocation();
-	const params = useParams();

-	// biome-ignore lint/correctness/useExhaustiveDependencies: using hacky deep equality for params
-	const routeInfo = useMemo(() => {
-		const { "*": catchall = "", ...pathParams } = params;
+	const pulseLocation = useMemo(() => {
```

```diff
-		} satisfies RouteInfo;
-	}, [location.hash, location.pathname, location.search, JSON.stringify(params)]);
+		} satisfies PulseLocation;
+	}, [location.hash, location.pathname, location.search]);
```

[Open the `pulse.tsx` diff](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-822807cb4ac0f5fb749b501724e53979616fb641f9314ce42f33b88256595861)

</details>

<details>
<summary><kbd>MODIFIED</kbd> <strong>packages/pulse/js/src/client.tsx, messages.ts, index.ts, client.test.ts</strong> - rename the field across the client.</summary>

<br />

- `client.tsx`: `MountedView.location`, `updateRoute(path, location)`, `#sendAttach(path, location)`, and the `navigate_to` check on `view.location.pathname`.
- `messages.ts`: `ClientAttachMessage.location` and `ClientUpdateMessage.location` typed as `PulseLocation`.
- `index.ts`: export `PulseLocation` and `extractServerLocation`.
- `client.test.ts`: the shared fixture drops `pathParams` and `catchall`.

[Open the `client.tsx` diff](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-e8989f04085cac1fce4b32cf4de8babda753bc95b2b6979765de2e29ece0b7b8) · [Open the `messages.ts` diff](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-44388a004e3dfccff3539feeb436938254ef6754ce79a410c52f4a3e90ec76c9) · [Open the `index.ts` diff](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-72da38b300d06a945bca5132306e31a3298579c3702eb4a010e83e4f6384ea79) · [Open the `client.test.ts` diff](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-dcb9118ec0af7524f17747ddf9d961804510c337700191b9de4c64a287b0ba81)

</details>

<details>
<summary><kbd>MODIFIED</kbd> <strong>packages/pulse/python/src/pulse/codegen/templates/layout.py and web/app/pulse/_layout.tsx</strong> - generated loaders send <code>location</code>.</summary>

<br />

The layout template and the checked-in generated layout call `extractServerLocation(args)` and send `{ paths, location }` in the prerender POST body.

[Open the `layout.py` diff](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-79b30cd07d03973549b7922c2491daa2d53b35b9797254b2c0cdcebebac3f360) · [Open the `web/app/pulse/_layout.tsx` diff](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-717262d2b5d8234cce2480e9769ac1cda7faf6fd4aef3dfe44977484b5189657)

</details>

</details>

<details>
<summary><kbd>STEP 6</kbd> <strong>Tests, docs, and skills</strong> - fixtures speak <code>Location</code>, docs match the new API.</summary>

<br />

**Before this PR.** Test fixtures hand-built full `RouteInfo` dicts, including `pathParams` values the server now derives. Docs described the removed `prerender_route` middleware hook and the client-computed `routeInfo`.

**This PR.** Test helpers return `Location`. `test_route_bound_navigation_validates_source_route_identity` mounts `Route("shared")` and `Route(":slug")`, because both patterns genuinely match the pathname `/shared`. The old fixture claimed a pathname that did not match its mounted routes, which the server now rejects.

<details>
<summary><kbd>MODIFIED</kbd> <strong>Python test files</strong> - wire fixtures and helpers.</summary>

<br />

- [`packages/pulse/python/tests/test_render_session.py`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-a5e6206b9bdd7be5885273d996726a9f83f4524761f2f52af8ec86fbce69512d)
- [`packages/pulse/python/tests/test_query_param.py`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-d3979fd642ab2750b26238db82d9a406ca97dd84942744a6cda23fb4b5909533)
- [`packages/pulse/python/tests/test_hooks.py`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-9366eb01edfbf1e7f36b3fe4051151bf1fd250d22fad8fc26b52e3b3de2d5576)
- [`packages/pulse/python/tests/test_app_message_order.py`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-36d36e823d35bf73c787531f548f754d98f9c8c0048c6b6cc0b2523bec277eca)
- [`packages/pulse/python/tests/test_socket_lifecycle.py`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-d216cea5c10b46d79ef640c31135c427d3439aec2a33b6a3d7c017f32624d801)
- [`packages/pulse/python/tests/test_forms.py`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-4f5088bee9ee5cd7b256f63e1f282d725ea8db9e96d2e04e1d97dcf9406f8514)
- [`packages/pulse/python/tests/test_user_session.py`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-3142a586c5518383c3fe7e01eaf0ab9ea36db0429013fb0d71cf770206bcb7cd)
- [`packages/pulse/python/tests/test_prerender_endpoint.py`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-8f44f1a472b8155e5385f3c4da6af6259fb1d72cdf4609682fddc1857af1499c)
- [`packages/pulse/python/tests/test_codegen.py`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-c7af5a8a32eeaf6c98c7470947ddf3cbea0e299fea852f1e63625e7a5c97bfbd)
- [`packages/pulse-aws/tests/test_plugin.py`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-47a68b97e8f952b6679d05d98a03219c37fdd88e9598dbc27eb87aa21c2caa0c)
- [`packages/pulse-railway/tests/test_railway_plugin.py`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-69193567ecac517a41e41eb756b276693827db63c9715c97a7d250124d3c1f44)

</details>

<details>
<summary><kbd>MODIFIED</kbd> <strong>Docs and skills</strong> - the reference pages, guides, and skill references match the new API.</summary>

<br />

The docs distinguish the unchanged component API from the changed wire API. `ps.route()` still returns `RouteInfo`, and the pages note the fields are server-derived. The middleware pages drop `prerender_route`. The glossary gains **Location** and **Route Info** entries.

- [`docs/content/docs/(core)/advanced/middleware.mdx`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-7f5ea116248f424ad00f832c6a4fb053585d64e82e5c3b2551b07b753195289e)
- [`docs/content/docs/(core)/concepts/routing.mdx`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-7235564c74b821eb11c4906c328f9dec1bc59423cbf7681d16eaf9d75df80131)
- [`docs/content/docs/(core)/concepts/sessions.mdx`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-92908352b5dee38a8eefebaf7dd7d70e94af8fc0e0427b0c608a279b4bcd4015)
- [`docs/content/docs/(core)/cookbook/auth/auth-middleware.mdx`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-ca3926f3e88f2e040c889726ffab34898fa12a7a68a177b3abb6173aa445e5ef)
- [`docs/content/docs/(core)/glossary.mdx`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-68962678dc314612e60768e754ab8b8d537d0383886fab0c88604837aeb603f8)
- [`docs/content/docs/packages/pulse-js-client.mdx`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-f8ce99558a25baffaa313e1ae7c4081792272728b004513964f7ef955cf9eb5e)
- [`docs/content/docs/reference/pulse-client/hooks.mdx`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-2aa62f059b7a813623516202559c5633f42254c530d493dae1e2e72d7b09eebe)
- [`docs/content/docs/reference/pulse-client/index.mdx`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-988ec932da840b49f6477326eb6222eb929d4772683d1fbdbccbaf3f3520e228)
- [`docs/content/docs/reference/pulse-client/serialization.mdx`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-db4988aff39bea6ffeb82be492b316eba21ab52be289a03b0d890f0ae47b19bf)
- [`docs/content/docs/reference/pulse-client/types.mdx`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-9c257b38837804d4461f28b2f5baae64c101d04b5646a42193d628953960cdb5)
- [`docs/content/docs/reference/pulse/app.mdx`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-ffef8e2fbdd6bf0e72fd2c94515c0f45aa026ab5a8b86836acfd9919b226aeca)
- [`docs/content/docs/reference/pulse/hooks.mdx`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-817cf3328e84a9e270ab55c1300dc19e4864ecbfe5f43a34108f643ec4838bf8)
- [`docs/content/docs/reference/pulse/index.mdx`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-7e52b5ab8691f73e285151f2ddf955a9846ea3aeded87dfe228b7743c4ea2c7a)
- [`docs/content/docs/reference/pulse/middleware.mdx`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-17a99541b7b86969f1d282051fced998394ecb9b27ac7f01e3ca45e3d065782a)
- [`docs/content/docs/reference/pulse/routing.mdx`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-837fe4d6dfb3cf38d2dc8658210f1809f4da231b35c65ae9390ec28a3db6e70d)
- [`skills/pulse/references/context.md`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-66dd33f01684fa1961761a823d082e636308b3f9bd7f84ff7a5e51fbe9020f9a)
- [`skills/pulse/references/middleware.md`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-968c5dd5f9cb3ad06c35608f4001e72c247aa016a386c23d853da2f047576404)
- [`skills/pulse/references/sessions.md`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-7c061a81387a94ceb53b95a0c3ce101e824c54a92bebc2db5a2b1f2b26e170dc)
- [`packages/pulse/js/README.md`](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-485d24c45602a88a3c4898208a45b074349beb66f81d27b32ce0dfafe3404ad5)

</details>

</details>

<details>
<summary><kbd>KEPT</kbd> <strong>Deliberately unchanged</strong> - the component-facing API and the query param sync.</summary>

<br />

- `ps.route()` still returns the full `RouteInfo` with `pathname`, `hash`, `query`, `queryParams`, `pathParams`, and `catchall`. Applications need no changes.
- `QueryParamSync` still reads `RenderSession.url`. The session URL keeps the same keys plus `query`.
- The client still sends one `update` message per mounted view. The server treats every one as an idempotent `set_url` call, deduplicated by `Signal` equality.

</details>

## Decision record

<details>
<summary><strong>1. Derive route-match data on the server instead of trusting the client</strong></summary>

<br />

**Decision.** `match_route_path` computes `pathParams` and `catchall` from the pathname and the `Route.segments` chain.

**Before this PR.** The client computed both values with `useParams()` and loader `params`, then sent them per mount. The `catchall` code paths in `pulse.tsx` and `helpers.ts` disagreed on single-character splats.

**Reason.** The server owns the `RouteTree`. Match data is a pure function of the URL and the pattern, so storing a client copy invites divergence.

**Alternatives not selected.** Keep the client-supplied values (leaves the divergence and the denormalized copies). Port React Router's matcher wholesale (far larger surface than the Pulse pattern grammar needs).

**Result.** One matcher, tested in `test_route_matching.py`, produces identical values for the socket path and the loader path.

**Review questions.** Does `match_route_path` reproduce React Router behavior for the patterns Pulse accepts: static, `:param`, `segment?`, `:param?`, and a trailing `*`?

<details>
<summary>Principal diff</summary>

<br />

```diff
+	def matched_from(
+		seg_idx: int, url_idx: int, params: dict[str, str]
+	) -> tuple[dict[str, str], list[str]] | None:
+		if seg_idx == len(segments):
+			return params, []
+		seg = segments[seg_idx]
+		if seg.is_splat:
+			return params, [unquote(part) for part in url_parts[url_idx:]]
```

</details>

[Open the `routing.py` diff](https://github.com/erwinkn/pulse-ui/pull/123/files#diff-fa5aa9f586a082010cc3d2151dc0ff10fe2a94737af1b82a73eb144f39311c27)

</details>

<details>
<summary><strong>2. Push derived info down from <code>set_url</code></strong></summary>

<br />

**Decision.** `RenderSession.set_url` updates every mount's `RouteContext` in one place. This pull request removes `RouteMount.update_route`.

**Before this PR.** Each mount waited for its own client message to refresh its info. A layout mount and a leaf mount refreshed separately.

**Reason.** One tab has one URL. One writer removes the possibility of mounts disagreeing about the current URL.

**Alternatives not selected.** Keep per-mount refresh with the reduced payload (retains N copies and N update paths for one value).

**Result.** `test_set_url_pushes_to_every_matching_mount` shows a parent mount refreshing from a child mount's `update` message.

**Review questions.** Is the `set_url` loop over `route_mounts` safe at every call site, including `prerender` before a new mount exists?

</details>

<details>
<summary><strong>3. Freeze a mount whose pattern stops matching</strong></summary>

<br />

**Decision.** `RouteContext.update` returns without changes when `match_route_path` returns `None`.

**Before this PR.** An outgoing mount kept its last client-sent info, because the client stopped sending updates for it.

**Reason.** During client-side navigation the incoming route prerenders while the outgoing route is still mounted. Applying the new URL to the outgoing mount would mix old `pathParams` with a new pathname. Freezing keeps the snapshot coherent and matches the old timing.

**Alternatives not selected.** Apply the new URL fields and keep the stale params (incoherent blend). Raise on mismatch during update (navigation overlap is structural, not an error).

**Result.** `test_non_matching_mount_keeps_last_snapshot` covers the overlap. Construction still raises `ValueError`, because a fresh mount for a non-matching URL is a real error.

**Review questions.** Is the freeze acceptable for a suspended mount that later resumes on a different URL, given that resume sends a fresh init?

</details>

<details>
<summary><strong>4. Rename the wire field to <code>location</code></strong></summary>

<br />

**Decision.** The wire carries `location: Location` (Python) and `location: PulseLocation` (TypeScript). The old `routeInfo` key is gone.

**Before this PR.** The wire carried `routeInfo: RouteInfo` with six fields.

**Reason.** The payload is no longer route info. It is the tab's URL. One term for one concept keeps the boundary honest, and the repository policy excludes backward compatibility.

**Alternatives not selected.** Keep the `routeInfo` key with fewer fields (misleading name, silent partial breakage for mixed versions instead of loud breakage).

**Result.** A mixed deployment fails loudly: an old client's `routeInfo` key raises `KeyError` in `_handle_pulse_message`, and the prerender endpoint returns 422. The Python and JS packages must release together.

**Review questions.** Is the coupled release acceptable for the next version bump?

</details>

<details>
<summary><strong>5. Add the raw query string to the session URL</strong></summary>

<br />

**Decision.** `Location` includes `query`, and `RenderSession.url` stores it.

**Before this PR.** The session URL held only `pathname`, `hash`, and `queryParams`. The raw string existed only in per-mount `RouteInfo`.

**Reason.** `RouteContext.query` is public API. Rebuilding the string from `queryParams` is lossy, because `Object.fromEntries` collapses duplicate keys and drops ordering.

**Alternatives not selected.** Rebuild the string from `queryParams` (lossy). Drop `RouteContext.query` (API break with no benefit).

**Result.** `test_route_info_updated_on_reconnect` asserts `mount.route.query` round-trips through reconnects.

**Review questions.** None.

</details>

## Deliberate non-goals

- This pull request does not replace per-mount `update` messages with one session-level message. The client still sends one `update` per mounted view, and the server treats them as idempotent `set_url` calls.
- This pull request does not keep backward compatibility for clients that send `routeInfo`.
- This pull request does not change `ps.route()`, `RouteInfo`, or any component-facing API.
- This pull request does not remove the `sourceRoutePath`/`sourceMountId` navigation attribution used by `ps.navigate()`.

## Evidence and verification

| Boundary | Evidence |
|---|---|
| `match_route_path` parity | `tests/test_route_matching.py::TestMatchRoutePath` covers 14 pattern cases, including optionals, splats, decoding, and layout chains. |
| Session-level derivation | `tests/test_route_matching.py::TestDerivedRouteInfo` covers derivation on prerender, push-down on `update_route`, snapshot freeze on overlap, and the `ValueError` on a non-matching construction. |
| Wire format | `tests/test_app_message_order.py`, `tests/test_socket_lifecycle.py`, `tests/test_prerender_endpoint.py`, `tests/test_forms.py`, and `tests/test_user_session.py` exercise `location` payloads end to end. |
| Query param sync on the new session URL | `tests/test_query_param.py` passes unchanged in behavior. |
| JS client | `packages/pulse/js/src/client.test.ts` passes with the `location` fixture. |

These checks passed on `a148787cffd9f8ec91f0df00aabaa85cd7801a9b`:

- `make all` (ruff, biome, basedpyright, tsc, pytest, bun test): all checks passed, 1698 Python tests and 120 JS tests
- GitHub Actions `lint-and-test`: pass
- Browser end-to-end with `pulse run examples/main.py` and `pulse run examples/query_param.py`:
  - `/dynamic/42/opt-seg/alpha/beta` derived `{'route_id': '42', 'optional_segment': 'opt-seg'}` and `['alpha', 'beta']` on hard load.
  - `/dynamic/99` derived `{'route_id': '99'}` with an empty `catchall`.
  - Client-side navigation re-derived the params and preserved the query string `q1=x&q2=y`.
  - `QueryParam` state hydrated from `?page=5&tags=alpha,beta&other=keepme` and wrote `page=6` back with `other=keepme` intact.

Checks not run:

- None

[Open the live pull request checks](https://github.com/erwinkn/pulse-ui/pull/123/checks)

## Stack

- GitHub stack #123 uses `pulse-session-url-ownership` as its base.
- Position 1: [PR #122](https://github.com/erwinkn/pulse-ui/pull/122), `pulse-session-url-ownership` → `main`
- Position 2: [PR #123](https://github.com/erwinkn/pulse-ui/pull/123), `pulse-url-single-source` → `pulse-session-url-ownership`
