### PR TITLE
Gate channels on owner disposal, not mount.active

### DIFF
--- a/docs/content/docs/(core)/advanced/channels.mdx
+++ b/docs/content/docs/(core)/advanced/channels.mdx
@@ -198,10 +198,15 @@ them when it destroys that route.
 
 Unmounting only the JavaScript consumer unsubscribes its bridge; it does not close
 the server channel. If the WebSocket reconnects, live bridges subscribe again.
+Route channels stay open while the route exists, including while Pulse is
+buffering VDOM for a prerender or reconnect. Incoming events still run. Pulse
+closes them when it destroys the route.
+
 While no bridge is subscribed, server `emit()` calls buffer up to 64 events and
 flush them in order after reconnecting. Client bridge `emit()` calls use the same
 64-event limit while the bridge waits for a subscription. Both buffers drop the
-oldest event at the limit.
+oldest event at the limit. Delivery is ordered and at-most-once; handlers must
+tolerate gaps.
 
 Use a tab-lifetime channel for state that persists across route changes:
 

--- a/docs/content/docs/(core)/advanced/channels.mdx
+++ b/docs/content/docs/(core)/advanced/channels.mdx
@@ -196,17 +196,16 @@ The `usePulseChannel` hook returns a bridge object with three methods:
 By default, channels are tied to the route where they are created. Pulse closes
 them when it destroys that route.
 
-Unmounting only the JavaScript consumer unsubscribes its bridge; it does not close
-the server channel. If the WebSocket reconnects, live bridges subscribe again.
-Route channels stay open while the route exists, including while Pulse is
-buffering VDOM for a prerender or reconnect. Incoming events still run. Pulse
-closes them when it destroys the route.
+If you unmount only the JavaScript consumer, Pulse unsubscribes the bridge.
+This does not close the server channel.
+If the WebSocket connects again, live bridges subscribe again.
+A subscribed client can send events while the route is still there.
 
-While no bridge is subscribed, server `emit()` calls buffer up to 64 events and
-flush them in order after reconnecting. Client bridge `emit()` calls use the same
-64-event limit while the bridge waits for a subscription. Both buffers drop the
-oldest event at the limit. Delivery is ordered and at-most-once; handlers must
-tolerate gaps.
+If no bridge is subscribed, Pulse keeps the last 64 events from emit().
+Pulse sends them in order when the client subscribes again.
+Client `emit()` uses the same limit while it waits to subscribe.
+If there are more than 64 events, Pulse removes the oldest event.
+If Pulse removes an event, your handler does not receive it.
 
 Use a tab-lifetime channel for state that persists across route changes:
 

--- a/docs/content/docs/reference/pulse-client/hooks.mdx
+++ b/docs/content/docs/reference/pulse-client/hooks.mdx
@@ -153,8 +153,9 @@ channel = ps.channel("notifications", lifetime="tab")
 const channel = usePulseChannel("notifications", "tab");
 ```
 
-Multiple components can subscribe to the same channel. Releasing all client
-subscriptions unsubscribes the bridge; it does not close the server channel.
+More than one component can subscribe to the same channel.
+If all client subscriptions stop, Pulse unsubscribes the bridge.
+This does not close the server channel.
 
 ### Example: Chat Room
 

--- a/docs/content/docs/reference/pulse-client/hooks.mdx
+++ b/docs/content/docs/reference/pulse-client/hooks.mdx
@@ -153,7 +153,8 @@ channel = ps.channel("notifications", lifetime="tab")
 const channel = usePulseChannel("notifications", "tab");
 ```
 
-Multiple components can subscribe to the same channel. The channel stays open as long as at least one component is subscribed.
+Multiple components can subscribe to the same channel. Releasing all client
+subscriptions unsubscribes the bridge; it does not close the server channel.
 
 ### Example: Chat Room
 

--- a/docs/content/docs/reference/pulse/channels.mdx
+++ b/docs/content/docs/reference/pulse/channels.mdx
@@ -61,10 +61,7 @@ hard upper boundary for all channels, so a tab channel is not shared with other
 tabs or users. A tab channel has no route owner, so its handlers run without a
 current route context.
 
-Inbound events run while the channel exists and a client is subscribed. Route
-mount transport state (pending, active, suspended) is not a gate. Delivery is
-ordered and at-most-once; disconnected `emit()` buffers drop the oldest event at
-64.
+A subscribed client can send events while the channel is open.
 
 ## Classes
 

--- a/docs/content/docs/reference/pulse/channels.mdx
+++ b/docs/content/docs/reference/pulse/channels.mdx
@@ -61,6 +61,11 @@ hard upper boundary for all channels, so a tab channel is not shared with other
 tabs or users. A tab channel has no route owner, so its handlers run without a
 current route context.
 
+Inbound events run while the channel exists and a client is subscribed. Route
+mount transport state (pending, active, suspended) is not a gate. Delivery is
+ordered and at-most-once; disconnected `emit()` buffers drop the oldest event at
+64.
+
 ## Classes
 
 ### Channel

--- a/packages/pulse/python/src/pulse/channel.py
+++ b/packages/pulse/python/src/pulse/channel.py
@@ -1,18 +1,16 @@
 """Bidirectional channels with client subscription lifetimes.
 
-The server owns channel lifetime; clients only subscribe and unsubscribe. Server
-emits made without a subscriber are buffered per channel in a 64-item FIFO. Once
-the cap is reached, the oldest event is dropped. Buffered events flush in order
-after a subscription is acknowledged. Requests are never buffered and fail
-immediately while disconnected.
+The server keeps the channel. Clients subscribe and unsubscribe.
+If no client is subscribed, Pulse keeps the last 64 events from emit().
+If there are more than 64 events, Pulse removes the oldest event.
+Pulse sends the kept events in order when a client subscribes again.
+request() does not keep events. It fails immediately if no client is subscribed.
 
-Route-lifetime channels close with the route that created them. Tab-lifetime
-channels survive route changes and close with the browser tab's render session.
-Both lifetimes permit an earlier explicit ``Channel.close()``.
+A route channel closes when Pulse destroys its route.
+A tab channel stays across route changes. It closes with the browser tab.
+You can also call Channel.close() before that.
 
-Inbound events run while the channel exists and a client is subscribed. Route
-mount transport state (pending, active, suspended) is not a gate; owner
-disposal closes the channel.
+A subscribed client can send events while the channel is open.
 """
 
 import asyncio
@@ -169,7 +167,7 @@ class ChannelsManager:
 		session: "UserSession",
 		owner_token: object | None,
 	) -> tuple[Any | None, str | None] | None:
-		"""Validate identity and resolve route context. Mount state is not a gate."""
+		"""Check that this session owns the channel. Then get the route context."""
 		if channel.render_id != render.id or channel.session_id != session.sid:
 			return None
 		if channel._owner_token != owner_token:  # pyright: ignore[reportPrivateUsage]
@@ -182,7 +180,7 @@ class ChannelsManager:
 			mount = render.get_route_mount(owner_token)
 		except ValueError:
 			logger.error(
-				"Open channel '%s' has no mount for owner %r",
+				"Channel '%s' is open, but its route %r is gone",
 				channel.id,
 				owner_token,
 			)

--- a/packages/pulse/python/src/pulse/channel.py
+++ b/packages/pulse/python/src/pulse/channel.py
@@ -9,6 +9,10 @@ immediately while disconnected.
 Route-lifetime channels close with the route that created them. Tab-lifetime
 channels survive route changes and close with the browser tab's render session.
 Both lifetimes permit an earlier explicit ``Channel.close()``.
+
+Inbound events run while the channel exists and a client is subscribed. Route
+mount transport state (pending, active, suspended) is not a gate; owner
+disposal closes the channel.
 """
 
 import asyncio
@@ -164,9 +168,8 @@ class ChannelsManager:
 		render: "RenderSession",
 		session: "UserSession",
 		owner_token: object | None,
-		require_active: bool = True,
 	) -> tuple[Any | None, str | None] | None:
-		"""Validate channel ownership and resolve its route context in one place."""
+		"""Validate identity and resolve route context. Mount state is not a gate."""
 		if channel.render_id != render.id or channel.session_id != session.sid:
 			return None
 		if channel._owner_token != owner_token:  # pyright: ignore[reportPrivateUsage]
@@ -178,8 +181,11 @@ class ChannelsManager:
 		try:
 			mount = render.get_route_mount(owner_token)
 		except ValueError:
-			return None
-		if require_active and mount.state != "active":
+			logger.error(
+				"Open channel '%s' has no mount for owner %r",
+				channel.id,
+				owner_token,
+			)
 			return None
 		return (mount.route, mount.mount_id)
 
@@ -258,7 +264,6 @@ class ChannelsManager:
 				render=render,
 				session=session,
 				owner_token=message.get("owner"),
-				require_active=False,
 			)
 			is None
 		):
@@ -296,7 +301,7 @@ class ChannelsManager:
 	) -> None:
 		channel_id = str(message.get("channel"))
 		channel = self._channels.get(channel_id)
-		if channel is None:
+		if channel is None or channel.closed:
 			if request_id := message.get("requestId"):
 				self._send_error_response(channel_id, request_id, "Channel closed")
 			return
@@ -313,7 +318,7 @@ class ChannelsManager:
 			)
 			if request_id := message.get("requestId"):
 				self._send_error_response(
-					channel_id, request_id, "Channel owner is inactive"
+					channel_id, request_id, "Channel owner is unavailable"
 				)
 			return
 		if not channel.connected:

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -521,8 +521,7 @@ class RenderSession:
 
 			results[path] = message
 			if message["type"] == "navigate_to":
-				mount.dispose()
-				del self.route_mounts[path]
+				self.dispose_mount(path, mount)
 				continue
 
 		return results

--- a/packages/pulse/python/tests/test_render_session.py
+++ b/packages/pulse/python/tests/test_render_session.py
@@ -2512,9 +2512,7 @@ async def test_prerender_redirect_closes_route_channels():
 @pytest.mark.asyncio
 async def test_dev_strict_mode_grace_channel_event_runs():
 	routes = RouteTree([Route("a", simple_component)])
-	render = RenderSession(
-		"strict-event", routes, dev_strict_mode_detach_timeout=10.0
-	)
+	render = RenderSession("strict-event", routes, dev_strict_mode_detach_timeout=10.0)
 	render.connect(lambda _message: None)
 	user_session: Any = SimpleNamespace(sid="strict-event-user")
 

--- a/packages/pulse/python/tests/test_render_session.py
+++ b/packages/pulse/python/tests/test_render_session.py
@@ -1943,7 +1943,7 @@ def test_dev_strict_mode_channel_unsubscribe_reacquire_keeps_server_channel():
 	assert channel.closed is False
 	assert channel.connected is False
 
-	assert not render.channels.handle_client_connect(
+	assert render.channels.handle_client_connect(
 		render=render,
 		session=user_session,
 		message={
@@ -1954,6 +1954,7 @@ def test_dev_strict_mode_channel_unsubscribe_reacquire_keeps_server_channel():
 		},
 	)
 	assert channel.closed is False
+	assert channel.connected is True
 
 	with ps.PulseContext.update(render=render, session=user_session):
 		render.attach("/a", make_route_info("/a"))
@@ -2365,3 +2366,196 @@ async def test_async_callback_error_reports_real_traceback():
 	assert "NoneType: None" not in err["stack"]
 
 	session.close()
+
+
+@pytest.mark.asyncio
+async def test_prerender_of_active_path_keeps_channel_subscription_live():
+	routes = RouteTree([Route("a", simple_component)])
+	render = RenderSession("channel-pending", routes)
+	messages: list[ServerMessage] = []
+	render.connect(messages.append)
+	user_session: Any = SimpleNamespace(sid="pending-user")
+
+	with ps.PulseContext.update(render=render, session=user_session):
+		render.prerender(["/a"])
+		render.attach("/a", make_route_info("/a"))
+	mount = render.get_route_mount("/a")
+	received: list[Any] = []
+	with ps.PulseContext.update(
+		render=render,
+		session=user_session,
+		route=mount.route,
+	):
+		channel = render.channels.create("layout-channel")
+		channel.on("syncValues", lambda payload: received.append(payload))
+		channel.on("ask", lambda payload: {"ok": True})
+
+	assert render.channels.handle_client_connect(
+		render=render,
+		session=user_session,
+		message={
+			"type": "channel_connect",
+			"channel": channel.id,
+			"subscriptionId": "sub-1",
+			"owner": "/a",
+		},
+	)
+	messages.clear()
+
+	with ps.PulseContext.update(render=render, session=user_session):
+		render.prerender(["/a"], make_route_info("/a"))
+	assert mount.state == "pending"
+	assert channel.closed is False
+	assert channel.connected is True
+
+	render.channels.handle_client_event(
+		render=render,
+		session=user_session,
+		message={
+			"type": "channel_message",
+			"channel": channel.id,
+			"event": "syncValues",
+			"payload": {"field": "x"},
+		},
+	)
+	await asyncio.sleep(0)
+	assert received == [{"field": "x"}]
+
+	render.channels.handle_client_event(
+		render=render,
+		session=user_session,
+		message={
+			"type": "channel_message",
+			"channel": channel.id,
+			"event": "ask",
+			"payload": {},
+			"requestId": "req-pending",
+		},
+	)
+	await asyncio.sleep(0)
+	responses = [
+		message
+		for message in messages
+		if message.get("type") == "channel_message"
+		and message.get("responseTo") == "req-pending"
+	]
+	assert len(responses) == 1
+	assert responses[0].get("payload") == {"ok": True}
+	assert "error" not in responses[0]
+
+	assert render.channels.handle_client_connect(
+		render=render,
+		session=user_session,
+		message={
+			"type": "channel_connect",
+			"channel": channel.id,
+			"subscriptionId": "sub-2",
+			"owner": "/a",
+		},
+	)
+	assert channel.connected is True
+	render.close()
+
+
+@pytest.mark.asyncio
+async def test_prerender_redirect_closes_route_channels():
+	should_redirect = {"on": False}
+
+	@ps.component
+	def maybe_redirect():
+		if should_redirect["on"]:
+			raise RedirectInterrupt("/other", replace=True)
+		return ps.div("ok")
+
+	routes = RouteTree([Route("a", maybe_redirect)])
+	render = RenderSession("redirect-channel", routes)
+	messages: list[ServerMessage] = []
+	render.connect(messages.append)
+	user_session: Any = SimpleNamespace(sid="redirect-user")
+
+	with ps.PulseContext.update(render=render, session=user_session):
+		render.prerender(["/a"])
+		render.attach("/a", make_route_info("/a"))
+	mount = render.get_route_mount("/a")
+	with ps.PulseContext.update(
+		render=render,
+		session=user_session,
+		route=mount.route,
+	):
+		channel = render.channels.create("redirect-form")
+	assert render.channels.handle_client_connect(
+		render=render,
+		session=user_session,
+		message={
+			"type": "channel_connect",
+			"channel": channel.id,
+			"subscriptionId": "sub-1",
+			"owner": "/a",
+		},
+	)
+	messages.clear()
+
+	should_redirect["on"] = True
+	with ps.PulseContext.update(render=render, session=user_session):
+		result = render.prerender(["/a"], make_route_info("/a"))["/a"]
+
+	assert result["type"] == "navigate_to"
+	assert "/a" not in render.route_mounts
+	assert channel.closed is True
+	assert any(
+		message.get("type") == "channel_message" and message.get("event") == "__close__"
+		for message in messages
+	)
+	render.close()
+
+
+@pytest.mark.asyncio
+async def test_dev_strict_mode_grace_channel_event_runs():
+	routes = RouteTree([Route("a", simple_component)])
+	render = RenderSession(
+		"strict-event", routes, dev_strict_mode_detach_timeout=10.0
+	)
+	render.connect(lambda _message: None)
+	user_session: Any = SimpleNamespace(sid="strict-event-user")
+
+	with ps.PulseContext.update(render=render, session=user_session):
+		render.prerender(["/a"])
+		render.attach("/a", make_route_info("/a"))
+	mount = render.get_route_mount("/a")
+	received: list[Any] = []
+	with ps.PulseContext.update(
+		render=render,
+		session=user_session,
+		route=mount.route,
+	):
+		channel = render.channels.create("strict-event-channel")
+		channel.on("ping", lambda payload: received.append(payload))
+	assert render.channels.handle_client_connect(
+		render=render,
+		session=user_session,
+		message={
+			"type": "channel_connect",
+			"channel": channel.id,
+			"subscriptionId": "sub-1",
+			"owner": "/a",
+		},
+	)
+
+	render.detach("/a")
+	assert mount.state == "pending"
+	assert channel.closed is False
+	assert channel.connected is True
+
+	render.channels.handle_client_event(
+		render=render,
+		session=user_session,
+		message={
+			"type": "channel_message",
+			"channel": channel.id,
+			"event": "ping",
+			"payload": {"n": 1},
+		},
+	)
+	await asyncio.sleep(0)
+	assert received == [{"n": 1}]
+	render.close()

--- a/skills/pulse/references/channels.md
+++ b/skills/pulse/references/channels.md
@@ -248,7 +248,10 @@ except ps.ChannelClosed:
 4. **Closed** — Lifetime owner disposal or explicit `channel.close()`
 
 Route channels close when Pulse destroys their route. Tab channels close when
-Pulse closes their render session.
+Pulse closes their render session. Incoming events run while the owner exists
+and a client is subscribed; they are not gated on mount transport state
+(pending vs active). Delivery is ordered and at-most-once; buffers drop the
+oldest event at 64.
 
 Always clean up handlers in `on_dispose()`:
 

--- a/skills/pulse/references/channels.md
+++ b/skills/pulse/references/channels.md
@@ -245,13 +245,13 @@ except ps.ChannelClosed:
 1. **Created** — `ps.channel()` in State `__init__`
 2. **Subscribed** — While a client bridge is listening
 3. **Disconnected** — The server channel stays alive and buffers emits
-4. **Closed** — Lifetime owner disposal or explicit `channel.close()`
+4. **Closed** — Pulse destroys the owner, or you call `channel.close()`
 
 Route channels close when Pulse destroys their route. Tab channels close when
-Pulse closes their render session. Incoming events run while the owner exists
-and a client is subscribed; they are not gated on mount transport state
-(pending vs active). Delivery is ordered and at-most-once; buffers drop the
-oldest event at 64.
+Pulse closes their render session.
+A subscribed client can send events while the channel is open.
+If no client is subscribed, Pulse keeps the last 64 events from emit().
+If there are more than 64 events, Pulse removes the oldest event.
 
 Always clean up handlers in `on_dispose()`:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #129.

Channels no longer read `RouteMount.state`. Inbound events and `channel_connect` run while the channel exists and (for events) a client is subscribed. Prerender `navigate_to` goes through `dispose_mount` so route channels actually close.

## Why

`pending` is VDOM send-buffering (prerender of a live layout, reconnect, StrictMode). Callbacks already run in that window. #129 dropped channel events there (`require_active=True`), which loses form/combobox traffic on every client nav.

Rejected connects permanently dispose the client bridge, so connect also must not use a transient `active` check.

## Changes

- `validate_owner` resolves route context only. No `require_active`.
- Events: `exists && !closed && connected`.
- Connect: `exists && !closed && token match`.
- Prerender redirect uses `dispose_mount` (closes owned channels, sends `__close__`).
- Tests: prerender-pending event+request+connect; redirecting prerender closes channels; StrictMode grace connect/event.

## Not here

Mount machine (stop flipping committed mounts to pending, aborted-nav freeze, route snapshot) stays on the view/prerender work.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffbdf-7322-766e-845c-589e7df01c53?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffbdf-7322-766e-845c-589e7df01c53&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

