### PR TITLE
Split agent-browser vs Cursor built-in browser in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,10 +14,13 @@ Full-stack Python framework for interactive web apps. Runs on React with WebSock
 - Use `make bump` for changing package versions
 - When using a framework/library, do not make assumptions, fetch latest docs (using context7 for example)
 - Use `bun info ...` to get information about a JS package
-- Test examples by running them with `pulse run` in a background task and using the agent-browser CLI for interacting with the UI. First page load after `pulse run` can 504 while Vite prebundles — reload once.
+- Test examples by running them with `pulse run` in a background task. First page load after `pulse run` can 504 while Vite prebundles — reload once. Local CLI agents (Codex, etc.): use the agent-browser CLI for the UI. Cursor: see Cursor instructions.
 - While debugging, feel free to add debug print statements, spin up test files, modify existing code, or anything else that would improve your feedback loop and accelerate the troubleshooting process. Remove those debug changes after fixing the issue.
 - Tests should never be used as a reason to keep aliases or dead code around.
 
+## Cursor instructions
+
+- Built-in browser for UI testing. Do not install or use `agent-browser` — that's for local CLI agents like Codex.
 
 ## Code Style
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Splits example UI testing in `AGENTS.md`:

- Shared: `pulse run` in the background; first load can 504 — reload once.
- Local CLI agents (Codex, etc.): `agent-browser`.
- Cursor: new **Cursor instructions** section — use the built-in browser, do not install `agent-browser`.

`CLAUDE.md` is a symlink to `AGENTS.md`, so it picks this up automatically.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f366b6b-9ef1-45e1-8123-be85ab6a90cf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f366b6b-9ef1-45e1-8123-be85ab6a90cf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

