### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,48 @@
+# Cursor Cloud Agent base image for the Pulse monorepo.
+# Provides the system toolchain (Python 3.12, Node 22) plus uv + bun installed
+# into /usr/local/bin so they are on PATH for every shell (login or not).
+# Project dependencies are installed by the `install` command in
+# .cursor/environment.json (`make sync`), NOT here — do not COPY the repo.
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System dependencies. git + sudo are required by the Cloud Agent runtime
+# (it clones the repo and expects passwordless sudo). build-essential provides
+# `make` and a C toolchain; python3.12 matches .python-version.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    sudo \
+    unzip \
+    xz-utils \
+    build-essential \
+    python3.12 \
+    python3.12-venv \
+    python3.12-dev \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node.js 22 (used by @react-router/serve in prod and some JS tooling).
+RUN curl --retry 3 --retry-delay 5 -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Non-root `ubuntu` user with passwordless sudo, as expected by Cloud Agents.
+RUN id -u ubuntu >/dev/null 2>&1 || useradd -m -s /bin/bash ubuntu \
+    && usermod -aG sudo ubuntu \
+    && echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu \
+    && chmod 0440 /etc/sudoers.d/ubuntu
+
+# uv (Python package/monorepo manager), pinned. Installed to /usr/local/bin so
+# it is on the default PATH for all shells without profile edits.
+RUN curl --retry 3 --retry-delay 5 -LsSf https://astral.sh/uv/0.12.3/install.sh \
+    | env UV_INSTALL_DIR=/usr/local/bin UV_NO_MODIFY_PATH=1 sh
+
+# bun (JS package manager/runtime), pinned. BUN_INSTALL=/usr/local places the
+# binary at /usr/local/bin/bun.
+RUN curl --retry 3 --retry-delay 5 -fsSL https://bun.sh/install \
+    | env BUN_INSTALL=/usr/local bash -s "bun-v1.3.14"
+
+USER ubuntu

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://www.cursor.com/schemas/environment.schema.json",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "install": "make sync"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,14 +7,14 @@ Full-stack Python framework for interactive web apps. Runs on React with WebSock
 - Be extremely concise. Sacrifice grammar for the sake of concision.
 - Read the README.md in the relevant package before starting work
 - Always add tests when implementing a new feature. 
-- If dependencies are not installed, run `make sync`
+- If dependencies are not installed, run `make sync` (`bun run build` is part of it; rebuild after editing `packages/*/js` or apps won't pick up changes)
 - Run `make test` after implementing
 - Run `make all` before committing
 - Check `examples/` for usage patterns
 - Use `make bump` for changing package versions
 - When using a framework/library, do not make assumptions, fetch latest docs (using context7 for example)
 - Use `bun info ...` to get information about a JS package
-- Test examples by running them with `pulse run` in a background task and using the agent-browser CLI for interacting with the UI.
+- Test examples by running them with `pulse run` in a background task and using the agent-browser CLI for interacting with the UI. First page load after `pulse run` can 504 while Vite prebundles — reload once.
 - While debugging, feel free to add debug print statements, spin up test files, modify existing code, or anything else that would improve your feedback loop and accelerate the troubleshooting process. Remove those debug changes after fixing the issue.
 - Tests should never be used as a reason to keep aliases or dead code around.
 
@@ -60,14 +60,3 @@ Before writing or editing docs, read `docs/GUIDELINES.md` for tone, structure, a
 - Be conversational—write like you're explaining to a friend
 - Update `docs/content/docs/(core)/glossary.mdx` if introducing new terms
 - When changing behavior/APIs, update both `docs/` and `skills/` (if the feature is covered there)
-
-## Cursor Cloud specific instructions
-
-Env is defined in `.cursor/environment.json` (Dockerfile-based, `.cursor/Dockerfile`): Ubuntu 24.04 with Python 3.12, Node 22, and `uv` + `bun` installed into `/usr/local/bin` (on PATH for every shell — no profile hacks). The `install` step runs `make sync` (Python 3.12 venv at `.venv`, all workspace packages installed, JS client packages built). To change system tooling, edit `.cursor/Dockerfile`; to change dependency setup, edit the `install` command. Standard dev commands live in the `## Commands` section, `Makefile`, and `CONTRIBUTING.md` — use those.
-
-Non-obvious caveats:
-- Run an app: `uv run pulse run examples/<app>.py` (e.g. `examples/todo.py`). Single-server mode: uvicorn backend on `:8000`, React Router (Vite) dev server on `:5173`. Open `:8000` (it proxies to the web server).
-- Vite dev cold-start: the very first page load right after `pulse run` can 504 on dynamically-imported modules while Vite pre-bundles deps. Not a real failure — wait a few seconds and reload once.
-- `pulse run` re-runs `bun install` in the app's `web/` dir and codegen on startup, so first boot is slower.
-- `bun run build` (part of `make sync`) builds the `pulse-ui-client` / `pulse-mantine` JS packages that apps depend on as `workspace:*`. If you edit those JS packages, rebuild before apps pick up changes.
-- `make test` runs `uv run pytest` then `bun test`. CDK tests are skipped by default (`-m 'not cdk'` in `pyproject.toml`); run with `uv run pytest -m cdk`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ Before writing or editing docs, read `docs/GUIDELINES.md` for tone, structure, a
 
 ## Cursor Cloud specific instructions
 
-Env is pre-provisioned: `uv` + `bun` are installed in `$HOME` and exposed via `~/.bashrc` (same mechanism as the preinstalled `nvm`/`cargo`), and the startup update script runs `make sync` (Python 3.12 venv at `.venv`, all workspace packages installed, JS client packages built). Standard commands live in the `## Commands` section, `Makefile`, and `CONTRIBUTING.md` — use those.
+Env is defined in `.cursor/environment.json` (Dockerfile-based, `.cursor/Dockerfile`): Ubuntu 24.04 with Python 3.12, Node 22, and `uv` + `bun` installed into `/usr/local/bin` (on PATH for every shell — no profile hacks). The `install` step runs `make sync` (Python 3.12 venv at `.venv`, all workspace packages installed, JS client packages built). To change system tooling, edit `.cursor/Dockerfile`; to change dependency setup, edit the `install` command. Standard dev commands live in the `## Commands` section, `Makefile`, and `CONTRIBUTING.md` — use those.
 
 Non-obvious caveats:
 - Run an app: `uv run pulse run examples/<app>.py` (e.g. `examples/todo.py`). Single-server mode: uvicorn backend on `:8000`, React Router (Vite) dev server on `:5173`. Open `:8000` (it proxies to the web server).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,3 +60,14 @@ Before writing or editing docs, read `docs/GUIDELINES.md` for tone, structure, a
 - Be conversational—write like you're explaining to a friend
 - Update `docs/content/docs/(core)/glossary.mdx` if introducing new terms
 - When changing behavior/APIs, update both `docs/` and `skills/` (if the feature is covered there)
+
+## Cursor Cloud specific instructions
+
+Env is pre-provisioned by the startup update script (`make sync`): `uv` (`~/.local/bin`) + `bun` (`~/.bun/bin`) on PATH, Python 3.12 venv at `.venv`, all workspace packages installed, JS client packages built. Standard commands live in the `## Commands` section, `Makefile`, and `CONTRIBUTING.md` — use those.
+
+Non-obvious caveats:
+- Run an app: `uv run pulse run examples/<app>.py` (e.g. `examples/todo.py`). Single-server mode: uvicorn backend on `:8000`, React Router (Vite) dev server on `:5173`. Open `:8000` (it proxies to the web server).
+- Vite dev cold-start: the very first page load right after `pulse run` can 504 on dynamically-imported modules while Vite pre-bundles deps. Not a real failure — wait a few seconds and reload once.
+- `pulse run` re-runs `bun install` in the app's `web/` dir and codegen on startup, so first boot is slower.
+- `bun run build` (part of `make sync`) builds the `pulse-ui-client` / `pulse-mantine` JS packages that apps depend on as `workspace:*`. If you edit those JS packages, rebuild before apps pick up changes.
+- `make test` runs `uv run pytest` then `bun test`. CDK tests are skipped by default (`-m 'not cdk'` in `pyproject.toml`); run with `uv run pytest -m cdk`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ Before writing or editing docs, read `docs/GUIDELINES.md` for tone, structure, a
 
 ## Cursor Cloud specific instructions
 
-Env is pre-provisioned by the startup update script (`make sync`): `uv` (`~/.local/bin`) + `bun` (`~/.bun/bin`) on PATH, Python 3.12 venv at `.venv`, all workspace packages installed, JS client packages built. Standard commands live in the `## Commands` section, `Makefile`, and `CONTRIBUTING.md` — use those.
+Env is pre-provisioned: `uv` + `bun` are installed in `$HOME` and exposed via `~/.bashrc` (same mechanism as the preinstalled `nvm`/`cargo`), and the startup update script runs `make sync` (Python 3.12 venv at `.venv`, all workspace packages installed, JS client packages built). Standard commands live in the `## Commands` section, `Makefile`, and `CONTRIBUTING.md` — use those.
 
 Non-obvious caveats:
 - Run an app: `uv run pulse run examples/<app>.py` (e.g. `examples/todo.py`). Single-server mode: uvicorn backend on `:8000`, React Router (Vite) dev server on `:5173`. Open `:8000` (it proxies to the web server).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up the Cursor Cloud development environment for the Pulse monorepo as **committed, reproducible config** (Dockerfile-based).

- `.cursor/Dockerfile` — Ubuntu 24.04 base with `git`/`sudo`, `build-essential` (`make`), Python 3.12, Node 22, and `uv` + `bun` installed into `/usr/local/bin` (pinned to `uv 0.12.3` / `bun 1.3.14`). Putting the tools on the system PATH means they resolve in any shell with no `~/.bashrc`/profile dependency.
- `.cursor/environment.json` — references the Dockerfile and runs `make sync` as the `install` step (deps + JS package build). No dev server auto-starts, since this is a framework monorepo with many example apps; agents start whichever example they need.
- `AGENTS.md` — two general gotchas folded into existing guidelines (rebuild JS packages after editing them; Vite first-load 504). No Cloud-specific section.

No application code changed.

## Why committed Dockerfile (vs snapshot-only)

Provisioning (`uv`/`bun` install) lives in version control and rebuilds deterministically from scratch, instead of depending on an opaque VM snapshot that happens to contain manual installs.

## Verification

Dev checks on this branch (live VM):

| Check | Command | Result |
|---|---|---|
| Lint | `make lint` (Ruff + Biome) | pass |
| Typecheck | `make typecheck` (basedpyright + tsc) | 0 errors |
| Python tests | `uv run pytest` | 2014 passed, 1 skipped |
| JS tests | `bun test` | 120 pass |
| Run app | `uv run pulse run examples/todo.py` | backend `:8000` + web `:5173`, HTTP 200 |

Hello-world: loaded the Todo example, added "Buy groceries" and "Set up dev environment", then removed the first via "Done" — confirming Python↔WebSocket state sync end-to-end.

Dockerfile validation (built locally with Docker, since this run is greenfield): image builds clean, and in a fresh container (non-login shell) `uv`/`bun`/`uvx` resolve from `/usr/local/bin` with no profile sourcing, then a fresh `git clone` + `make sync` completes with exit 0.

[pulse_todo_app_clean_demo.mp4](https://cursor.com/agents/bc-ffd49f11-dd9f-48ed-8606-ea1e13a954c3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpulse_todo_app_clean_demo.mp4)

[Two todo items added](https://cursor.com/agents/bc-ffd49f11-dd9f-48ed-8606-ea1e13a954c3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftodo_two_items_clean.webp)
[After removing first item](https://cursor.com/agents/bc-ffd49f11-dd9f-48ed-8606-ea1e13a954c3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftodo_after_remove_clean.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ffd49f11-dd9f-48ed-8606-ea1e13a954c3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ffd49f11-dd9f-48ed-8606-ea1e13a954c3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

