### PR TITLE
Keep interned ChannelBridge objects across unsubscribes

### DIFF
--- a/docs/content/docs/(core)/advanced/channels.mdx
+++ b/docs/content/docs/(core)/advanced/channels.mdx
@@ -204,6 +204,7 @@ A subscribed client can send events while the route is still there.
 If no bridge is subscribed, Pulse keeps the last 64 events from emit().
 Pulse sends them in order when the client subscribes again.
 Client `emit()` uses the same limit while it waits to subscribe.
+After the server closes the channel, client `emit()` does nothing.
 If there are more than 64 events, Pulse removes the oldest event.
 If Pulse removes an event, your handler does not receive it.
 

--- a/docs/content/docs/reference/pulse-client/classes.mdx
+++ b/docs/content/docs/reference/pulse-client/classes.mdx
@@ -16,6 +16,7 @@ Manages bidirectional communication over a Pulse channel. You get a ChannelBridg
 ```ts
 class ChannelBridge {
   readonly id: string;
+  readonly closed: boolean;
 
   emit(event: string, payload?: any): void;
   request(event: string, payload?: any): Promise<any>;
@@ -30,12 +31,16 @@ type ChannelEventHandler = (payload: any) => any | Promise<any>;
 | Property | Type | Description |
 |----------|------|-------------|
 | `id` | `string` | The channel identifier |
+| `closed` | `boolean` | `true` after the server closes the channel |
 
 ### Methods
 
 #### emit
 
 Sends a fire-and-forget event to the server. The server receives the event but does not send a response.
+
+Queues up to 64 events while the client is not subscribed. Drops the oldest
+event at the cap. Does nothing if the channel is closed.
 
 ```ts
 emit(event: string, payload?: any): void
@@ -73,7 +78,8 @@ request(event: string, payload?: any): Promise<any>
 
 **Returns:** Promise resolving to the server's response.
 
-**Throws:** `PulseChannelResetError` if the channel closes before the response arrives.
+**Throws:** `PulseChannelResetError` if the channel is closed, not subscribed, or
+closes before the response arrives. Requests are not queued.
 
 **Example:**
 

--- a/docs/content/docs/reference/pulse-client/hooks.mdx
+++ b/docs/content/docs/reference/pulse-client/hooks.mdx
@@ -110,7 +110,7 @@ import { usePulseChannel } from "pulse-ui-client";
 function usePulseChannel(
   channelId: string,
   lifetime: "route" | "tab" = "route",
-): ChannelBridge | null
+): ChannelBridge
 ```
 
 ### Parameters
@@ -122,8 +122,8 @@ function usePulseChannel(
 
 ### Returns
 
-Returns `null` before the effect subscribes. It then returns a `ChannelBridge`
-for sending and receiving messages.
+Returns a `ChannelBridge` on the first render. The hook interns the bridge
+immediately and subscribes after commit.
 
 ### Throws
 
@@ -134,14 +134,14 @@ for sending and receiving messages.
 
 The hook manages channel subscription automatically:
 
-1. On mount: acquires a reference to the channel
-2. On unmount: releases the reference
-3. When all references are released: the local bridge is removed and the client unsubscribes
+1. On render: intern a stable `ChannelBridge` for this channel id
+2. On mount: subscribe to the server
+3. On unmount: unsubscribe. This does not close the bridge.
 4. The server closes the channel only at its configured lifetime boundary or after `Channel.close()`
 
-If the transport or subscription is not ready, `emit()` buffers up to 64 events.
-It drops the oldest event when the buffer is full. `request()` fails immediately
-and is not replayed.
+`emit()` queues up to 64 events while the subscription is not ready.
+It no-ops after the server closes the channel. `request()` fails immediately
+when the channel is disconnected or closed and is not replayed.
 
 Use the same lifetime on both sides:
 

--- a/docs/content/docs/reference/pulse-client/types.mdx
+++ b/docs/content/docs/reference/pulse-client/types.mdx
@@ -713,6 +713,7 @@ Type for the channel bridge class.
 ```ts
 interface ChannelBridge {
   readonly id: string;
+  readonly closed: boolean;
   emit(event: string, payload?: any): void;
   request(event: string, payload?: any): Promise<any>;
   on(event: string, handler: ChannelEventHandler): () => void;

--- a/packages/pulse-mantine/js/src/combobox.tsx
+++ b/packages/pulse-mantine/js/src/combobox.tsx
@@ -1,10 +1,6 @@
 import { Combobox as MantineCombobox, useCombobox } from "@mantine/core";
-import {
-	usePulseChannelOwner,
-	usePulseClient,
-	type ChannelBridge,
-} from "pulse-ui-client";
-import { type ComponentPropsWithoutRef, useEffect, useRef } from "react";
+import { usePulseChannel } from "pulse-ui-client";
+import { type ComponentPropsWithoutRef, useEffect } from "react";
 
 type DropdownEventSource = "keyboard" | "mouse" | "unknown";
 
@@ -42,32 +38,31 @@ export function Combobox({
 	scrollBehavior,
 	...rest
 }: PulseComboboxProps) {
-	const client = usePulseClient();
-	const owner = usePulseChannelOwner();
-	const channelRef = useRef<ChannelBridge | null>(null);
+	const channel = usePulseChannel(channelId);
 
 	const combobox = useCombobox({
 		defaultOpened,
 		opened,
 		onOpenedChange: (nextOpened) => {
 			onOpenedChange?.(nextOpened);
-			channelRef.current?.emit("openedChange", { opened: nextOpened });
+			channel.emit("openedChange", { opened: nextOpened });
 		},
 		onDropdownOpen: (eventSource) => {
 			onDropdownOpen?.(eventSource);
-			channelRef.current?.emit("dropdownOpen", { eventSource });
+			channel.emit("dropdownOpen", { eventSource });
 		},
 		onDropdownClose: (eventSource) => {
 			onDropdownClose?.(eventSource);
-			channelRef.current?.emit("dropdownClose", { eventSource });
+			channel.emit("dropdownClose", { eventSource });
 		},
 		loop,
 		scrollBehavior,
 	});
 
 	useEffect(() => {
-		const channel = client.acquireChannel(channelId, owner);
-		channelRef.current = channel;
+		if (channel.closed) {
+			return;
+		}
 		const cleanups = [
 			channel.on("openDropdown", (payload: OptionalEventSourcePayload) => {
 				combobox.openDropdown(payload?.eventSource);
@@ -113,12 +108,8 @@ export function Combobox({
 
 		return () => {
 			for (const dispose of cleanups) dispose();
-			if (channelRef.current === channel) {
-				channelRef.current = null;
-			}
-			client.releaseChannel(channelId, channel);
 		};
-	}, [client, channelId, owner, combobox]);
+	}, [channel, combobox]);
 
 	return <MantineCombobox {...(rest as any)} store={combobox} />;
 }

--- a/packages/pulse-mantine/js/src/form/form.tsx
+++ b/packages/pulse-mantine/js/src/form/form.tsx
@@ -1,12 +1,9 @@
 import type { UseFormInput, UseFormReturnType } from "@mantine/form";
 import { useForm } from "@mantine/form";
 import {
-	PulseChannelResetError,
 	submitForm,
-	usePulseChannelOwner,
-	usePulseClient,
+	usePulseChannel,
 	usePulseDirectivesSource,
-	type ChannelBridge,
 } from "pulse-ui-client";
 import {
 	type ComponentPropsWithoutRef,
@@ -66,10 +63,8 @@ export function Form<TValues extends Record<string, any> = Record<string, any>>(
 	cascadeUpdates,
 	...formProps
 }: MantineFormProps<TValues>) {
-	const client = usePulseClient();
-	const owner = usePulseChannelOwner();
+	const channel = usePulseChannel(channelId);
 	const directives = usePulseDirectivesSource();
-	const channelRef = useRef<ChannelBridge | null>(null);
 	const formRef = useRef<UseFormReturnType<TValues> | null>(null);
 	// Timers for server-validation per path
 	const serverTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
@@ -94,16 +89,18 @@ export function Form<TValues extends Record<string, any> = Record<string, any>>(
 		>;
 	}, [validate]);
 
-	const emitChannel = useCallback((event: string, payload?: any) => {
-		const channel = channelRef.current;
-		if (!channel || channel.closed) return;
-		try {
-			channel.emit(event, payload);
-		} catch (error) {
-			if (!(error instanceof PulseChannelResetError)) throw error;
-			if (channelRef.current === channel) channelRef.current = null;
-		}
-	}, []);
+	const sendSync = useCallback(
+		(reason: "change" | "blur", path?: string) => {
+			const values = formRef.current?.getValues();
+			if (!values) return;
+			channel.emit("syncValues", {
+				reason,
+				path,
+				values: stripFilesForSync(values),
+			});
+		},
+		[channel],
+	);
 
 	const clearPendingTimers = useCallback(() => {
 		serverTimersRef.current.forEach(clearTimeout);
@@ -111,19 +108,6 @@ export function Form<TValues extends Record<string, any> = Record<string, any>>(
 		syncTimersRef.current.forEach(clearTimeout);
 		syncTimersRef.current.clear();
 	}, []);
-
-	const sendSync = useCallback(
-		(reason: "change" | "blur", path?: string) => {
-			const values = formRef.current?.getValues();
-			if (!values) return;
-			emitChannel("syncValues", {
-				reason,
-				path,
-				values: stripFilesForSync(values),
-			});
-		},
-		[emitChannel],
-	);
 
 	const getValueAtPath = useCallback((source: any, path?: string) => {
 		if (!source || !path) return undefined;
@@ -215,7 +199,7 @@ export function Form<TValues extends Record<string, any> = Record<string, any>>(
 						const latestValues = formRef.current?.getValues();
 						if (!latestValues) return;
 						const value = getValueAtPath(latestValues, path);
-						emitChannel("serverValidate", {
+						channel.emit("serverValidate", {
 							value: stripFilesForSync(value),
 							values: stripFilesForSync(latestValues),
 							path,
@@ -232,7 +216,7 @@ export function Form<TValues extends Record<string, any> = Record<string, any>>(
 			sendSync,
 			serverRulesByPath,
 			shouldValidateOnChange,
-			emitChannel,
+			channel,
 		],
 	);
 
@@ -278,13 +262,13 @@ export function Form<TValues extends Record<string, any> = Record<string, any>>(
 			const latestValues = formRef.current?.getValues();
 			if (!latestValues) return;
 			const value = getValueAtPath(latestValues, path);
-			emitChannel("serverValidate", {
+			channel.emit("serverValidate", {
 				value: stripFilesForSync(value),
 				values: stripFilesForSync(latestValues),
 				path,
 			});
 		},
-		[getValueAtPath, syncMode, sendSync, serverRulesByPath, shouldValidateOnBlur, emitChannel],
+		[getValueAtPath, syncMode, sendSync, serverRulesByPath, shouldValidateOnBlur, channel],
 	);
 
 	const form = useForm<any>({
@@ -309,8 +293,9 @@ export function Form<TValues extends Record<string, any> = Record<string, any>>(
 	}, [clearPendingTimers]);
 
 	useEffect(() => {
-		const channel = client.acquireChannel(channelId, owner);
-		channelRef.current = channel;
+		if (channel.closed) {
+			return;
+		}
 		const cleanups = [
 			channel.on("setValues", (payload: { values: TValues }) => {
 				const currentForm = formRef.current;
@@ -399,12 +384,8 @@ export function Form<TValues extends Record<string, any> = Record<string, any>>(
 		return () => {
 			clearPendingTimers();
 			for (const dispose of cleanups) dispose();
-			if (channelRef.current === channel) {
-				channelRef.current = null;
-			}
-			client.releaseChannel(channelId, channel);
 		};
-	}, [client, channelId, owner, sendSync, clearPendingTimers]);
+	}, [channel, sendSync, clearPendingTimers]);
 
 	const submitHandler = useMemo(
 		() =>

--- a/packages/pulse-mantine/js/src/form/integration.test.tsx
+++ b/packages/pulse-mantine/js/src/form/integration.test.tsx
@@ -4,17 +4,25 @@ import { fireEvent, render } from "@testing-library/react";
 import { useField } from "./connect";
 import { Checkbox, CheckboxGroup, MultiSelect, TagsInput, TextInput } from "./fields";
 
-class PulseChannelResetError extends Error {}
+const channels = new Map<
+	string,
+	{ closed: boolean; on: () => () => void; emit: ReturnType<typeof mock> }
+>();
 
-const channel = {
-	closed: false,
-	on: () => () => {},
-	emit: mock(),
-};
-const client = {
-	acquireChannel: () => channel,
-	releaseChannel: () => {},
-};
+function channelFor(id: string) {
+	let channel = channels.get(id);
+	if (!channel) {
+		channel = {
+			closed: false,
+			on: () => () => {},
+			emit: mock(() => {}),
+		};
+		channels.set(id, channel);
+	}
+	return channel;
+}
+
+const usePulseChannel = mock((id: string) => channelFor(id));
 let currentDirectives = {
 	query: { pulse_deployment: "prod-old" },
 };
@@ -24,19 +32,15 @@ const submitForm = mock(
 );
 
 mock.module("pulse-ui-client", () => ({
-	PulseChannelResetError,
 	submitForm,
-	usePulseChannelOwner: () => "/",
-	usePulseClient: () => client,
+	usePulseChannel,
 	usePulseDirectivesSource: () => directivesSource,
 }));
 
 const { Form } = await import("./form");
 
 beforeEach(() => {
-	channel.closed = false;
-	channel.emit.mockClear();
-	channel.emit.mockImplementation(() => {});
+	channels.clear();
 });
 
 type Sample = {
@@ -109,7 +113,6 @@ describe("MantineForm list-valued fields", () => {
 		"reproduces custom useField list commit for %s rows",
 		(_label, rows) => {
 			submitForm.mockClear();
-			channel.emit.mockClear();
 			const view = render(
 				<MantineProvider>
 					<Form
@@ -126,7 +129,7 @@ describe("MantineForm list-valued fields", () => {
 			);
 
 			fireEvent.click(view.getByRole("button", { name: "Commit rows" }));
-			const sync = channel.emit.mock.calls.find(
+			const sync = channelFor("form-custom-list-repro").emit.mock.calls.find(
 				([event]) => event === "syncValues",
 			)?.[1];
 			expect(sync?.values).toEqual({ samples: rows });
@@ -139,7 +142,6 @@ describe("MantineForm list-valued fields", () => {
 
 	it.each(listFields)("submits %s values as a list", (_label, Field) => {
 		submitForm.mockClear();
-		channel.emit.mockClear();
 		const view = render(
 			<MantineProvider>
 				<Form
@@ -171,7 +173,7 @@ describe("MantineForm list-valued fields", () => {
 			fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
 		}
 
-		expect(channel.emit).toHaveBeenCalledWith("syncValues", {
+		expect(channelFor("form-list-fields").emit).toHaveBeenCalledWith("syncValues", {
 			reason: "change",
 			path: "tags",
 			values: { tags: ["react", "vue"] },
@@ -184,7 +186,6 @@ describe("MantineForm list-valued fields", () => {
 
 	it("submits CheckboxGroup values as a list", () => {
 		submitForm.mockClear();
-		channel.emit.mockClear();
 		const view = render(
 			<MantineProvider>
 				<Form
@@ -205,7 +206,7 @@ describe("MantineForm list-valued fields", () => {
 			true,
 		);
 		fireEvent.click(view.getByRole("checkbox", { name: "Editor" }));
-		expect(channel.emit).toHaveBeenCalledWith("syncValues", {
+		expect(channelFor("form-checkbox-group").emit).toHaveBeenCalledWith("syncValues", {
 			reason: "change",
 			path: "privileges",
 			values: { privileges: ["admin", "editor"] },
@@ -300,13 +301,10 @@ describe("MantineForm channel timer lifecycle", () => {
 		);
 		await new Promise((resolve) => setTimeout(resolve, 20));
 
-		expect(channel.emit).not.toHaveBeenCalled();
+		expect(channelFor("form-old").emit).not.toHaveBeenCalled();
 	});
 
-	it("contains reset errors from validation timer callbacks", async () => {
-		channel.emit.mockImplementation(() => {
-			throw new PulseChannelResetError("Channel is closed");
-		});
+	it("fires server validation after the debounce", async () => {
 		const view = render(
 			<MantineProvider>
 				<Form
@@ -326,7 +324,7 @@ describe("MantineForm channel timer lifecycle", () => {
 		fireEvent.change(view.getByRole("textbox"), { target: { value: "Grace" } });
 		await new Promise((resolve) => setTimeout(resolve, 10));
 
-		expect(channel.emit).toHaveBeenCalledWith("serverValidate", {
+		expect(channelFor("form-reset").emit).toHaveBeenCalledWith("serverValidate", {
 			path: "name",
 			value: "Grace",
 			values: { name: "Grace" },
@@ -334,10 +332,7 @@ describe("MantineForm channel timer lifecycle", () => {
 		view.unmount();
 	});
 
-	it("contains reset errors from sync timer callbacks", async () => {
-		channel.emit.mockImplementation(() => {
-			throw new PulseChannelResetError("Channel is closed");
-		});
+	it("fires value sync after the debounce", async () => {
 		const view = render(
 			<MantineProvider>
 				<Form
@@ -354,7 +349,7 @@ describe("MantineForm channel timer lifecycle", () => {
 		fireEvent.change(view.getByRole("textbox"), { target: { value: "Lin" } });
 		await new Promise((resolve) => setTimeout(resolve, 10));
 
-		expect(channel.emit).toHaveBeenCalledWith("syncValues", {
+		expect(channelFor("form-sync-reset").emit).toHaveBeenCalledWith("syncValues", {
 			path: "name",
 			reason: "change",
 			values: { name: "Lin" },

--- a/packages/pulse-mantine/js/src/notifications.test.tsx
+++ b/packages/pulse-mantine/js/src/notifications.test.tsx
@@ -7,19 +7,17 @@ const channel = {
 	on: mock(() => () => {}),
 	emit: mock(() => {}),
 };
-const acquireChannel = mock((_id: string) => channel);
-const releaseChannel = mock(() => {});
-const usePulseChannelOwner = mock(() => ({
-	token: "/current-route",
-	attachPath: "/current-route",
-}));
-class PulseChannelResetError extends Error {}
+const usePulseChannel = mock((_id: string, _lifetime?: string) => channel);
 
 mock.module("pulse-ui-client", () => ({
-	PulseChannelResetError,
+	PulseChannelResetError: class PulseChannelResetError extends Error {},
 	submitForm: mock(() => {}),
-	usePulseChannelOwner,
-	usePulseClient: () => ({ acquireChannel, releaseChannel }),
+	usePulseChannel,
+	usePulseChannelOwner: mock(() => ({
+		token: "/current-route",
+		attachPath: "/current-route",
+	})),
+	usePulseClient: () => ({}),
 	usePulseDirectivesSource: () => undefined,
 }));
 
@@ -32,9 +30,7 @@ it("subscribes to its tab channel without route ownership", () => {
 		</MantineProvider>,
 	);
 
-	expect(acquireChannel.mock.calls).toEqual([["notifications-tab"]]);
-	expect(usePulseChannelOwner).not.toHaveBeenCalled();
+	expect(usePulseChannel.mock.calls).toEqual([["notifications-tab", "tab"]]);
 
 	view.unmount();
-	expect(releaseChannel).toHaveBeenCalledWith("notifications-tab", channel);
 });

--- a/packages/pulse-mantine/js/src/notifications.tsx
+++ b/packages/pulse-mantine/js/src/notifications.tsx
@@ -5,8 +5,8 @@ import {
 	type NotificationsProps,
 	notifications as notificationsApi,
 } from "@mantine/notifications";
-import { usePulseClient, type ChannelBridge } from "pulse-ui-client";
-import { useEffect, useRef } from "react";
+import { usePulseChannel } from "pulse-ui-client";
+import { useEffect } from "react";
 
 type NotificationUpdatePayload = Parameters<typeof notificationsApi.update>[0];
 type NotificationShowPayload = NotificationData;
@@ -38,14 +38,11 @@ export function Notifications({ channelId, ...props }: PulseNotificationsProps) 
 
 function ConnectedNotifications({ channelId, ...props }: ConnectedNotificationsProps) {
 	const { store = defaultStore, ...rest } = props;
-	const client = usePulseClient();
-	const channelRef = useRef<ChannelBridge | null>(null);
+	const channel = usePulseChannel(channelId, "tab");
 
 	useEffect(() => {
-		if (!channelId) return;
+		if (channel.closed) return;
 
-		const channel = client.acquireChannel(channelId);
-		channelRef.current = channel;
 		const cleanups = [
 			channel.on("show", (payload: unknown) => {
 				if (!isNotificationData(payload)) return;
@@ -75,15 +72,13 @@ function ConnectedNotifications({ channelId, ...props }: ConnectedNotificationsP
 				notificationsApi.updateState(store, () => next as NotificationData[]);
 			}),
 			store.subscribe((state) => {
-				const currentChannel = channelRef.current;
-				if (!currentChannel) return;
 				const notificationIds = state.notifications
 					.map((item) => item.id)
 					.filter((id): id is string => !!id && id.length > 0);
 				const queueIds = state.queue
 					.map((item) => item.id)
 					.filter((id): id is string => !!id && id.length > 0);
-				currentChannel.emit("stateSync", {
+				channel.emit("stateSync", {
 					notifications: notificationIds,
 					queue: queueIds,
 				});
@@ -94,12 +89,8 @@ function ConnectedNotifications({ channelId, ...props }: ConnectedNotificationsP
 			for (const dispose of cleanups) {
 				dispose();
 			}
-			if (channelRef.current === channel) {
-				channelRef.current = null;
-			}
-			client.releaseChannel(channelId, channel);
 		};
-	}, [client, channelId, store]);
+	}, [channel, store]);
 
 	return <MantineNotifications {...rest} store={store} />;
 }

--- a/packages/pulse-mantine/js/src/tree.tsx
+++ b/packages/pulse-mantine/js/src/tree.tsx
@@ -1,10 +1,6 @@
 import { Tree as MantineTree, useTree } from "@mantine/core";
-import {
-	usePulseChannelOwner,
-	usePulseClient,
-	type ChannelBridge,
-} from "pulse-ui-client";
-import { type ComponentPropsWithoutRef, useEffect, useRef } from "react";
+import { usePulseChannel } from "pulse-ui-client";
+import { type ComponentPropsWithoutRef, useEffect } from "react";
 
 type ExpandedState = Record<string, boolean>;
 
@@ -63,9 +59,7 @@ function ConnectedTree({
 	autoSync = true,
 	...rest
 }: ConnectedTreeProps) {
-	const client = usePulseClient();
-	const owner = usePulseChannelOwner();
-	const channelRef = useRef<ChannelBridge | null>(null);
+	const channel = usePulseChannel(channelId);
 
 	// Create controller with initial state and wire auto-sync callbacks
 	const tree = useTree({
@@ -75,19 +69,17 @@ function ConnectedTree({
 		multiple,
 		onNodeExpand: (value: string) => {
 			if (!autoSync) return;
-			channelRef.current?.emit("nodeExpand", { value });
+			channel.emit("nodeExpand", { value });
 		},
 		onNodeCollapse: (value: string) => {
 			if (!autoSync) return;
-			channelRef.current?.emit("nodeCollapse", { value });
+			channel.emit("nodeCollapse", { value });
 		},
 	} as any);
 
 	// Server -> client imperative API
 	useEffect(() => {
-		if (!channelId) return;
-		const channel = client.acquireChannel(channelId, owner);
-		channelRef.current = channel;
+		if (channel.closed) return;
 		const cleanups = [
 			channel.on("toggleExpanded", (payload: { value: string }) => {
 				if (!payload) return;
@@ -165,12 +157,8 @@ function ConnectedTree({
 		];
 		return () => {
 			for (const dispose of cleanups) dispose();
-			if (channelRef.current === channel) {
-				channelRef.current = null;
-			}
-			client.releaseChannel(channelId, channel);
 		};
-	}, [client, channelId, owner, tree]);
+	}, [channel, tree]);
 
 	return <MantineTree {...(rest as any)} tree={tree as any} />;
 }

--- a/packages/pulse/js/src/channel.test.ts
+++ b/packages/pulse/js/src/channel.test.ts
@@ -96,7 +96,7 @@ describe("ChannelBridge", () => {
 		expect(sent.at(-1)).toMatchObject({ event: "after-reconnect" });
 	});
 
-	it("reacquires a fresh bridge after release closes a channel", () => {
+	it("does not close the bridge on release and reuses it on reacquire", () => {
 		const client = new PulseSocketIOClient(
 			"http://pulse.test",
 			{},
@@ -111,11 +111,19 @@ describe("ChannelBridge", () => {
 		const first = client.acquireChannel("chan-1");
 		client.releaseChannel("chan-1", first);
 
-		expect(() => first.on("event", vi.fn())).toThrow(PulseChannelResetError);
+		expect(first.closed).toBe(false);
+		expect(() => first.on("event", vi.fn())).not.toThrow();
 
 		const second = client.acquireChannel("chan-1");
-		expect(second).not.toBe(first);
-		expect(() => second.on("event", vi.fn())).not.toThrow();
+		expect(second).toBe(first);
+		expect(() => second.emit("after-release")).not.toThrow();
+	});
+
+	it("no-ops emit after the server closes the bridge", () => {
+		const { bridge, sent } = makeClient();
+		bridge.dispose(new PulseChannelResetError("Channel closed by server"));
+		expect(() => bridge.emit("after-close")).not.toThrow();
+		expect(sent).toHaveLength(0);
 	});
 });
 
@@ -124,21 +132,21 @@ describe("usePulseChannel", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("uses route ownership only for route-lifetime channels and releases each exact bridge", () => {
+	it("returns a bridge on the first render and subscribes with the matching owner", () => {
 		const path = "/current-route";
 		const fakeClient = { sendMessage: vi.fn() } as any;
-		const acquiredBridges: ChannelBridge[] = [];
 		vi.spyOn(PulseSocketIOClient.prototype, "connect").mockResolvedValue();
-		const acquireChannel = vi
-			.spyOn(PulseSocketIOClient.prototype, "acquireChannel")
-			.mockImplementation((id) => {
-				const bridge = new ChannelBridge(fakeClient, id);
-				acquiredBridges.push(bridge);
-				return bridge;
-			});
-		const releaseChannel = vi
-			.spyOn(PulseSocketIOClient.prototype, "releaseChannel")
+		const ensureChannel = vi
+			.spyOn(PulseSocketIOClient.prototype, "ensureChannel")
+			.mockImplementation((id) => new ChannelBridge(fakeClient, id));
+		const subscribeChannel = vi
+			.spyOn(PulseSocketIOClient.prototype, "subscribeChannel")
 			.mockImplementation(() => {});
+		const unsubscribeChannel = vi
+			.spyOn(PulseSocketIOClient.prototype, "unsubscribeChannel")
+			.mockImplementation(() => {});
+
+		const firstRender: Array<ChannelBridge | null> = [];
 
 		function Probe({
 			channelId,
@@ -147,7 +155,8 @@ describe("usePulseChannel", () => {
 			channelId: string;
 			lifetime: "route" | "tab";
 		}) {
-			usePulseChannel(channelId, lifetime);
+			const bridge = usePulseChannel(channelId, lifetime);
+			firstRender.push(bridge);
 			return null;
 		}
 
@@ -194,20 +203,34 @@ describe("usePulseChannel", () => {
 			{ reactStrictMode: true },
 		);
 
-		expect(acquireChannel.mock.calls).toEqual([
-			["route-channel", { token: path, attachPath: path }],
-			["tab-channel", undefined],
-			["route-channel", { token: path, attachPath: path }],
-			["tab-channel", undefined],
+		expect(firstRender.length).toBeGreaterThan(0);
+		expect(firstRender.every((bridge) => bridge instanceof ChannelBridge)).toBe(true);
+
+		expect([...new Set(ensureChannel.mock.calls.map(([id]) => id))].sort()).toEqual([
+			"route-channel",
+			"tab-channel",
 		]);
+		expect(
+			subscribeChannel.mock.calls.some(
+				([bridge, ownership]) =>
+					bridge.id === "route-channel" &&
+					ownership?.token === path &&
+					ownership?.attachPath === path,
+			),
+		).toBe(true);
+		expect(
+			subscribeChannel.mock.calls.some(
+				([bridge, ownership]) => bridge.id === "tab-channel" && ownership === undefined,
+			),
+		).toBe(true);
 
 		view.unmount();
 
-		expect(releaseChannel.mock.calls).toEqual([
-			["route-channel", acquiredBridges[0]],
-			["tab-channel", acquiredBridges[1]],
-			["route-channel", acquiredBridges[2]],
-			["tab-channel", acquiredBridges[3]],
-		]);
+		expect(
+			unsubscribeChannel.mock.calls.some(([bridge]) => bridge.id === "route-channel"),
+		).toBe(true);
+		expect(
+			unsubscribeChannel.mock.calls.some(([bridge]) => bridge.id === "tab-channel"),
+		).toBe(true);
 	});
 });

--- a/packages/pulse/js/src/channel.ts
+++ b/packages/pulse/js/src/channel.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo } from "react";
 import type { PulseSocketIOClient } from "./client";
 import type {
 	ChannelEventMessage,
@@ -55,7 +55,9 @@ export class ChannelBridge {
 	}
 
 	emit(event: string, payload?: any): void {
-		this.ensureOpen();
+		if (this._closed) {
+			return;
+		}
 		this.client.sendMessage({
 			type: "channel",
 			action: "event",
@@ -234,36 +236,35 @@ export class ChannelBridge {
 		this.pending.clear();
 		this.handlers.clear();
 		this.backlog = [];
-		// No-op: owning client manages registry lifecycle.
 	}
 }
 
 export function usePulseChannel(
 	channelId: string,
 	lifetime: ChannelLifetime = "route",
-): ChannelBridge | null {
+): ChannelBridge {
 	const client = usePulseClient();
 	const routeOwner = usePulseChannelOwner();
 	const ownerToken = lifetime === "route" ? routeOwner?.token : undefined;
 	const attachPath = lifetime === "route" ? routeOwner?.attachPath : undefined;
 
-	const [bridge, setBridge] = useState<ChannelBridge | null>(null);
-
-	useEffect(() => {
+	const bridge = useMemo(() => {
 		if (!channelId) {
 			throw new Error("usePulseChannel requires a non-empty channelId");
 		}
+		return client.ensureChannel(channelId);
+	}, [client, channelId]);
+
+	useEffect(() => {
 		const ownership =
 			ownerToken === undefined && attachPath === undefined
 				? undefined
 				: { token: ownerToken, attachPath };
-		const acquired = client.acquireChannel(channelId, ownership);
-		setBridge(acquired);
+		client.subscribeChannel(bridge, ownership);
 		return () => {
-			setBridge((current) => (current === acquired ? null : current));
-			client.releaseChannel(channelId, acquired);
+			client.unsubscribeChannel(bridge);
 		};
-	}, [client, channelId, lifetime, ownerToken, attachPath]);
+	}, [client, bridge, ownerToken, attachPath]);
 
 	return bridge;
 }

--- a/packages/pulse/js/src/client.test.ts
+++ b/packages/pulse/js/src/client.test.ts
@@ -230,7 +230,7 @@ describe("PulseSocketIOClient attach ack", () => {
 			channel: "chan-1",
 			owner: "view-owner",
 		});
-		expect(second).not.toBe(first);
+		expect(second).toBe(first);
 
 		socket.trigger(
 			"message",
@@ -410,7 +410,8 @@ describe("PulseSocketIOClient attach ack", () => {
 			}),
 		);
 		expect(bridge.closed).toBe(true);
-		expect(() => bridge.emit("after-close")).toThrow("Channel is closed");
+		expect(() => bridge.emit("after-close")).not.toThrow();
+		expect(sentMessages().some((message) => message.event === "after-close")).toBe(false);
 		expect(connect.subscriptionId).not.toBe(reconnect.subscriptionId);
 		const afterClose = sentMessages().length;
 		client.releaseChannel("chan-1", bridge);
@@ -502,6 +503,41 @@ describe("PulseSocketIOClient attach ack", () => {
 			}),
 		);
 		expect(second.closed).toBe(true);
+	});
+
+	it("queues emits from ensureChannel until the bridge is subscribed", async () => {
+		const client = await makeClient();
+		const connected = client.connect();
+		socket.trigger("connect");
+		await connected;
+
+		const bridge = client.ensureChannel("chan-1");
+		bridge.emit("before-subscribe");
+		expect(sentMessages()).toEqual([]);
+
+		client.subscribeChannel(bridge);
+		const connect = sentMessages().at(-1)!;
+		expect(connect).toMatchObject({
+			type: "channel",
+			action: "connect",
+			channel: "chan-1",
+		});
+		socket.trigger(
+			"message",
+			serialize({
+				type: "channel",
+				action: "connect_ack",
+				channel: "chan-1",
+				subscriptionId: connect.subscriptionId,
+				accepted: true,
+			}),
+		);
+		expect(sentMessages().at(-1)).toMatchObject({
+			type: "channel",
+			action: "event",
+			event: "before-subscribe",
+			subscriptionId: connect.subscriptionId,
+		});
 	});
 
 	it("drops queued events and closes a rejected subscription", async () => {

--- a/packages/pulse/js/src/client.tsx
+++ b/packages/pulse/js/src/client.tsx
@@ -613,18 +613,33 @@ export class PulseSocketIOClient {
 		this.sendMessage(msg);
 	}
 
-	public acquireChannel(id: string, ownership?: ChannelOwnership): ChannelBridge {
-		let entry = this.#channels.get(id);
-		if (
-			entry &&
-			!entry.bridge.closed &&
-			(entry.ownerToken !== ownership?.token || entry.attachPath !== ownership?.attachPath)
-		) {
-			throw new Error(`Pulse channel '${id}' is already acquired by another owner`);
+	public ensureChannel(id: string): ChannelBridge {
+		const entry = this.#channels.get(id);
+		if (entry && !entry.bridge.closed) {
+			return entry.bridge;
 		}
-		if (!entry || entry.bridge.closed) {
+		const bridge = new ChannelBridge(this, id);
+		this.#channels.set(id, {
+			bridge,
+			queue: [],
+			refCount: 0,
+			subscribed: false,
+			subscriptionId: null,
+		});
+		return bridge;
+	}
+
+	public subscribeChannel(bridge: ChannelBridge, ownership?: ChannelOwnership): void {
+		if (bridge.closed) {
+			return;
+		}
+		let entry = this.#channels.get(bridge.id);
+		if (!entry || entry.bridge !== bridge) {
+			if (entry && !entry.bridge.closed) {
+				throw new Error(`Pulse channel '${bridge.id}' is already acquired by another owner`);
+			}
 			entry = {
-				bridge: new ChannelBridge(this, id),
+				bridge,
 				ownerToken: ownership?.token,
 				attachPath: ownership?.attachPath,
 				queue: [],
@@ -632,28 +647,46 @@ export class PulseSocketIOClient {
 				subscribed: false,
 				subscriptionId: null,
 			};
-			this.#channels.set(id, entry);
-			if (this.isConnected()) {
-				this.#connectChannelIfReady(entry, this.#socket!);
-			}
+			this.#channels.set(bridge.id, entry);
+		} else if (
+			entry.refCount > 0 &&
+			(entry.ownerToken !== ownership?.token || entry.attachPath !== ownership?.attachPath)
+		) {
+			throw new Error(`Pulse channel '${bridge.id}' is already acquired by another owner`);
+		} else if (entry.refCount === 0) {
+			entry.ownerToken = ownership?.token;
+			entry.attachPath = ownership?.attachPath;
 		}
 		entry.refCount += 1;
-		return entry.bridge;
+		if (this.isConnected()) {
+			this.#connectChannelIfReady(entry, this.#socket!);
+		}
 	}
 
-	public releaseChannel(id: string, bridge: ChannelBridge): void {
-		const entry = this.#channels.get(id);
+	public unsubscribeChannel(bridge: ChannelBridge): void {
+		const entry = this.#channels.get(bridge.id);
 		if (!entry || entry.bridge !== bridge) {
 			return;
 		}
 		entry.refCount = Math.max(0, entry.refCount - 1);
 		if (entry.refCount === 0) {
-			entry.bridge.dispose(new PulseChannelResetError("Channel released"));
 			if (this.isConnected() && entry.subscriptionId !== null) {
 				this.#sendChannelDisconnect(entry, this.#socket!);
 			}
-			this.#channels.delete(id);
+			entry.subscribed = false;
+			entry.subscriptionId = null;
+			entry.queue = [];
 		}
+	}
+
+	public acquireChannel(id: string, ownership?: ChannelOwnership): ChannelBridge {
+		const bridge = this.ensureChannel(id);
+		this.subscribeChannel(bridge, ownership);
+		return bridge;
+	}
+
+	public releaseChannel(_id: string, bridge: ChannelBridge): void {
+		this.unsubscribeChannel(bridge);
 	}
 
 	#routeChannelMessage(
@@ -711,6 +744,7 @@ export class PulseSocketIOClient {
 			entry.bridge.dispose(
 				new PulseChannelResetError(message.error ?? "Channel subscription rejected"),
 			);
+			this.#channels.delete(message.channel);
 			return;
 		}
 		if (!this.isConnected() || entry.bridge.closed) return;
@@ -729,13 +763,11 @@ export class PulseSocketIOClient {
 		const entry = this.#channels.get(message.channel);
 		if (!entry || entry.subscriptionId !== message.subscriptionId) return;
 		entry.bridge.dispose(new PulseChannelResetError("Channel closed by server"));
-		entry.subscriptionId = null;
-		entry.subscribed = false;
-		entry.queue = [];
+		this.#channels.delete(message.channel);
 	}
 
 	#connectChannelIfReady(entry: ChannelEntry, socket: Socket): void {
-		if (entry.bridge.closed || entry.subscriptionId !== null) return;
+		if (entry.bridge.closed || entry.subscriptionId !== null || entry.refCount === 0) return;
 		if (entry.attachPath !== undefined && !this.#isAttachAcked(entry.attachPath)) return;
 		this.#sendChannelConnect(entry, socket);
 	}

--- a/packages/pulse/python/src/pulse/js/pulse.py
+++ b/packages/pulse/python/src/pulse/js/pulse.py
@@ -12,19 +12,16 @@ def MyChannelComponent(*, channel_id: str):
 
     # Subscribe to events
     useEffect(
-        lambda: bridge and bridge.on("server:notify", lambda payload: console.log(payload)),
+        lambda: bridge.on("server:notify", lambda payload: console.log(payload)),
         [bridge],
     )
 
     # Emit events to server
     def send_ping():
-        if bridge:
-            bridge.emit("client:ping", {"message": "hello"})
+        bridge.emit("client:ping", {"message": "hello"})
 
     # Make requests to server
     async def send_request():
-        if not bridge:
-            return
         response = await bridge.request("client:request", {"data": 123})
         console.log(response)
 
@@ -64,8 +61,16 @@ class ChannelBridge:
 		"""The unique channel identifier."""
 		...
 
+	@property
+	def closed(self) -> bool:
+		"""Whether the server has closed this channel."""
+		...
+
 	def emit(self, event: str, payload: _Any = None) -> None:
 		"""Emit an event to the server.
+
+		Queues the event while the client is not subscribed, up to 64 events.
+		Does nothing if the channel has been closed.
 
 		Args:
 		    event: The event name to emit.
@@ -103,7 +108,7 @@ class ChannelBridge:
 def usePulseChannel(
 	channel_id: str,
 	lifetime: _Literal["route", "tab"] = "route",
-) -> ChannelBridge | None:
+) -> ChannelBridge:
 	"""React hook to connect to a Pulse channel.
 
 	Must be called from within a React component. The channel connection

--- a/skills/pulse/references/channels.md
+++ b/skills/pulse/references/channels.md
@@ -41,8 +41,10 @@ self.channel.emit("server:notify", {"type": "update", "data": {...}})
 ```
 
 Disconnected emits are buffered in a 64-event FIFO. Pulse flushes them when the
-client subscribes again and drops the oldest event at the cap. Client bridge
-emits use the same policy while the subscription is not ready.
+client subscribes again and drops the oldest event at the cap. Client
+`emit()` uses the same queue before the hook has subscribed and while the
+socket is down. After the server closes the channel, client `emit()` is a
+no-op.
 
 ### Request (with response)
 
@@ -127,8 +129,9 @@ For a tab-lifetime server channel, use `usePulseChannel(channelId, "tab")`.
 ### Client Bridge API
 
 ```typescript
-bridge.emit(event: string, payload?: any): void
-bridge.request(event: string, payload?: any): Promise<any>
+bridge.closed: boolean
+bridge.emit(event: string, payload?: any): void  // queues while unsubscribed; no-op if closed
+bridge.request(event: string, payload?: any): Promise<any>  // throws if closed or unsubscribed
 bridge.on(event: string, handler: (payload) => any): () => void
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #129. The public `ChannelBridge` stays interned after unsubscribe so React consumers can hold a stable object without `emit()` throwing on a closed leftover.

**API**
- `usePulseChannel` returns a `ChannelBridge` on the first render (never `null`)
- Unsubscribe drops the 64-event queue and sends disconnect, but does not dispose the object
- Terminal close / reject / `client.disconnect()` dispose and delete the registry entry
- `emit()` queues while unsubscribed or the socket is down; no-ops after server close
- `request()` still fails immediately when closed or disconnected

**Consumers**
- Pulse Mantine form, combobox, tree, and notifications use `usePulseChannel` only
- `acquireChannel` / `releaseChannel` remain for VDOM/ref wiring as subscribe/unsubscribe wrappers

**Tests**
- Client: emit-before-subscribe, emit no-op after close, same object on reacquire
- Hook: first-render bridge + subscribe/unsubscribe
- Mantine: per-id mock channels so identity changes still clean up timers
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffcff-5d5e-7f12-ad15-4d5230afff14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffcff-5d5e-7f12-ad15-4d5230afff14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

