### PR TITLE
Rewrite channels as session-scoped names with attach/detach handles

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,3 +1,3 @@
 # Known Issues
 
-- Message ordering not guaranteed across global vs per-route queues on reconnect. Global messages (navigate_to, reload, api_call, channel_message) may flush before pending per-route updates/errors/js_exec. If strict cross-type ordering is required, use explicit sequencing or avoid reliance on ordering across queues.
+- Message ordering not guaranteed across global vs per-route queues on reconnect. Global messages (navigate_to, reload, api_call, channel) may flush before pending per-route updates/errors/js_exec. If strict cross-type ordering is required, use explicit sequencing or avoid reliance on ordering across queues.

--- a/docs/content/docs/(core)/advanced/channels.mdx
+++ b/docs/content/docs/(core)/advanced/channels.mdx
@@ -196,7 +196,7 @@ A channel id is just a name. Nothing is created or destroyed on the wire. The on
 - `"route"` (default) — tear down this handle's `on()` set when that route unmounts, even if you stored the object.
 - `"tab"` — do not detach on route unmount. Lives until the render session ends or you call `detach()`.
 
-After a route handle detaches, `on()` raises `ChannelDetached`; queued handlers that have not run are skipped. `emit()` is a debug-logged no-op, while `request()` still addresses the channel name.
+After a route handle detaches, `on()` and `request()` raise `ChannelDetached`; handlers still queued (or awaiting) are cancelled. `emit()` becomes a debug-logged no-op, since background tasks legitimately race an unmount.
 
 On the client, lifetime is React placement: put `useChannel(id)` in a route component to drop listeners on navigation, or in a layout to keep them for the tab. There is no `lifetime` argument on the hook.
 
@@ -206,9 +206,23 @@ Several live handles can share one name. Events fan out to all attached handles.
 chat.detach()
 ```
 
+## Event ordering
+
+Events on a handle are processed one at a time, in arrival order — each event's handlers are awaited before the next event starts. So a slow `async` handler delays later events instead of reordering them, and an event handler must never block indefinitely:
+
+```python
+# ❌ stalls every later event on this handle
+chat.on("ping", lambda _: chat.request("slow"))
+
+# ✅ bounded
+chat.on("ping", lambda _: chat.request("slow", timeout=5.0))
+```
+
+The guarantee covers **events only**. Inbound requests run as independent tasks — they can overtake queued events, and that's deliberate: a request handler often awaits a request back to the client, which would otherwise deadlock the handle. The event backlog is capped at 500 per handle (oldest dropped, one warning) so a stuck handler can't grow it forever.
+
 ## Error handling
 
-`emit()` raises `TypeError` immediately if its payload is not serializable. While the socket is down, events buffer in the session queue, capped at 1000 messages with the oldest dropped past that limit.
+`emit()` raises `TypeError` immediately if its payload is not serializable. While the socket is down, events buffer in the session queue: channel messages get their own 500-message budget (oldest dropped first, so a chatty channel can never evict control-plane messages like `reload` or `navigate_to`) inside an overall 1000-message bound.
 
 `request()` fails immediately if the socket is down. If the peer has no handler, you get a `ChannelRemoteError` with code `no_handler`. Middleware `Deny` is `denied`; a middleware exception is `handler_error`. The client timeout defaults to 30 seconds. Detaching the client handle rejects its in-flight requests with `PulseChannelDetachedError`.
 

--- a/docs/content/docs/(core)/advanced/channels.mdx
+++ b/docs/content/docs/(core)/advanced/channels.mdx
@@ -148,7 +148,7 @@ async def get_client_info(chat: ps.Channel):
 
 The `timeout` parameter prevents your code from waiting forever if the client doesn't respond.
 
-Don't `emit` during prerender or the first server render and expect the client to hear it. `useChannel` registers during render, so an emit after the hook has rendered is delivered. Earlier events drop.
+Don't `emit` during prerender or the first server render and expect the client to hear it. `useChannel` attaches in an effect, so events sent before that effect runs can drop.
 
 ## Using channels on the client
 
@@ -206,7 +206,9 @@ chat.detach()
 
 ## Error handling
 
-`request()` fails immediately if the socket is down. If the peer has no handler, you get a `ChannelRemoteError` with code `no_handler`. Middleware `Deny` is `denied`; a middleware exception is `handler_error`. It never hangs when `timeout=None`.
+`request()` fails immediately if the socket is down. If the peer has no handler, you get a `ChannelRemoteError` with code `no_handler`. Middleware `Deny` is `denied`; a middleware exception is `handler_error`. The client timeout defaults to 30 seconds. Detaching the client handle rejects its in-flight requests with `PulseChannelDetachedError`.
+
+Requests use the first attached handle in registration order that has a handler for the event. Events fan out to all attached handles for that channel name.
 
 ```python
 from pulse import ChannelDisconnected, ChannelRemoteError, ChannelTimeout

--- a/docs/content/docs/(core)/advanced/channels.mdx
+++ b/docs/content/docs/(core)/advanced/channels.mdx
@@ -196,7 +196,11 @@ A channel id is just a name. Nothing is created or destroyed on the wire. The on
 - `"route"` (default) — tear down this handle's `on()` set when that route unmounts, even if you stored the object.
 - `"tab"` — do not detach on route unmount. Lives until the render session ends or you call `detach()`.
 
-After a route handle detaches, `on()` raises `ChannelDetached`. `emit` and `request` still address the channel name.
+After a handle detaches, `on()` and `request()` raise `ChannelDetached`, and `emit()` becomes a no-op (background tasks racing an unmount shouldn't crash). Handlers already queued but not yet run are skipped.
+
+Several live handles can share one name — say a `"tab"` handle in a layout plus a `"route"` handle in a page. Events fan out to all of them. A request goes to just one: the first attached handle that has a handler for that event, in registration order.
+
+Events on a handle run in arrival order, and each event's handlers are awaited before the next event starts, so a slow `async` handler delays later events instead of reordering them. Inbound requests run independently of that queue, so a request handler is free to `await` a request back to the client.
 
 On the client, lifetime is React placement: put `useChannel(id)` in a route component to drop listeners on navigation, or in a layout to keep them for the tab. There is no `lifetime` argument on the hook.
 
@@ -205,6 +209,8 @@ chat.detach()
 ```
 
 ## Error handling
+
+`emit()` raises `TypeError` right away if the payload isn't serializable — you get the error where you emitted, not later at flush time. While the socket is down, events buffer in the session queue (capped at 1000 messages; oldest dropped past that).
 
 `request()` fails immediately if the socket is down. If the peer has no handler, you get a `ChannelRemoteError` with code `no_handler`. Middleware `Deny` is `denied`; a middleware exception is `handler_error`. It never hangs when `timeout=None`.
 

--- a/docs/content/docs/(core)/advanced/channels.mdx
+++ b/docs/content/docs/(core)/advanced/channels.mdx
@@ -155,14 +155,14 @@ The `timeout` parameter prevents your code from waiting forever if the client do
 
 When you need custom client-side logic to interact with a channel, you'll write JavaScript code that runs in the browser. Pulse provides the `@ps.javascript` decorator for embedding JavaScript in your Python code.
 
-`usePulseChannel(channelId)` returns a handle. Client lifetime is where you put the hook (route vs layout):
+`useChannel(channelId)` returns a handle. Client lifetime is where you put the hook (route vs layout):
 
 ```python
-from pulse.js.pulse import usePulseChannel
+from pulse.js.pulse import useChannel
 
 @ps.javascript(jsx=True)
 def ChatClient(*, channelId: str):
-    bridge = usePulseChannel(channelId)
+    bridge = useChannel(channelId)
 
     # Listen for events from the server
     def on_new_message(payload):
@@ -183,7 +183,7 @@ def ChatClient(*, channelId: str):
 
 A note on `@ps.javascript`: This decorator lets you write JavaScript logic that runs in the browser. The code inside looks like Python but transpiles to JavaScript. This is useful when you need browser APIs (like `localStorage`, `window`, or DOM manipulation) or want to optimize performance by keeping some logic client-side.
 
-The `usePulseChannel` hook returns a bridge object with three methods:
+The `useChannel` hook returns a bridge object with three methods:
 - `on(event, handler)` - Listen for events from the server
 - `emit(event, payload)` - Send events to the server (fire-and-forget)
 - `request(event, payload)` - Send a request and await the server's response
@@ -199,7 +199,7 @@ A channel id is just a mailbox name. Nothing is created or destroyed on the wire
 
 After a route handle detaches, `on()` raises `ChannelDetached`. `emit` and `request` still address the mailbox name.
 
-On the client, lifetime is React placement: put `usePulseChannel(id)` in a route component to drop listeners on navigation, or in a layout to keep them for the tab. There is no `lifetime` argument on the hook.
+On the client, lifetime is React placement: put `useChannel(id)` in a route component to drop listeners on navigation, or in a layout to keep them for the tab. There is no `lifetime` argument on the hook.
 
 ```python
 chat.detach()

--- a/docs/content/docs/(core)/advanced/channels.mdx
+++ b/docs/content/docs/(core)/advanced/channels.mdx
@@ -93,7 +93,7 @@ The notification appears instantly for the user, without them clicking anything.
 
 ## Creating a channel
 
-Create a channel inside a component using `ps.channel()`. Each channel is automatically scoped to the current user session and route.
+Call `ps.channel()` inside a component to get a handle on a mailbox. The id is just a name in this render session.
 
 ```python
 import pulse as ps
@@ -106,7 +106,7 @@ def ChatRoom():
     # ... rest of component
 ```
 
-The string argument (`"chat"`) is an identifier that helps with debugging. If you don't provide one, Pulse generates a UUID automatically. The channel is cleaned up automatically when the component unmounts or the user navigates away.
+The string argument (`"chat"`) is the mailbox name. If you don't provide one, Pulse generates a UUID. `lifetime="route"` (the default) detaches this handle's listeners when the route unmounts. The mailbox name itself is not created or destroyed.
 
 ## Handling events from the client
 
@@ -155,7 +155,7 @@ The `timeout` parameter prevents your code from waiting forever if the client do
 
 When you need custom client-side logic to interact with a channel, you'll write JavaScript code that runs in the browser. Pulse provides the `@ps.javascript` decorator for embedding JavaScript in your Python code.
 
-The `usePulseChannel` hook connects your JavaScript to a channel:
+`usePulseChannel(channelId)` returns a handle. Client lifetime is where you put the hook (route vs layout):
 
 ```python
 from pulse.js.pulse import usePulseChannel
@@ -190,33 +190,40 @@ The `usePulseChannel` hook returns a bridge object with three methods:
 
 ## Channel lifecycle
 
-Channels are tied to the route where they're created. When the user navigates to a different route, the channel closes automatically and resources are cleaned up. This prevents memory leaks and stale connections.
+A channel id is just a mailbox name. Nothing is created or destroyed on the wire. The only lifecycle is local: this handle's listeners attach and detach.
 
-If you need a channel that persists across route changes (like a global notification system), create it at a higher level in your component tree, such as in a layout component.
+`lifetime` controls when the **handle** auto-detaches, not whether the mailbox exists:
 
-You can also close a channel manually when you're done with it:
+- `"route"` (default) — tear down this handle's `on()` set when that route unmounts, even if you stored the object.
+- `"tab"` — do not detach on route unmount. Lives until the render session ends or you call `detach()`.
+
+After a route handle detaches, `on()` raises `ChannelDetached`. `emit` and `request` still address the mailbox name.
+
+On the client, lifetime is React placement: put `usePulseChannel(id)` in a route component to drop listeners on navigation, or in a layout to keep them for the tab. There is no `lifetime` argument on the hook.
 
 ```python
-chat.close()
+chat.detach()
 ```
 
 ## Error handling
 
-Network connections aren't always reliable. When using `channel.request()`, the client might be slow or unresponsive. Always handle timeouts:
+`request()` fails immediately if the socket is down. If the peer has no handler, you get a `ChannelRemoteError` with code `no_handler` — it never hangs when `timeout=None`.
 
 ```python
-from pulse import ChannelTimeout
+from pulse import ChannelDisconnected, ChannelRemoteError, ChannelTimeout
 
 async def safe_request(chat: ps.Channel):
     try:
-        response = await chat.request("get_data", timeout=5.0)
-        return response
+        return await chat.request("get_data", timeout=5.0)
     except ChannelTimeout:
-        # Client didn't respond in time
         return None
+    except ChannelDisconnected:
+        return None
+    except ChannelRemoteError as exc:
+        if exc.code == "no_handler":
+            return None
+        raise
 ```
-
-You can also catch `ChannelClosed` if you need to handle the case where someone tries to use a channel that's already been closed.
 
 ## When to use channels
 

--- a/docs/content/docs/(core)/advanced/channels.mdx
+++ b/docs/content/docs/(core)/advanced/channels.mdx
@@ -39,6 +39,10 @@ import pulse as ps
 class NotificationState(ps.State):
     notifications: list[dict] = []
 
+    def __init__(self):
+        self.channel = ps.channel("notifications")
+        self.channel.on("new_notification", self.add)
+
     def add(self, notification: dict):
         self.notifications = [notification] + self.notifications
 
@@ -51,11 +55,7 @@ class NotificationState(ps.State):
 @ps.component
 def NotificationCenter():
     with ps.init():
-        channel = ps.channel("notifications")
         state = NotificationState()
-
-    # When the server sends a notification, add it to state
-    channel.on("new_notification", lambda payload: state.add(payload))
 
     return ps.div(className="fixed top-4 right-4 space-y-2")[
         ps.For(
@@ -93,7 +93,7 @@ The notification appears instantly for the user, without them clicking anything.
 
 ## Creating a channel
 
-Call `ps.channel()` inside a component to get a handle on a mailbox. The id is just a name in this render session.
+Call `ps.channel()` inside a component to get a handle. The id is just a name in this render session.
 
 ```python
 import pulse as ps
@@ -106,30 +106,27 @@ def ChatRoom():
     # ... rest of component
 ```
 
-The string argument (`"chat"`) is the mailbox name. If you don't provide one, Pulse generates a UUID. `lifetime="route"` (the default) detaches this handle's listeners when the route unmounts. The mailbox name itself is not created or destroyed.
+The string argument (`"chat"`) is the channel name. If you don't provide one, Pulse generates a UUID. `lifetime="route"` (the default) detaches this handle's listeners when the route actually unmounts — it requires a route context. The name itself is not created or destroyed.
 
 ## Handling events from the client
 
 Use `channel.on()` to register handlers for events sent from the browser. This is how you receive messages from client-side JavaScript code.
 
 ```python
-@ps.component
-def ChatRoom():
-    with ps.init():
-        chat = ps.channel("chat")
-        messages = ChatState()
+class ChatState(ps.State):
+    def __init__(self):
+        self.channel = ps.channel("chat")
+        self.channel.on("send_message", self._on_send)
+        self.channel.on("typing", self._on_typing)
 
-    # Handle incoming messages from the client
-    chat.on("send_message", lambda payload: messages.add(payload["text"]))
+    def _on_send(self, payload: dict):
+        self.add(payload["text"])
 
-    # Handlers can be async for operations that need to await
-    async def handle_typing(payload):
-        await messages.set_typing(payload["user"])
-
-    chat.on("typing", handle_typing)
+    async def _on_typing(self, payload: dict):
+        await self.set_typing(payload["user"])
 ```
 
-Each handler receives a `payload` dictionary containing whatever data the client sent. You can register multiple handlers for the same event if needed.
+Each handler receives a `payload` dictionary containing whatever data the client sent. `on(event, handler)` is idempotent for the same handler — register a stable method, not a new lambda each render. You can register multiple different handlers for the same event.
 
 ## Sending events to the client
 
@@ -150,6 +147,8 @@ async def get_client_info(chat: ps.Channel):
 ```
 
 The `timeout` parameter prevents your code from waiting forever if the client doesn't respond.
+
+Don't `emit` during prerender or the first server render and expect the client to hear it. `useChannel` registers during render, so an emit after the hook has rendered is delivered. Earlier events drop.
 
 ## Using channels on the client
 
@@ -190,14 +189,14 @@ The `useChannel` hook returns a bridge object with three methods:
 
 ## Channel lifecycle
 
-A channel id is just a mailbox name. Nothing is created or destroyed on the wire. The only lifecycle is local: this handle's listeners attach and detach.
+A channel id is just a name. Nothing is created or destroyed on the wire. The only lifecycle is local: this handle's listeners attach and detach.
 
-`lifetime` controls when the **handle** auto-detaches, not whether the mailbox exists:
+`lifetime` controls when the **handle** auto-detaches, not whether the name exists:
 
 - `"route"` (default) — tear down this handle's `on()` set when that route unmounts, even if you stored the object.
 - `"tab"` — do not detach on route unmount. Lives until the render session ends or you call `detach()`.
 
-After a route handle detaches, `on()` raises `ChannelDetached`. `emit` and `request` still address the mailbox name.
+After a route handle detaches, `on()` raises `ChannelDetached`. `emit` and `request` still address the channel name.
 
 On the client, lifetime is React placement: put `useChannel(id)` in a route component to drop listeners on navigation, or in a layout to keep them for the tab. There is no `lifetime` argument on the hook.
 
@@ -207,7 +206,7 @@ chat.detach()
 
 ## Error handling
 
-`request()` fails immediately if the socket is down. If the peer has no handler, you get a `ChannelRemoteError` with code `no_handler` — it never hangs when `timeout=None`.
+`request()` fails immediately if the socket is down. If the peer has no handler, you get a `ChannelRemoteError` with code `no_handler`. Middleware `Deny` is `denied`; a middleware exception is `handler_error`. It never hangs when `timeout=None`.
 
 ```python
 from pulse import ChannelDisconnected, ChannelRemoteError, ChannelTimeout

--- a/docs/content/docs/(core)/advanced/middleware.mdx
+++ b/docs/content/docs/(core)/advanced/middleware.mdx
@@ -145,11 +145,13 @@ async def message(self, *, data, session, next):
 
 ### `channel`
 
-Called for pub/sub channel messages. Useful for authorizing access to real-time channels:
+Called for inbound channel **events and requests** only — never responses, and never connect/disconnect. Mailbox names are guessable, so gate messages here.
+
+`Deny` on an event drops it. `Deny` on a request sends a `denied` error response.
 
 ```python
-async def channel(self, *, channel_id, event, payload, session, next):
-    # Only admins can access admin channels
+async def channel(self, *, channel_id, event, payload, request_id, session, next):
+    # Only admins can use admin mailboxes
     if channel_id.startswith("admin:") and not session.get("is_admin"):
         return ps.Deny()
     return await next()

--- a/docs/content/docs/(core)/advanced/middleware.mdx
+++ b/docs/content/docs/(core)/advanced/middleware.mdx
@@ -145,13 +145,13 @@ async def message(self, *, data, session, next):
 
 ### `channel`
 
-Called for inbound channel **events and requests** only — never responses, and never connect/disconnect. Mailbox names are guessable, so gate messages here.
+Called for inbound channel **events and requests** only — never responses, and never connect/disconnect. Channel ids are guessable, so gate messages here.
 
 `Deny` on an event drops it. `Deny` on a request sends a `denied` error response.
 
 ```python
 async def channel(self, *, channel_id, event, payload, request_id, session, next):
-    # Only admins can use admin mailboxes
+    # Only admins can use admin channels
     if channel_id.startswith("admin:") and not session.get("is_admin"):
         return ps.Deny()
     return await next()

--- a/docs/content/docs/(core)/cookbook/advanced-patterns/chat-channels.mdx
+++ b/docs/content/docs/(core)/cookbook/advanced-patterns/chat-channels.mdx
@@ -10,7 +10,7 @@ You need server-initiated updates that go beyond the normal render cycle - live 
 
 ## Solution
 
-Create a channel on the server and use `usePulseChannel` on the client to send and receive messages.
+Create a channel on the server and use `useChannel` on the client to send and receive messages.
 
 ### Server side
 
@@ -61,14 +61,14 @@ def ChatRoom():
 ### Client side
 
 ```python
-from pulse.js.pulse import usePulseChannel
+from pulse.js.pulse import useChannel
 
 useState = ps.Import("useState", "react")
 useEffect = ps.Import("useEffect", "react")
 
 @ps.javascript(jsx=True)
 def ChatClient(*, channelId: str):
-    bridge = usePulseChannel(channelId)
+    bridge = useChannel(channelId)
     messages, setMessages = useState([])
     inputText, setInputText = useState("")
 
@@ -111,7 +111,7 @@ def ChatClient(*, channelId: str):
 - `ps.channel()` creates a bidirectional channel scoped to the current user session
 - `channel.on(event, handler)` registers a handler for client events
 - `channel.emit(event, payload)` sends fire-and-forget messages to the client
-- `usePulseChannel(id)` connects the client to the channel
+- `useChannel(id)` connects the client to the channel
 - Channels are automatically cleaned up when the component unmounts
 
 ## Request-response pattern

--- a/docs/content/docs/(core)/cookbook/advanced-patterns/chat-channels.mdx
+++ b/docs/content/docs/(core)/cookbook/advanced-patterns/chat-channels.mdx
@@ -108,11 +108,11 @@ def ChatClient(*, channelId: str):
 
 ## How it works
 
-- `ps.channel()` creates a bidirectional channel scoped to the current user session
+- `ps.channel(name)` returns an attached handle for a session-scoped channel name — the name is just an address, nothing is created on the wire
 - `channel.on(event, handler)` registers a handler for client events
 - `channel.emit(event, payload)` sends fire-and-forget messages to the client
-- `useChannel(id)` connects the client to the channel
-- Channels are automatically cleaned up when the component unmounts
+- `useChannel(id)` returns a client handle for the same name and attaches it while the component is mounted
+- Handles detach automatically: server handles when their route unmounts, client handles when the component unmounts
 
 ## Request-response pattern
 

--- a/docs/content/docs/(core)/glossary.mdx
+++ b/docs/content/docs/(core)/glossary.mdx
@@ -196,20 +196,20 @@ In Pulse, an isolated execution context per browser tab. Each tab has its own co
 **WebSocket**
 A persistent, bidirectional connection between browser and server. Unlike HTTP request/response, either side can send messages anytime. Pulse uses WebSockets for all UI updates.
 
-**Channel / mailbox**
-A string id scoped to a render session. Messages route by that name. The mailbox is not created or destroyed on the wire — handles only attach and detach local listeners.
+**Channel**
+A string id scoped to a render session. Messages route by that name. The name is not created or destroyed on the wire — handles only attach and detach local listeners.
 
 **Handle**
-A local object (`Channel` on the server, `ChannelBridge` on the client) with its own `on()` set. Two handles can share one mailbox; events fan out.
+A local object (`Channel` on the server, `ChannelBridge` on the client) with its own `on()` set. Two handles can share one channel id; events fan out.
 
 **Emit**
-Sending a fire-and-forget event to a mailbox. The sender doesn't wait for a response.
+Sending a fire-and-forget event to a channel. The sender doesn't wait for a response.
 
 **Listen**
-Registering a handler on a handle. When an event arrives on that mailbox, every attached handle with a matching listener runs.
+Registering a handler on a handle. When an event arrives on that channel, every attached handle with a matching listener runs.
 
 **Detach**
-Drop this handle's listeners. The mailbox name still accepts `emit` / `request`.
+Drop this handle's listeners. The channel name still accepts `emit` / `request`.
 
 ## JavaScript Interop
 

--- a/docs/content/docs/(core)/glossary.mdx
+++ b/docs/content/docs/(core)/glossary.mdx
@@ -196,17 +196,20 @@ In Pulse, an isolated execution context per browser tab. Each tab has its own co
 **WebSocket**
 A persistent, bidirectional connection between browser and server. Unlike HTTP request/response, either side can send messages anytime. Pulse uses WebSockets for all UI updates.
 
-**Channel**
-A named communication pathway for real-time features. Components can emit events to channels and listen for events from them.
+**Channel / mailbox**
+A string id scoped to a render session. Messages route by that name. The mailbox is not created or destroyed on the wire — handles only attach and detach local listeners.
+
+**Handle**
+A local object (`Channel` on the server, `ChannelBridge` on the client) with its own `on()` set. Two handles can share one mailbox; events fan out.
 
 **Emit**
-Sending a message/event through a channel (fire-and-forget). The sender doesn't wait for a response.
+Sending a fire-and-forget event to a mailbox. The sender doesn't wait for a response.
 
-**Subscribe / Listen**
-Registering to receive messages on a channel. When events arrive, your handler function runs.
+**Listen**
+Registering a handler on a handle. When an event arrives on that mailbox, every attached handle with a matching listener runs.
 
-**Broadcast**
-Sending a message to all connected clients, not just one. Used for features like live notifications or collaborative editing.
+**Detach**
+Drop this handle's listeners. The mailbox name still accepts `emit` / `request`.
 
 ## JavaScript Interop
 

--- a/docs/content/docs/(core)/tutorial/13-channels.mdx
+++ b/docs/content/docs/(core)/tutorial/13-channels.mdx
@@ -65,11 +65,11 @@ def ChatWidget(*, channelId: str):
     ]
 ```
 
-`useChannel` always returns a bridge. There is no `lifetime` argument — put the hook in a layout if listeners should outlive the route. It registers the handle during render, so an emit after the client has rendered this hook is delivered. Emit during prerender / before the first client render is dropped — nothing is listening yet.
+`useChannel` always returns a bridge. There is no `lifetime` argument — put the hook in a layout if listeners should outlive the route. It attaches the handle in an effect, so an emit before that effect runs can be dropped.
 
 ## Request / response
 
-If the peer has no handler, it NACKs immediately with `no_handler`. Requests never hang when you omit `timeout`. If the WebSocket is down, `request` fails immediately with `ChannelDisconnected` / `PulseChannelDisconnectedError`.
+If the peer has no handler, it NACKs immediately with `no_handler`. Client requests time out after 30 seconds by default; detaching the handle rejects in-flight requests with `PulseChannelDetachedError`. If the WebSocket is down, `request` fails immediately with `ChannelDisconnected` / `PulseChannelDisconnectedError`.
 
 ```python
 try:

--- a/docs/content/docs/(core)/tutorial/13-channels.mdx
+++ b/docs/content/docs/(core)/tutorial/13-channels.mdx
@@ -2,14 +2,14 @@
 title: "Channels"
 ---
 
-Sometimes your app needs to talk to the browser without a re-render: chat, live notifications, asking the client for viewport size. A channel id is a mailbox name in the current render session. Messages route by that name. Nothing is created or destroyed on the wire — you just attach and detach local listeners.
+Sometimes your app needs to talk to the browser without a re-render: chat, live notifications, asking the client for viewport size. A channel id is a name in the current render session. Messages route by that name. Nothing is created or destroyed on the wire — you just attach and detach local listeners.
 
-## What is a mailbox?
+## What is a channel?
 
 - **State** is for data that belongs to one user's session and drives the UI
 - **Channels** are for events and RPC between Python and the browser
 
-`ps.channel("chat")` returns a **handle**. During a live route mount, calling it again with the same id returns the same handle. After that handle detaches, the next call is a new handle on the same mailbox.
+`ps.channel("chat")` returns a **handle**. During a live route mount, calling it again with the same id returns the same handle. After that handle detaches, the next call is a new handle on the same name.
 
 ## Server handle
 
@@ -65,7 +65,7 @@ def ChatWidget(*, channelId: str):
     ]
 ```
 
-`useChannel` always returns a bridge. There is no `lifetime` argument — put the hook in a layout if listeners should outlive the route.
+`useChannel` always returns a bridge. There is no `lifetime` argument — put the hook in a layout if listeners should outlive the route. It registers the handle during render, so an emit after the client has rendered this hook is delivered. Emit during prerender / before the first client render is dropped — nothing is listening yet.
 
 ## Request / response
 

--- a/docs/content/docs/(core)/tutorial/13-channels.mdx
+++ b/docs/content/docs/(core)/tutorial/13-channels.mdx
@@ -47,12 +47,12 @@ def chat_room():
 ## Client handle
 
 ```python
-from pulse.js.pulse import usePulseChannel
+from pulse.js.pulse import useChannel
 from pulse.js.react import useEffect, useState
 
 @ps.javascript(jsx=True)
 def ChatWidget(*, channelId: str):
-    bridge = usePulseChannel(channelId)
+    bridge = useChannel(channelId)
     draft, setDraft = useState("")
 
     def send():
@@ -65,7 +65,7 @@ def ChatWidget(*, channelId: str):
     ]
 ```
 
-`usePulseChannel` always returns a bridge. There is no `lifetime` argument — put the hook in a layout if listeners should outlive the route.
+`useChannel` always returns a bridge. There is no `lifetime` argument — put the hook in a layout if listeners should outlive the route.
 
 ## Request / response
 

--- a/docs/content/docs/(core)/tutorial/13-channels.mdx
+++ b/docs/content/docs/(core)/tutorial/13-channels.mdx
@@ -2,107 +2,31 @@
 title: "Channels"
 ---
 
-Sometimes your app needs to update in real-time. A chat application needs to show new messages instantly. A collaborative document editor needs to sync changes between users. A live dashboard needs to display fresh data as it arrives. Channels are Pulse's answer to these real-time communication needs.
+Sometimes your app needs to talk to the browser without a re-render: chat, live notifications, asking the client for viewport size. A channel id is a mailbox name in the current render session. Messages route by that name. Nothing is created or destroyed on the wire — you just attach and detach local listeners.
 
-Channels let you send messages between the server and connected clients, and even between clients, all in real-time over WebSockets.
+## What is a mailbox?
 
-## What Are Channels?
+- **State** is for data that belongs to one user's session and drives the UI
+- **Channels** are for events and RPC between Python and the browser
 
-A channel is like a chat room for your app. Clients can join a channel, send messages to it, and receive messages from it. You define what happens when messages arrive by writing handlers on the server.
+`ps.channel("chat")` returns a **handle**. During a live route mount, calling it again with the same id returns the same handle. After that handle detaches, the next call is a new handle on the same mailbox.
 
-Think of it this way:
-- **State** is for data that belongs to one user's session
-- **Channels** are for data that needs to flow between multiple users or from server to clients in real-time
-
-## Creating a Channel
-
-Define a channel with `ps.channel()` and add handlers for different message types:
+## Server handle
 
 ```python
 import pulse as ps
-
-# Create a channel named "notifications"
-notifications = ps.channel("notifications")
-
-
-@notifications.on("subscribe")
-def on_subscribe(payload):
-    """Called when a client joins the channel."""
-    print(f"A user subscribed to notifications")
-
-
-@notifications.on("unsubscribe")
-def on_unsubscribe(payload):
-    """Called when a client leaves the channel."""
-    print(f"A user left the notifications channel")
-```
-
-The channel name ("notifications" here) is how clients will reference this channel.
-
-## Broadcasting Messages
-
-The real power of channels is broadcasting: sending a message to everyone subscribed to the channel.
-
-```python
-@notifications.on("new_alert")
-def on_new_alert(payload):
-    """When we receive an alert, broadcast it to all subscribers."""
-    # payload contains whatever the sender included
-    message = payload.get("message", "New notification!")
-
-    # Send to everyone in this channel
-    notifications.broadcast("alert", {"message": message, "time": "now"})
-```
-
-You can also broadcast from anywhere in your code, like from an event handler:
-
-```python
-class AdminState(ps.State):
-    def send_announcement(self, message: str):
-        # This reaches all users subscribed to the notifications channel
-        notifications.broadcast("announcement", {
-            "message": message,
-            "from": "Admin"
-        })
-```
-
-## Building a Simple Chat
-
-Let's put it together with a chat example. This shows how multiple users can communicate in real-time:
-
-```python
-import pulse as ps
-
-# Create the chat channel
-chat = ps.channel("chat")
-
-
-@chat.on("message")
-def on_chat_message(payload):
-    """When someone sends a message, broadcast it to everyone."""
-    username = payload.get("username", "Anonymous")
-    text = payload.get("text", "")
-
-    # Broadcast to all connected clients
-    chat.broadcast("new_message", {
-        "username": username,
-        "text": text,
-    })
-
 
 class ChatState(ps.State):
     messages: list[dict] = []
-    username: str = ""
-    current_message: str = ""
 
-    def send_message(self):
-        if self.current_message.strip():
-            # Send to the channel (this triggers on_chat_message above)
-            chat.send("message", {
-                "username": self.username or "Anonymous",
-                "text": self.current_message,
-            })
-            self.current_message = ""
+    def __init__(self):
+        self.channel = ps.channel("chat")
+        self.channel.on("send", self._on_send)
+
+    def _on_send(self, payload: dict):
+        msg = {"user": payload["user"], "text": payload["text"]}
+        self.messages.append(msg)
+        self.channel.emit("message", msg)
 
 
 @ps.component
@@ -110,107 +34,52 @@ def chat_room():
     with ps.init():
         st = ChatState()
 
-    return ps.div(className="max-w-lg mx-auto p-4")[
-        ps.h1("Chat Room", className="text-2xl font-bold mb-4"),
-
-        # Username input
-        ps.input(
-            value=st.username,
-            onChange=lambda e: setattr(st, "username", e["target"]["value"]),
-            placeholder="Your name",
-            className="w-full border rounded px-3 py-2 mb-4",
-        ),
-
-        # Messages display
-        ps.div(className="border rounded p-4 h-64 overflow-y-auto mb-4")[
-            ps.For(
-                st.messages,
-                lambda msg: ps.div(className="mb-2")[
-                    ps.span(f"{msg['username']}: ", className="font-bold"),
-                    ps.span(msg['text']),
-                ],
-            ),
-        ],
-
-        # Message input
-        ps.div(className="flex gap-2")[
-            ps.input(
-                value=st.current_message,
-                onChange=lambda e: setattr(st, "current_message", e["target"]["value"]),
-                placeholder="Type a message...",
-                className="flex-1 border rounded px-3 py-2",
-            ),
-            ps.button(
-                "Send",
-                onClick=st.send_message,
-                className="bg-blue-500 text-white px-4 py-2 rounded",
-            ),
-        ],
+    return ps.div[
+        ps.For(st.messages, lambda msg, _: ps.div[f"{msg['user']}: {msg['text']}"]),
+        ChatWidget(channelId=st.channel.id),
     ]
 ```
 
-## Listening to Channel Messages on the Client
+`on(event, handler)` is a two-arg call, not a decorator. It returns a remover.
 
-To receive channel messages in your component, you need to subscribe to the channel from the JavaScript side. Pulse provides a `usePulseChannel` hook for this:
+`lifetime="route"` (default) detaches this handle when the route unmounts. Use `lifetime="tab"` for something like notifications that should survive navigation.
 
-```javascript
-// In your React/client code
-import { usePulseChannel } from "pulse-js";
+## Client handle
 
-function ChatMessages() {
-  const [messages, setMessages] = useState([]);
+```python
+from pulse.js.pulse import usePulseChannel
+from pulse.js.react import useEffect, useState
 
-  usePulseChannel("chat", {
-    onMessage: (event, payload) => {
-      if (event === "new_message") {
-        setMessages(prev => [...prev, payload]);
-      }
-    }
-  });
+@ps.javascript(jsx=True)
+def ChatWidget(*, channelId: str):
+    bridge = usePulseChannel(channelId)
+    draft, setDraft = useState("")
 
-  return (
-    <div>
-      {messages.map((msg, i) => (
-        <div key={i}>{msg.username}: {msg.text}</div>
-      ))}
-    </div>
-  );
-}
+    def send():
+        bridge.emit("send", {"user": "You", "text": draft})
+        setDraft("")
+
+    return ps.div[
+        ps.input(value=draft, onChange=lambda e: setDraft(e.target.value)),
+        ps.button("Send", onClick=send),
+    ]
 ```
 
-If you're working purely in Python and want to handle incoming channel messages, you can use the `pulse.js.pulse` utilities or set up effects that respond to channel state.
+`usePulseChannel` always returns a bridge. There is no `lifetime` argument — put the hook in a layout if listeners should outlive the route.
 
-## Channel Use Cases
+## Request / response
 
-Channels are perfect for:
+If the peer has no handler, it NACKs immediately with `no_handler`. Requests never hang when you omit `timeout`. If the WebSocket is down, `request` fails immediately with `ChannelDisconnected` / `PulseChannelDisconnectedError`.
 
-- **Chat and messaging**: Real-time conversations between users
-- **Live notifications**: Alerts that appear instantly when something happens
-- **Collaborative editing**: Syncing changes between multiple users
-- **Live dashboards**: Pushing new data to all viewers simultaneously
-- **Gaming**: Real-time game state updates
-- **Presence**: Showing who's online or viewing a page
-
-## Broadcasting vs. Sending
-
-There's an important distinction:
-
-- **`channel.broadcast(event, payload)`**: Sends to ALL subscribed clients
-- **`channel.send(event, payload)`**: Sends to a specific client (the one that triggered the handler)
-
-Use broadcast when everyone should see something (a new chat message). Use send when only one user should see it (a private notification).
-
-## Tips for Working with Channels
-
-1. **Keep payloads small**: Channels are for real-time updates, not large data transfers.
-
-2. **Use meaningful event names**: `"new_message"` is clearer than `"msg"`.
-
-3. **Handle reconnections**: Users might disconnect and reconnect. Consider what state they need to catch up on.
-
-4. **Combine with state**: Channels deliver real-time updates, but your components still need state to store and display that data.
-
-5. **Think about scale**: Broadcasting to thousands of users is different from a small chat room. Design accordingly.
+```python
+try:
+    size = await chat.request("viewport", timeout=5.0)
+except ps.ChannelRemoteError as exc:
+    if exc.code == "no_handler":
+        size = None
+    else:
+        raise
+```
 
 ## See also
 

--- a/docs/content/docs/packages/pulse-js-client.mdx
+++ b/docs/content/docs/packages/pulse-js-client.mdx
@@ -81,15 +81,15 @@ function MyComponent() {
 }
 ```
 
-### usePulseChannel
+### useChannel
 
 Hook for real-time bidirectional messaging between client and server.
 
 ```tsx
-import { usePulseChannel } from "pulse-client";
+import { useChannel } from "pulse-client";
 
 function Chat() {
-  const channel = usePulseChannel("chat");
+  const channel = useChannel("chat");
 
   channel.on("new_message", (msg) => {
     // Handle incoming message
@@ -143,7 +143,7 @@ const data = deserialize(wire);
 
 **Hooks:**
 - `usePulseClient()` - Access the client instance
-- `usePulseChannel(name)` - Real-time messaging
+- `useChannel(name)` - Real-time messaging
 
 **Functions:**
 - `serialize` - Convert data for wire transfer

--- a/docs/content/docs/reference/pulse-client/classes.mdx
+++ b/docs/content/docs/reference/pulse-client/classes.mdx
@@ -11,7 +11,7 @@ Core classes for Pulse client functionality.
 
 ## ChannelBridge
 
-A local handle on a mailbox. You get a `ChannelBridge` from `usePulseChannel`. Messages route by `id`. Detach only drops this handle's listeners.
+A local handle on a mailbox. You get a `ChannelBridge` from `useChannel`. Messages route by `id`. Detach only drops this handle's listeners.
 
 ```ts
 class ChannelBridge {
@@ -49,7 +49,7 @@ emit(event: string, payload?: any): void
 **Example:**
 
 ```ts
-const channel = usePulseChannel("notifications");
+const channel = useChannel("notifications");
 
 // Notify server of user activity (no response expected)
 channel.emit("user_active", { page: "/dashboard" });
@@ -78,7 +78,7 @@ request(event: string, payload?: any): Promise<any>
 **Example:**
 
 ```ts
-const channel = usePulseChannel("api");
+const channel = useChannel("api");
 
 // Fetch data from server
 const users = await channel.request("get_users", { limit: 10 });
@@ -110,7 +110,7 @@ The handler can be sync or async. If multiple handlers are registered for the sa
 **Example:**
 
 ```ts
-const channel = usePulseChannel("notifications");
+const channel = useChannel("notifications");
 
 // Subscribe to events
 useEffect(() => {
@@ -135,11 +135,11 @@ Events with no listener are dropped. Requests with no handler NACKs immediately.
 ### Complete Example
 
 ```tsx
-import { usePulseChannel, PulseChannelDisconnectedError } from "pulse-ui-client";
+import { useChannel, PulseChannelDisconnectedError } from "pulse-ui-client";
 import { useState, useEffect } from "react";
 
 function LiveAuction({ auctionId }: { auctionId: string }) {
-  const channel = usePulseChannel(`auction-${auctionId}`);
+  const channel = useChannel(`auction-${auctionId}`);
   const [currentBid, setCurrentBid] = useState(0);
   const [error, setError] = useState<string | null>(null);
 
@@ -334,6 +334,6 @@ function CustomView({ path }: { path: string }) {
 
 ## See Also
 
-- [Hooks](/docs/reference/pulse-client/hooks) - usePulseChannel hook
+- [Hooks](/docs/reference/pulse-client/hooks) - useChannel hook
 - [Types](/docs/reference/pulse-client/types) - VDOM and update types
 - [Serialization](/docs/reference/pulse-client/serialization) - Wire format

--- a/docs/content/docs/reference/pulse-client/classes.mdx
+++ b/docs/content/docs/reference/pulse-client/classes.mdx
@@ -63,17 +63,20 @@ channel.emit("typing", { conversationId: "123" });
 Sends a request and waits for the server's response. This is like a remote procedure call.
 
 ```ts
-request(event: string, payload?: any): Promise<any>
+request(event: string, payload?: any, options?: { timeout?: number }): Promise<any>
 ```
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `event` | `string` | Event name |
 | `payload` | `any` | Optional request data |
+| `options.timeout` | `number` | Timeout in milliseconds; defaults to 30,000 |
 
 **Returns:** Promise resolving to the server's response.
 
-**Throws:** `PulseChannelDisconnectedError` if the socket is down or dies mid-flight. `PulseChannelRemoteError` if the peer NACKs (`no_handler`, `denied`, `handler_error`).
+**Throws:** `PulseChannelDisconnectedError` if the socket is down or dies mid-flight, `PulseChannelDetachedError` if this handle detaches while the request is in flight, `PulseChannelRemoteError` if the peer NACKs (`no_handler`, `denied`, `handler_error`), or `PulseChannelTimeoutError` if it exceeds its timeout.
+
+The default timeout is 30 seconds. Pass `options.timeout` to override it.
 
 **Example:**
 
@@ -130,7 +133,7 @@ useEffect(() => {
 }, [channel]);
 ```
 
-Events with no listener are dropped. Requests with no handler NACKs immediately.
+Events with no listener are dropped. Requests with no handler NACK immediately. Requests route to the first attached handle in registration order that has a handler; events fan out to every attached handle for the channel name.
 
 ### Complete Example
 
@@ -201,7 +204,7 @@ class PulseChannelRemoteError extends Error {
 
 ## PulseChannelDetachedError
 
-Unused by current client `on()` — registering while detached is legal (StrictMode). `emit` and `request` still address the channel name.
+Thrown when a handle detaches while one of its requests is in flight. `on()` remains legal while detached, and `emit` still addresses the channel name (with a warning).
 
 ```ts
 class PulseChannelDetachedError extends Error {

--- a/docs/content/docs/reference/pulse-client/classes.mdx
+++ b/docs/content/docs/reference/pulse-client/classes.mdx
@@ -11,14 +11,14 @@ Core classes for Pulse client functionality.
 
 ## ChannelBridge
 
-A local handle on a mailbox. You get a `ChannelBridge` from `useChannel`. Messages route by `id`. Detach only drops this handle's listeners.
+A local handle on a channel name. You get a `ChannelBridge` from `useChannel`. Messages route by `id`. Detach only drops this handle's listeners.
 
 ```ts
 class ChannelBridge {
   readonly id: string;
 
   emit(event: string, payload?: any): void;
-  request(event: string, payload?: any): Promise<any>;
+  request(event: string, payload?: any, options?: { timeout?: number }): Promise<any>;
   on(event: string, handler: ChannelEventHandler): () => void;
 }
 
@@ -201,7 +201,7 @@ class PulseChannelRemoteError extends Error {
 
 ## PulseChannelDetachedError
 
-Thrown when `on()` is called on a detached handle. `emit` and `request` still address the mailbox.
+Unused by current client `on()` — registering while detached is legal (StrictMode). `emit` and `request` still address the channel name.
 
 ```ts
 class PulseChannelDetachedError extends Error {

--- a/docs/content/docs/reference/pulse-client/classes.mdx
+++ b/docs/content/docs/reference/pulse-client/classes.mdx
@@ -11,7 +11,7 @@ Core classes for Pulse client functionality.
 
 ## ChannelBridge
 
-Manages bidirectional communication over a Pulse channel. You get a ChannelBridge instance from the `usePulseChannel` hook.
+A local handle on a mailbox. You get a `ChannelBridge` from `usePulseChannel`. Messages route by `id`. Detach only drops this handle's listeners.
 
 ```ts
 class ChannelBridge {
@@ -73,7 +73,7 @@ request(event: string, payload?: any): Promise<any>
 
 **Returns:** Promise resolving to the server's response.
 
-**Throws:** `PulseChannelResetError` if the channel closes before the response arrives.
+**Throws:** `PulseChannelDisconnectedError` if the socket is down or dies mid-flight. `PulseChannelRemoteError` if the peer NACKs (`no_handler`, `denied`, `handler_error`).
 
 **Example:**
 
@@ -130,14 +130,12 @@ useEffect(() => {
 }, [channel]);
 ```
 
-### Event Backlog
-
-If an event arrives before any handler is registered, it's queued in a backlog. Once a handler is registered for that event, backlogged events are delivered immediately. This prevents race conditions during component mounting.
+Events with no listener are dropped. Requests with no handler NACKs immediately.
 
 ### Complete Example
 
 ```tsx
-import { usePulseChannel, PulseChannelResetError } from "pulse-ui-client";
+import { usePulseChannel, PulseChannelDisconnectedError } from "pulse-ui-client";
 import { useState, useEffect } from "react";
 
 function LiveAuction({ auctionId }: { auctionId: string }) {
@@ -160,7 +158,7 @@ function LiveAuction({ auctionId }: { auctionId: string }) {
         setError(result.error);
       }
     } catch (e) {
-      if (e instanceof PulseChannelResetError) {
+      if (e instanceof PulseChannelDisconnectedError) {
         setError("Connection lost. Please refresh.");
       }
     }
@@ -180,39 +178,34 @@ function LiveAuction({ auctionId }: { auctionId: string }) {
 
 ---
 
-## PulseChannelResetError
+## PulseChannelDisconnectedError
 
-Error thrown when a channel operation fails due to channel closure or disconnection.
+Thrown when a request cannot complete because the socket is down or died.
 
 ```ts
-class PulseChannelResetError extends Error {
-  name: "PulseChannelResetError";
+class PulseChannelDisconnectedError extends Error {
+  name: "PulseChannelDisconnectedError";
 }
 ```
 
-### When It's Thrown
+## PulseChannelRemoteError
 
-- Channel is closed by the server
-- WebSocket connection is lost
-- `request()` is pending when the channel closes
-- Attempting to use a closed channel
-
-### Example
+Thrown when the peer responds with `no_handler`, `denied`, or `handler_error`.
 
 ```ts
-import { PulseChannelResetError } from "pulse-ui-client";
+class PulseChannelRemoteError extends Error {
+  name: "PulseChannelRemoteError";
+  code: "no_handler" | "denied" | "handler_error";
+}
+```
 
-async function fetchData(channel: ChannelBridge) {
-  try {
-    return await channel.request("get_data");
-  } catch (error) {
-    if (error instanceof PulseChannelResetError) {
-      // Handle channel closure gracefully
-      console.log("Channel closed:", error.message);
-      return null;
-    }
-    throw error;
-  }
+## PulseChannelDetachedError
+
+Thrown when `on()` is called on a detached handle. `emit` and `request` still address the mailbox.
+
+```ts
+class PulseChannelDetachedError extends Error {
+  name: "PulseChannelDetachedError";
 }
 ```
 

--- a/docs/content/docs/reference/pulse-client/components.mdx
+++ b/docs/content/docs/reference/pulse-client/components.mdx
@@ -275,6 +275,6 @@ function ContactForm() {
 
 ## See Also
 
-- [Hooks](/docs/reference/pulse-client/hooks) - usePulseClient, usePulseChannel, usePulsePrerender
+- [Hooks](/docs/reference/pulse-client/hooks) - usePulseClient, useChannel, usePulsePrerender
 - [Classes](/docs/reference/pulse-client/classes) - ChannelBridge, VDOMRenderer
 - [Types](/docs/reference/pulse-client/types) - TypeScript type definitions

--- a/docs/content/docs/reference/pulse-client/hooks.mdx
+++ b/docs/content/docs/reference/pulse-client/hooks.mdx
@@ -102,7 +102,7 @@ Most of these are used internally by `PulseView`. The most useful for app code a
 
 ## useChannel
 
-Hook that returns a handle on a channel. Client lifetime is React placement: a route component detaches on navigation, a layout keeps the handle for the tab. The handle is registered during render so a live-socket emit is not dropped waiting for `useEffect`.
+Hook that returns a handle on a channel. Client lifetime is React placement: a route component detaches on navigation, a layout keeps the handle for the tab. The handle attaches in an effect and detaches in that effect's cleanup.
 
 ```ts
 import { useChannel } from "pulse-ui-client";
@@ -127,7 +127,9 @@ Returns a `ChannelBridge` instance for sending and receiving messages.
 
 ### Lifecycle
 
-The hook memoizes one `ChannelBridge` per hook instance (`[client, id]`) and attach/detaches that same object. StrictMode reuses it. Two hooks on the same id are two handles, one name. `on()` is legal while detached. Events emitted before this hook has rendered are dropped.
+The hook memoizes one `ChannelBridge` per hook instance (`[client, id]`) and attaches/detaches that same object. StrictMode reuses it. Two hooks on the same id are two handles, one name. `on()` is legal while detached. Events emitted before the effect runs are queued only if the client is offline; otherwise they can be dropped because no handle is attached yet.
+
+Requests route to the first attached handle in registration order that has a handler. Events fan out to every attached handle for the channel name.
 
 There is no `lifetime` argument. Put the hook in a layout if listeners should survive route changes.
 

--- a/docs/content/docs/reference/pulse-client/hooks.mdx
+++ b/docs/content/docs/reference/pulse-client/hooks.mdx
@@ -100,14 +100,14 @@ Most of these are used internally by `PulseView`. The most useful for app code a
 
 ---
 
-## usePulseChannel
+## useChannel
 
 Hook that returns a handle on a mailbox. Client lifetime is React placement: a route component detaches on navigation, a layout keeps the handle for the tab.
 
 ```ts
-import { usePulseChannel } from "pulse-ui-client";
+import { useChannel } from "pulse-ui-client";
 
-function usePulseChannel(channelId: string): ChannelBridge
+function useChannel(channelId: string): ChannelBridge
 ```
 
 ### Parameters
@@ -134,7 +134,7 @@ There is no `lifetime` argument. Put the hook in a layout if listeners should su
 ### Example: Chat Room
 
 ```tsx
-import { usePulseChannel } from "pulse-ui-client";
+import { useChannel } from "pulse-ui-client";
 import { useState, useEffect } from "react";
 
 interface Message {
@@ -144,7 +144,7 @@ interface Message {
 }
 
 function ChatRoom({ roomId }: { roomId: string }) {
-  const channel = usePulseChannel(`chat-${roomId}`);
+  const channel = useChannel(`chat-${roomId}`);
   const [messages, setMessages] = useState<Message[]>([]);
 
   useEffect(() => {
@@ -181,11 +181,11 @@ function ChatRoom({ roomId }: { roomId: string }) {
 ### Example: Request-Response
 
 ```tsx
-import { usePulseChannel } from "pulse-ui-client";
+import { useChannel } from "pulse-ui-client";
 import { useState } from "react";
 
 function UserSearch() {
-  const channel = usePulseChannel("user-search");
+  const channel = useChannel("user-search");
   const [results, setResults] = useState([]);
   const [loading, setLoading] = useState(false);
 

--- a/docs/content/docs/reference/pulse-client/hooks.mdx
+++ b/docs/content/docs/reference/pulse-client/hooks.mdx
@@ -102,7 +102,7 @@ Most of these are used internally by `PulseView`. The most useful for app code a
 
 ## usePulseChannel
 
-Hook to subscribe to a Pulse channel for bidirectional communication. Channels enable real-time messaging patterns like chat, notifications, or streaming data.
+Hook that returns a handle on a mailbox. Client lifetime is React placement: a route component detaches on navigation, a layout keeps the handle for the tab.
 
 ```ts
 import { usePulseChannel } from "pulse-ui-client";
@@ -127,13 +127,9 @@ Returns a `ChannelBridge` instance for sending and receiving messages.
 
 ### Lifecycle
 
-The hook manages channel subscription automatically:
+The hook memoizes one `ChannelBridge` per hook instance (`[client, id]`) and attach/detaches that same object. StrictMode reuses it. Two hooks on the same id are two handles, one mailbox.
 
-1. On mount: acquires a reference to the channel
-2. On unmount: releases the reference
-3. When all references are released: channel closes
-
-Multiple components can subscribe to the same channel. The channel stays open as long as at least one component is subscribed.
+There is no `lifetime` argument. Put the hook in a layout if listeners should survive route changes.
 
 ### Example: Chat Room
 

--- a/docs/content/docs/reference/pulse-client/hooks.mdx
+++ b/docs/content/docs/reference/pulse-client/hooks.mdx
@@ -102,7 +102,7 @@ Most of these are used internally by `PulseView`. The most useful for app code a
 
 ## useChannel
 
-Hook that returns a handle on a mailbox. Client lifetime is React placement: a route component detaches on navigation, a layout keeps the handle for the tab.
+Hook that returns a handle on a channel. Client lifetime is React placement: a route component detaches on navigation, a layout keeps the handle for the tab. The handle is registered during render so a live-socket emit is not dropped waiting for `useEffect`.
 
 ```ts
 import { useChannel } from "pulse-ui-client";
@@ -127,7 +127,7 @@ Returns a `ChannelBridge` instance for sending and receiving messages.
 
 ### Lifecycle
 
-The hook memoizes one `ChannelBridge` per hook instance (`[client, id]`) and attach/detaches that same object. StrictMode reuses it. Two hooks on the same id are two handles, one mailbox.
+The hook memoizes one `ChannelBridge` per hook instance (`[client, id]`) and attach/detaches that same object. StrictMode reuses it. Two hooks on the same id are two handles, one name. `on()` is legal while detached. Events emitted before this hook has rendered are dropped.
 
 There is no `lifetime` argument. Put the hook in a layout if listeners should survive route changes.
 

--- a/docs/content/docs/reference/pulse-client/hooks.mdx
+++ b/docs/content/docs/reference/pulse-client/hooks.mdx
@@ -127,7 +127,7 @@ Returns a `ChannelBridge` instance for sending and receiving messages.
 
 ### Lifecycle
 
-The hook memoizes one `ChannelBridge` per hook instance (`[client, id]`) and attaches/detaches that same object. StrictMode reuses it. Two hooks on the same id are two handles, one name. `on()` is legal while detached. Events emitted before the effect runs are queued only if the client is offline; otherwise they can be dropped because no handle is attached yet.
+The hook memoizes one `ChannelBridge` per hook instance (`[client, id]`) and attaches/detaches that same object. StrictMode reuses it. Two hooks on the same id are two handles, one name. `on()` is legal while detached. Server events arriving before the attach effect runs are dropped — no handle is attached yet.
 
 Requests route to the first attached handle in registration order that has a handler. Events fan out to every attached handle for the channel name.
 

--- a/docs/content/docs/reference/pulse-client/index.mdx
+++ b/docs/content/docs/reference/pulse-client/index.mdx
@@ -85,14 +85,16 @@ The package exports several categories of APIs:
 ### Hooks
 
 - **usePulseClient** - Access the Pulse client instance
-- **usePulseChannel** - Subscribe to bidirectional channels
+- **usePulseChannel** - Attach a handle to a mailbox
 - **usePulsePrerender** - Access prerendered view data
 
 ### Classes
 
 - **ChannelBridge** - Bidirectional communication over channels
 - **VDOMRenderer** - Converts VDOM to React elements
-- **PulseChannelResetError** - Error for channel failures
+- **PulseChannelDisconnectedError** - Request failed because the socket is down
+- **PulseChannelRemoteError** - Peer responded with an error
+- **PulseChannelDetachedError** - `on()` called on a detached handle
 
 ### Utilities
 

--- a/docs/content/docs/reference/pulse-client/index.mdx
+++ b/docs/content/docs/reference/pulse-client/index.mdx
@@ -85,7 +85,7 @@ The package exports several categories of APIs:
 ### Hooks
 
 - **usePulseClient** - Access the Pulse client instance
-- **useChannel** - Attach a handle to a mailbox
+- **useChannel** - Attach a handle to a channel
 - **usePulsePrerender** - Access prerendered view data
 
 ### Classes

--- a/docs/content/docs/reference/pulse-client/index.mdx
+++ b/docs/content/docs/reference/pulse-client/index.mdx
@@ -94,7 +94,8 @@ The package exports several categories of APIs:
 - **VDOMRenderer** - Converts VDOM to React elements
 - **PulseChannelDisconnectedError** - Request failed because the socket is down
 - **PulseChannelRemoteError** - Peer responded with an error
-- **PulseChannelDetachedError** - `on()` called on a detached handle
+- **PulseChannelDetachedError** - An in-flight request's handle was detached
+- **PulseChannelTimeoutError** - A request exceeded its timeout (30 seconds by default)
 
 ### Utilities
 
@@ -119,6 +120,8 @@ React App                          Pulse Server
 ```
 
 When a user interacts with the UI, callbacks are sent to the server. The server updates state and sends VDOM patches back. The client applies these patches incrementally, preserving React's reconciliation benefits.
+
+Channel requests go to the first attached handle in registration order that has a handler for the event. Channel events fan out to every attached handle for that channel name.
 
 ## See Also
 

--- a/docs/content/docs/reference/pulse-client/index.mdx
+++ b/docs/content/docs/reference/pulse-client/index.mdx
@@ -85,7 +85,7 @@ The package exports several categories of APIs:
 ### Hooks
 
 - **usePulseClient** - Access the Pulse client instance
-- **usePulseChannel** - Attach a handle to a mailbox
+- **useChannel** - Attach a handle to a mailbox
 - **usePulsePrerender** - Access prerendered view data
 
 ### Classes
@@ -123,6 +123,6 @@ When a user interacts with the UI, callbacks are sent to the server. The server 
 ## See Also
 
 - [Components](/docs/reference/pulse-client/components) - PulseProvider, PulseView, PulseForm
-- [Hooks](/docs/reference/pulse-client/hooks) - usePulseClient, usePulseChannel
+- [Hooks](/docs/reference/pulse-client/hooks) - usePulseClient, useChannel
 - [Types](/docs/reference/pulse-client/types) - TypeScript type definitions
 - [Architecture](/docs/reference/architecture) - How Pulse works

--- a/docs/content/docs/reference/pulse-client/types.mdx
+++ b/docs/content/docs/reference/pulse-client/types.mdx
@@ -427,31 +427,41 @@ interface ClientApiResultMessage {
 }
 ```
 
-#### ClientChannelRequestMessage
-
-Channel event sent to server.
+#### ClientChannelEventMessage
 
 ```ts
-interface ClientChannelRequestMessage {
-  type: "channel_message";
+interface ClientChannelEventMessage {
+  type: "channel";
+  action: "event";
   channel: string;
   event: string;
   payload?: any;
-  requestId?: string;
+}
+```
+
+#### ClientChannelRequestMessage
+
+```ts
+interface ClientChannelRequestMessage {
+  type: "channel";
+  action: "request";
+  channel: string;
+  event: string;
+  requestId: string;
+  payload?: any;
 }
 ```
 
 #### ClientChannelResponseMessage
 
-Response to a server channel request.
-
 ```ts
 interface ClientChannelResponseMessage {
-  type: "channel_message";
+  type: "channel";
+  action: "response";
   channel: string;
   responseTo: string;
   payload?: any;
-  error?: any;
+  error?: { code: "no_handler" | "denied" | "handler_error"; message: string };
 }
 ```
 
@@ -542,31 +552,41 @@ interface ServerNavigateToMessage {
 }
 ```
 
-#### ServerChannelRequestMessage
-
-Channel event from server.
+#### ServerChannelEventMessage
 
 ```ts
-interface ServerChannelRequestMessage {
-  type: "channel_message";
+interface ServerChannelEventMessage {
+  type: "channel";
+  action: "event";
   channel: string;
   event: string;
   payload?: any;
-  requestId?: string;
+}
+```
+
+#### ServerChannelRequestMessage
+
+```ts
+interface ServerChannelRequestMessage {
+  type: "channel";
+  action: "request";
+  channel: string;
+  event: string;
+  requestId: string;
+  payload?: any;
 }
 ```
 
 #### ServerChannelResponseMessage
 
-Response to a client channel request.
-
 ```ts
 interface ServerChannelResponseMessage {
-  type: "channel_message";
+  type: "channel";
+  action: "response";
   channel: string;
   responseTo: string;
   payload?: any;
-  error?: any;
+  error?: { code: "no_handler" | "denied" | "handler_error"; message: string };
 }
 ```
 

--- a/docs/content/docs/reference/pulse/channels.mdx
+++ b/docs/content/docs/reference/pulse/channels.mdx
@@ -63,6 +63,10 @@ def on(self, event: str, handler: ChannelHandler) -> Callable[[], None]
 
 Register a handler on this handle. Idempotent for the same `(event, handler)`.
 
+Events run serially per handle, in arrival order: an event's handlers are awaited before the next event starts. An event handler must therefore never block indefinitely — `await channel.request(...)` without a `timeout` inside an event handler stalls every later event on that handle. The guarantee covers events only: inbound requests run as independent tasks (so a request handler may itself call `request()`) and can overtake queued events. The backlog is capped at 500 events per handle, oldest dropped, with one warning.
+
+All live handles on the same name receive every event (fan-out, including a tab handle and a route handle together). A request goes to the first attached handle that has a handler for the event — registration order decides the single winner.
+
 **Raises:** `ChannelDetached` if this handle has been detached.
 
 ##### emit
@@ -71,7 +75,7 @@ Register a handler on this handle. Idempotent for the same `(event, handler)`.
 def emit(self, event: str, payload: Any = None) -> None
 ```
 
-Send a fire-and-forget event to the channel. No-op after detach. If the WebSocket is down, the message uses the session's global queue, capped at 1000 messages (oldest dropped past that limit). Events emitted before the `useChannel` effect runs can be dropped.
+Send a fire-and-forget event to the channel. No-op after detach. If the WebSocket is down, the message uses the session's global queue: channel messages get their own 500-message budget (oldest dropped first, so they can never evict control-plane messages like `reload` or `navigate_to`) inside an overall 1000-message bound. Events emitted before the `useChannel` effect runs can be dropped.
 
 **Raises:** `TypeError` if the payload cannot be serialized.
 
@@ -103,7 +107,7 @@ A request with no handler NACKs immediately (`no_handler`). Requests are never q
 def detach(self) -> None
 ```
 
-Detach this handle's listeners. Idempotent. Does not destroy the channel name. After detach, `on()` and `request()` raise `ChannelDetached` and `emit()` is a debug-logged no-op. Queued and not-yet-run handlers are skipped.
+Detach this handle's listeners. Idempotent. Does not destroy the channel name. After detach, `on()` and `request()` raise `ChannelDetached` and `emit()` is a debug-logged no-op. The handle's event pump is cancelled, so queued and in-flight handlers do not run.
 
 ## Exceptions
 

--- a/docs/content/docs/reference/pulse/channels.mdx
+++ b/docs/content/docs/reference/pulse/channels.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Channels"
-description: "Realtime mailboxes"
+description: "Realtime channels"
 ---
 
-A channel id is a mailbox name scoped to a render session. Messages route by id. The only lifecycle is local listener attach/detach — the mailbox is not created or destroyed on the wire.
+A channel id is a session-scoped name. Messages route by id. The only lifecycle is local listener attach/detach — the name is not created or destroyed on the wire.
 
 ## Functions
 
@@ -17,17 +17,17 @@ def channel(
 ) -> Channel
 ```
 
-Return a handle on a mailbox.
+Return a handle on a channel name.
 
 **Parameters:**
-- `identifier` — Mailbox name. `None` generates a UUID. Empty string raises `ValueError`.
-- `lifetime` — When this handle auto-detaches. `"route"` (default) detaches on that route/component unmount. `"tab"` lives until the render session ends or you call `detach()`.
+- `identifier` — Channel name. `None` generates a UUID. Empty string raises `ValueError`.
+- `lifetime` — When this handle auto-detaches. `"route"` (default) detaches on that route's real unmount and requires a route context. `"tab"` lives until the render session ends or you call `detach()`.
 
 **Returns:** `Channel` handle.
 
-**Raises:** `RuntimeError` if called outside an active render session. `ValueError` if `identifier` is empty.
+**Raises:** `RuntimeError` if called outside an active render session, or if `lifetime="route"` has no route context. `ValueError` if `identifier` is empty.
 
-During a live route mount, `ps.channel("foo")` returns the same handle. After that handle auto-detaches, the next `ps.channel("foo")` is a new handle on the same mailbox.
+During a live route mount, `ps.channel("foo")` returns the same handle. `on(event, handler)` is idempotent for that triple. After that handle auto-detaches, the next `ps.channel("foo")` is a new handle on the same name.
 
 ```python
 import pulse as ps
@@ -44,13 +44,13 @@ def ChatRoom():
 
 ### Channel
 
-A local handle on a mailbox. Messages still route by `id` after detach.
+A local handle on a channel name. Messages still route by `id` after detach.
 
 #### Attributes
 
 | Attribute | Type | Description |
 |-----------|------|-------------|
-| `id` | `str` | Mailbox name |
+| `id` | `str` | Channel name |
 | `lifetime` | `Literal["route", "tab"]` | Handle auto-detach policy |
 
 #### Methods
@@ -61,7 +61,7 @@ A local handle on a mailbox. Messages still route by `id` after detach.
 def on(self, event: str, handler: ChannelHandler) -> Callable[[], None]
 ```
 
-Register a handler on this handle.
+Register a handler on this handle. Idempotent for the same `(event, handler)`.
 
 **Raises:** `ChannelDetached` if this handle has been detached.
 
@@ -71,7 +71,7 @@ Register a handler on this handle.
 def emit(self, event: str, payload: Any = None) -> None
 ```
 
-Send a fire-and-forget event to the mailbox. Still works after detach. If the WebSocket is down, the message uses the session's global queue.
+Send a fire-and-forget event to the channel. Still works after detach. If the WebSocket is down, the message uses the session's global queue. Events emitted before the client has rendered `useChannel` are dropped.
 
 ##### request
 
@@ -100,7 +100,7 @@ A request with no handler NACKs immediately (`no_handler`). Requests are never q
 def detach(self) -> None
 ```
 
-Detach this handle's listeners. Idempotent. Does not destroy the mailbox. `on()` after detach raises `ChannelDetached`. `emit` / `request` still address the mailbox name.
+Detach this handle's listeners. Idempotent. Does not destroy the channel name. `on()` after detach raises `ChannelDetached`. `emit` / `request` still address the name.
 
 ## Exceptions
 

--- a/docs/content/docs/reference/pulse/channels.mdx
+++ b/docs/content/docs/reference/pulse/channels.mdx
@@ -1,39 +1,42 @@
 ---
 title: "Channels"
-description: "Realtime channels"
+description: "Realtime mailboxes"
 ---
 
-Bidirectional communication channels for real-time messaging between server and client.
+A channel id is a mailbox name scoped to a render session. Messages route by id. The only lifecycle is local listener attach/detach — the mailbox is not created or destroyed on the wire.
 
 ## Functions
 
 ### channel
 
 ```python
-def channel(identifier: str | None = None) -> Channel
+def channel(
+    identifier: str | None = None,
+    *,
+    lifetime: Literal["route", "tab"] = "route",
+) -> Channel
 ```
 
-Create a channel bound to the current render session.
+Return a handle on a mailbox.
 
 **Parameters:**
-- `identifier` - Optional channel ID. Auto-generated UUID if not provided.
+- `identifier` — Mailbox name. `None` generates a UUID. Empty string raises `ValueError`.
+- `lifetime` — When this handle auto-detaches. `"route"` (default) detaches on that route/component unmount. `"tab"` lives until the render session ends or you call `detach()`.
 
-**Returns:** `Channel` instance.
+**Returns:** `Channel` handle.
 
-**Raises:** `RuntimeError` if called outside an active render session.
+**Raises:** `RuntimeError` if called outside an active render session. `ValueError` if `identifier` is empty.
+
+During a live route mount, `ps.channel("foo")` returns the same handle. After that handle auto-detaches, the next `ps.channel("foo")` is a new handle on the same mailbox.
 
 ```python
 import pulse as ps
 
 @ps.component
 def ChatRoom():
-    ch = ps.channel("chat")
-
-    @ch.on("message")
-    def handle_message(payload):
-        # Handle incoming message from client
-        ch.emit("broadcast", payload)
-
+    with ps.init():
+        ch = ps.channel("chat")
+        ch.on("message", lambda payload: ch.emit("echo", payload))
     return ps.div("Chat room")
 ```
 
@@ -41,17 +44,14 @@ def ChatRoom():
 
 ### Channel
 
-Bidirectional communication channel bound to a render session.
+A local handle on a mailbox. Messages still route by `id` after detach.
 
 #### Attributes
 
 | Attribute | Type | Description |
 |-----------|------|-------------|
-| `id` | `str` | Channel identifier |
-| `render_id` | `str` | Associated render session ID |
-| `session_id` | `str` | Associated user session ID |
-| `route_path` | `str \| None` | Route path this channel is bound to |
-| `closed` | `bool` | Whether the channel is closed |
+| `id` | `str` | Mailbox name |
+| `lifetime` | `Literal["route", "tab"]` | Handle auto-detach policy |
 
 #### Methods
 
@@ -61,24 +61,9 @@ Bidirectional communication channel bound to a render session.
 def on(self, event: str, handler: ChannelHandler) -> Callable[[], None]
 ```
 
-Register a handler for an incoming event.
+Register a handler on this handle.
 
-**Parameters:**
-- `event` - Event name to listen for.
-- `handler` - Callback function `(payload: Any) -> Any | Awaitable[Any]`.
-
-**Returns:** Callable that removes the handler when invoked.
-
-**Raises:** `ChannelClosed` if channel is closed.
-
-```python
-ch = ps.channel()
-
-def cleanup():
-    remove_handler()
-
-remove_handler = ch.on("data", lambda payload: print(payload))
-```
+**Raises:** `ChannelDetached` if this handle has been detached.
 
 ##### emit
 
@@ -86,17 +71,7 @@ remove_handler = ch.on("data", lambda payload: print(payload))
 def emit(self, event: str, payload: Any = None) -> None
 ```
 
-Send a fire-and-forget event to the client.
-
-**Parameters:**
-- `event` - Event name.
-- `payload` - Data to send (optional).
-
-**Raises:** `ChannelClosed` if channel is closed.
-
-```python
-ch.emit("notification", {"message": "Hello"})
-```
+Send a fire-and-forget event to the mailbox. Still works after detach. If the WebSocket is down, the message uses the session's global queue.
 
 ##### request
 
@@ -110,48 +85,46 @@ async def request(
 ) -> Any
 ```
 
-Send a request to the client and await the response.
-
-**Parameters:**
-- `event` - Event name.
-- `payload` - Data to send (optional).
-- `timeout` - Timeout in seconds (optional).
-
-**Returns:** Response payload from client.
+Send a request and await the peer's response.
 
 **Raises:**
-- `ChannelClosed` if channel is closed.
-- `ChannelTimeout` if request times out.
+- `ChannelDisconnected` if there is no socket, or it dies mid-flight
+- `ChannelRemoteError` if the peer responds with `no_handler`, `denied`, or `handler_error`
+- `ChannelTimeout` if `timeout` elapses
+
+A request with no handler NACKs immediately (`no_handler`). Requests are never queued while the socket is down.
+
+##### detach
 
 ```python
-result = await ch.request("get_value", timeout=5.0)
+def detach(self) -> None
 ```
 
-##### close
-
-```python
-def close(self) -> None
-```
-
-Close the channel and clean up resources.
+Detach this handle's listeners. Idempotent. Does not destroy the mailbox. `on()` after detach raises `ChannelDetached`. `emit` / `request` still address the mailbox name.
 
 ## Exceptions
 
-### ChannelClosed
+### ChannelDetached
+
+Raised when `on()` is called on a detached handle.
+
+### ChannelDisconnected
+
+Raised when a request cannot complete because the socket is down or died.
+
+### ChannelRemoteError
 
 ```python
-class ChannelClosed(RuntimeError)
+class ChannelRemoteError(Exception):
+    code: Literal["no_handler", "denied", "handler_error"]
+    message: str
 ```
 
-Raised when interacting with a channel that has been closed.
+Raised when the peer responds with an error.
 
 ### ChannelTimeout
 
-```python
-class ChannelTimeout(asyncio.TimeoutError)
-```
-
-Raised when a channel request times out waiting for a response.
+Raised when a request exceeds `timeout`.
 
 ## Type Aliases
 
@@ -160,5 +133,3 @@ Raised when a channel request times out waiting for a response.
 ```python
 ChannelHandler = Callable[[Any], Any | Awaitable[Any]]
 ```
-
-Handler function for channel events. Can be sync or async.

--- a/docs/content/docs/reference/pulse/channels.mdx
+++ b/docs/content/docs/reference/pulse/channels.mdx
@@ -63,6 +63,10 @@ def on(self, event: str, handler: ChannelHandler) -> Callable[[], None]
 
 Register a handler on this handle. Idempotent for the same `(event, handler)`.
 
+Inbound events run in arrival order per handle: an event's handlers are awaited before the next event starts. Inbound requests run as independent tasks, so a request handler may itself `await request(...)` without stalling the session.
+
+All live handles on the same name receive every event (fan-out, including a tab handle and a route handle together). A request goes to the first attached handle that has a handler for the event — registration order decides the single winner.
+
 **Raises:** `ChannelDetached` if this handle has been detached.
 
 ##### emit
@@ -71,7 +75,9 @@ Register a handler on this handle. Idempotent for the same `(event, handler)`.
 def emit(self, event: str, payload: Any = None) -> None
 ```
 
-Send a fire-and-forget event to the channel. Still works after detach. If the WebSocket is down, the message uses the session's global queue. Events emitted before the client has rendered `useChannel` are dropped.
+Send a fire-and-forget event to the channel. No-op after detach. If the WebSocket is down, the message uses the session's global queue, capped at 1000 messages (oldest dropped past that). Events emitted before the client has rendered `useChannel` are dropped.
+
+**Raises:** `TypeError` if the payload cannot be serialized — validated here, at the emitter, not at flush time.
 
 ##### request
 
@@ -88,6 +94,7 @@ async def request(
 Send a request and await the peer's response.
 
 **Raises:**
+- `ChannelDetached` if this handle has been detached
 - `ChannelDisconnected` if there is no socket, or it dies mid-flight
 - `ChannelRemoteError` if the peer responds with `no_handler`, `denied`, or `handler_error`
 - `ChannelTimeout` if `timeout` elapses
@@ -100,13 +107,13 @@ A request with no handler NACKs immediately (`no_handler`). Requests are never q
 def detach(self) -> None
 ```
 
-Detach this handle's listeners. Idempotent. Does not destroy the channel name. `on()` after detach raises `ChannelDetached`. `emit` / `request` still address the name.
+Detach this handle's listeners. Idempotent. Does not destroy the channel name. After detach, `on()` and `request()` raise `ChannelDetached` and `emit()` is a no-op (emits legitimately race detach from background tasks). Queued and not-yet-run handlers are skipped.
 
 ## Exceptions
 
 ### ChannelDetached
 
-Raised when `on()` is called on a detached handle.
+Raised when `on()` or `request()` is called on a detached handle.
 
 ### ChannelDisconnected
 

--- a/docs/content/docs/reference/pulse/channels.mdx
+++ b/docs/content/docs/reference/pulse/channels.mdx
@@ -71,7 +71,7 @@ Register a handler on this handle. Idempotent for the same `(event, handler)`.
 def emit(self, event: str, payload: Any = None) -> None
 ```
 
-Send a fire-and-forget event to the channel. Still works after detach. If the WebSocket is down, the message uses the session's global queue. Events emitted before the client has rendered `useChannel` are dropped.
+Send a fire-and-forget event to the channel. Still works after detach. If the WebSocket is down, the message uses the session's global queue. Events emitted before the `useChannel` effect runs can be dropped.
 
 ##### request
 

--- a/docs/content/docs/reference/pulse/index.mdx
+++ b/docs/content/docs/reference/pulse/index.mdx
@@ -124,7 +124,7 @@ Channels enable real-time bidirectional communication between server and client.
 
 | Export | Description |
 |--------|-------------|
-| `channel` | Return a handle on a mailbox |
+| `channel` | Return a handle on a channel |
 | `Channel` | Channel handle type |
 | `ChannelDetached` | `on()` called on a detached handle |
 | `ChannelDisconnected` | Request failed because the socket is down |

--- a/docs/content/docs/reference/pulse/index.mdx
+++ b/docs/content/docs/reference/pulse/index.mdx
@@ -124,9 +124,11 @@ Channels enable real-time bidirectional communication between server and client.
 
 | Export | Description |
 |--------|-------------|
-| `channel` | Create a bidirectional channel |
-| `Channel` | Channel instance type |
-| `ChannelClosed` | Exception for closed channel |
+| `channel` | Return a handle on a mailbox |
+| `Channel` | Channel handle type |
+| `ChannelDetached` | `on()` called on a detached handle |
+| `ChannelDisconnected` | Request failed because the socket is down |
+| `ChannelRemoteError` | Peer responded with an error |
 | `ChannelTimeout` | Exception for channel timeout |
 
 ## Serialization

--- a/examples/channels.py
+++ b/examples/channels.py
@@ -11,7 +11,7 @@ import pulse as ps
 from pulse.js import Math, obj
 from pulse.js.date import Date
 from pulse.js.json import stringify
-from pulse.js.pulse import usePulseChannel
+from pulse.js.pulse import useChannel
 from pulse.js.react import useEffect, useState
 
 
@@ -19,10 +19,10 @@ from pulse.js.react import useEffect, useState
 def ChannelTester(*, channelId: str, label: str):
 	"""Client-side channel tester component.
 
-	This component runs entirely in the browser and uses the usePulseChannel
+	This component runs entirely in the browser and uses the useChannel
 	hook to communicate with the server-side channel.
 	"""
-	bridge = usePulseChannel(channelId)
+	bridge = useChannel(channelId)
 
 	# State for logs and counters
 	logs, setLogs = useState([])

--- a/packages/pulse-mantine/js/src/combobox.tsx
+++ b/packages/pulse-mantine/js/src/combobox.tsx
@@ -60,55 +60,53 @@ export function Combobox({
 		loop,
 		scrollBehavior,
 	});
+	const comboboxRef = useRef(combobox);
+	comboboxRef.current = combobox;
 
 	useEffect(() => {
 		const cleanups = [
 			channel.on("openDropdown", (payload: OptionalEventSourcePayload) => {
-				combobox.openDropdown(payload?.eventSource);
+				comboboxRef.current.openDropdown(payload?.eventSource);
 			}),
 			channel.on("closeDropdown", (payload: OptionalEventSourcePayload) => {
-				combobox.closeDropdown(payload?.eventSource);
+				comboboxRef.current.closeDropdown(payload?.eventSource);
 			}),
 			channel.on("toggleDropdown", (payload: OptionalEventSourcePayload) => {
-				combobox.toggleDropdown(payload?.eventSource);
+				comboboxRef.current.toggleDropdown(payload?.eventSource);
 			}),
 			channel.on("selectOption", (payload: { index: number }) => {
-				combobox.selectOption(payload.index);
+				comboboxRef.current.selectOption(payload.index);
 			}),
-			channel.on("selectActiveOption", () => combobox.selectActiveOption()),
-			channel.on("selectFirstOption", () => combobox.selectFirstOption()),
-			channel.on("selectNextOption", () => combobox.selectNextOption()),
-			channel.on("selectPreviousOption", () => combobox.selectPreviousOption()),
+			channel.on("selectActiveOption", () => comboboxRef.current.selectActiveOption()),
+			channel.on("selectFirstOption", () => comboboxRef.current.selectFirstOption()),
+			channel.on("selectNextOption", () => comboboxRef.current.selectNextOption()),
+			channel.on("selectPreviousOption", () => comboboxRef.current.selectPreviousOption()),
 			channel.on("resetSelectedOption", () => {
-				combobox.resetSelectedOption();
+				comboboxRef.current.resetSelectedOption();
 			}),
 			channel.on("clickSelectedOption", () => {
-				combobox.clickSelectedOption();
+				comboboxRef.current.clickSelectedOption();
 			}),
 			channel.on(
 				"updateSelectedOptionIndex",
 				(payload: OptionalTargetPayload) => {
-					combobox.updateSelectedOptionIndex(payload?.target);
+					comboboxRef.current.updateSelectedOptionIndex(payload?.target);
 				},
 			),
-			channel.on("focusSearchInput", () => {
-				combobox.focusSearchInput();
-			}),
-			channel.on("focusTarget", () => {
-				combobox.focusTarget();
-			}),
+			channel.on("focusSearchInput", () => comboboxRef.current.focusSearchInput()),
+			channel.on("focusTarget", () => comboboxRef.current.focusTarget()),
 			channel.on("setListId", (payload: { listId: string }) => {
-				combobox.setListId(payload.listId);
+				comboboxRef.current.setListId(payload.listId);
 			}),
-			channel.on("getDropdownOpened", () => combobox.dropdownOpened),
-			channel.on("getSelectedOptionIndex", () => combobox.selectedOptionIndex),
-			channel.on("getListId", () => combobox.listId),
+			channel.on("getDropdownOpened", () => comboboxRef.current.dropdownOpened),
+			channel.on("getSelectedOptionIndex", () => comboboxRef.current.selectedOptionIndex),
+			channel.on("getListId", () => comboboxRef.current.listId),
 		];
 
 		return () => {
 			for (const dispose of cleanups) dispose();
 		};
-	}, [channel, combobox]);
+	}, [channel]);
 
 	return <MantineCombobox {...(rest as any)} store={combobox} />;
 }

--- a/packages/pulse-mantine/js/src/combobox.tsx
+++ b/packages/pulse-mantine/js/src/combobox.tsx
@@ -1,6 +1,6 @@
 import { Combobox as MantineCombobox, useCombobox } from "@mantine/core";
 import { useChannel } from "pulse-ui-client";
-import { type ComponentPropsWithoutRef, useEffect, useRef } from "react";
+import { type ComponentPropsWithoutRef, useEffect, useLayoutEffect, useRef } from "react";
 
 type DropdownEventSource = "keyboard" | "mouse" | "unknown";
 
@@ -40,7 +40,9 @@ export function Combobox({
 }: PulseComboboxProps) {
 	const channel = useChannel(channelId);
 	const channelRef = useRef(channel);
-	channelRef.current = channel;
+	useLayoutEffect(() => {
+		channelRef.current = channel;
+	}, [channel]);
 
 	const combobox = useCombobox({
 		defaultOpened,
@@ -61,7 +63,10 @@ export function Combobox({
 		scrollBehavior,
 	});
 	const comboboxRef = useRef(combobox);
-	comboboxRef.current = combobox;
+	const listIdRef = useRef<string | undefined>(undefined);
+	useLayoutEffect(() => {
+		comboboxRef.current = combobox;
+	});
 
 	useEffect(() => {
 		const cleanups = [
@@ -96,11 +101,13 @@ export function Combobox({
 			channel.on("focusSearchInput", () => comboboxRef.current.focusSearchInput()),
 			channel.on("focusTarget", () => comboboxRef.current.focusTarget()),
 			channel.on("setListId", (payload: { listId: string }) => {
+				listIdRef.current = payload.listId;
 				comboboxRef.current.setListId(payload.listId);
 			}),
 			channel.on("getDropdownOpened", () => comboboxRef.current.dropdownOpened),
-			channel.on("getSelectedOptionIndex", () => comboboxRef.current.selectedOptionIndex),
-			channel.on("getListId", () => comboboxRef.current.listId),
+			channel.on("getSelectedOptionIndex", () => comboboxRef.current.getSelectedOptionIndex()),
+			// Mantine has no getListId(); setListId mutates a ref without rerender.
+			channel.on("getListId", () => listIdRef.current ?? comboboxRef.current.listId),
 		];
 
 		return () => {

--- a/packages/pulse-mantine/js/src/combobox.tsx
+++ b/packages/pulse-mantine/js/src/combobox.tsx
@@ -1,5 +1,5 @@
 import { Combobox as MantineCombobox, useCombobox } from "@mantine/core";
-import { usePulseChannel } from "pulse-ui-client";
+import { useChannel } from "pulse-ui-client";
 import { type ComponentPropsWithoutRef, useEffect, useRef } from "react";
 
 type DropdownEventSource = "keyboard" | "mouse" | "unknown";
@@ -38,7 +38,7 @@ export function Combobox({
 	scrollBehavior,
 	...rest
 }: PulseComboboxProps) {
-	const channel = usePulseChannel(channelId);
+	const channel = useChannel(channelId);
 	const channelRef = useRef(channel);
 	channelRef.current = channel;
 

--- a/packages/pulse-mantine/js/src/combobox.tsx
+++ b/packages/pulse-mantine/js/src/combobox.tsx
@@ -1,5 +1,5 @@
 import { Combobox as MantineCombobox, useCombobox } from "@mantine/core";
-import { usePulseClient, type ChannelBridge } from "pulse-ui-client";
+import { usePulseChannel } from "pulse-ui-client";
 import { type ComponentPropsWithoutRef, useEffect, useRef } from "react";
 
 type DropdownEventSource = "keyboard" | "mouse" | "unknown";
@@ -38,8 +38,9 @@ export function Combobox({
 	scrollBehavior,
 	...rest
 }: PulseComboboxProps) {
-	const client = usePulseClient();
-	const channelRef = useRef<ChannelBridge | null>(null);
+	const channel = usePulseChannel(channelId);
+	const channelRef = useRef(channel);
+	channelRef.current = channel;
 
 	const combobox = useCombobox({
 		defaultOpened,
@@ -61,8 +62,6 @@ export function Combobox({
 	});
 
 	useEffect(() => {
-		const channel = client.acquireChannel(channelId);
-		channelRef.current = channel;
 		const cleanups = [
 			channel.on("openDropdown", (payload: OptionalEventSourcePayload) => {
 				combobox.openDropdown(payload?.eventSource);
@@ -108,12 +107,8 @@ export function Combobox({
 
 		return () => {
 			for (const dispose of cleanups) dispose();
-			if (channelRef.current === channel) {
-				channelRef.current = null;
-			}
-			client.releaseChannel(channelId);
 		};
-	}, [client, channelId, combobox]);
+	}, [channel, combobox]);
 
 	return <MantineCombobox {...(rest as any)} store={combobox} />;
 }

--- a/packages/pulse-mantine/js/src/form/form.tsx
+++ b/packages/pulse-mantine/js/src/form/form.tsx
@@ -1,6 +1,6 @@
 import type { UseFormInput, UseFormReturnType } from "@mantine/form";
 import { useForm } from "@mantine/form";
-import { submitForm, usePulseChannel, usePulseDirectivesSource } from "pulse-ui-client";
+import { submitForm, useChannel, usePulseDirectivesSource } from "pulse-ui-client";
 import {
 	type ComponentPropsWithoutRef,
 	type FormEvent,
@@ -59,7 +59,7 @@ export function Form<TValues extends Record<string, any> = Record<string, any>>(
 	cascadeUpdates,
 	...formProps
 }: MantineFormProps<TValues>) {
-	const channel = usePulseChannel(channelId);
+	const channel = useChannel(channelId);
 	const directives = usePulseDirectivesSource();
 	const formRef = useRef<UseFormReturnType<TValues> | null>(null);
 	// Timers for server-validation per path

--- a/packages/pulse-mantine/js/src/form/form.tsx
+++ b/packages/pulse-mantine/js/src/form/form.tsx
@@ -1,11 +1,6 @@
 import type { UseFormInput, UseFormReturnType } from "@mantine/form";
 import { useForm } from "@mantine/form";
-import {
-	submitForm,
-	usePulseClient,
-	usePulseDirectivesSource,
-	type ChannelBridge,
-} from "pulse-ui-client";
+import { submitForm, usePulseChannel, usePulseDirectivesSource } from "pulse-ui-client";
 import {
 	type ComponentPropsWithoutRef,
 	type FormEvent,
@@ -64,9 +59,8 @@ export function Form<TValues extends Record<string, any> = Record<string, any>>(
 	cascadeUpdates,
 	...formProps
 }: MantineFormProps<TValues>) {
-	const client = usePulseClient();
+	const channel = usePulseChannel(channelId);
 	const directives = usePulseDirectivesSource();
-	const channelRef = useRef<ChannelBridge | null>(null);
 	const formRef = useRef<UseFormReturnType<TValues> | null>(null);
 	// Timers for server-validation per path
 	const serverTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
@@ -91,21 +85,17 @@ export function Form<TValues extends Record<string, any> = Record<string, any>>(
 		>;
 	}, [validate]);
 
-	const emitChannel = useCallback((event: string, payload?: any) => {
-		channelRef.current?.emit(event, payload);
-	}, []);
-
 	const sendSync = useCallback(
 		(reason: "change" | "blur", path?: string) => {
 			const values = formRef.current?.getValues();
 			if (!values) return;
-			emitChannel("syncValues", {
+			channel.emit("syncValues", {
 				reason,
 				path,
 				values: stripFilesForSync(values),
 			});
 		},
-		[emitChannel],
+		[channel],
 	);
 
 	const getValueAtPath = useCallback((source: any, path?: string) => {
@@ -198,7 +188,7 @@ export function Form<TValues extends Record<string, any> = Record<string, any>>(
 						const latestValues = formRef.current?.getValues();
 						if (!latestValues) return;
 						const value = getValueAtPath(latestValues, path);
-						emitChannel("serverValidate", {
+						channel.emit("serverValidate", {
 							value: stripFilesForSync(value),
 							values: stripFilesForSync(latestValues),
 							path,
@@ -215,7 +205,7 @@ export function Form<TValues extends Record<string, any> = Record<string, any>>(
 			sendSync,
 			serverRulesByPath,
 			shouldValidateOnChange,
-			emitChannel,
+			channel,
 		],
 	);
 
@@ -261,13 +251,13 @@ export function Form<TValues extends Record<string, any> = Record<string, any>>(
 			const latestValues = formRef.current?.getValues();
 			if (!latestValues) return;
 			const value = getValueAtPath(latestValues, path);
-			emitChannel("serverValidate", {
+			channel.emit("serverValidate", {
 				value: stripFilesForSync(value),
 				values: stripFilesForSync(latestValues),
 				path,
 			});
 		},
-		[getValueAtPath, syncMode, sendSync, serverRulesByPath, shouldValidateOnBlur, emitChannel],
+		[getValueAtPath, syncMode, sendSync, serverRulesByPath, shouldValidateOnBlur, channel],
 	);
 
 	const form = useForm<any>({
@@ -298,11 +288,9 @@ export function Form<TValues extends Record<string, any> = Record<string, any>>(
 			});
 			syncTimersRef.current.clear();
 		};
-	}, []);
+	}, [channelId]);
 
 	useEffect(() => {
-		const channel = client.acquireChannel(channelId);
-		channelRef.current = channel;
 		const cleanups = [
 			channel.on("setValues", (payload: { values: TValues }) => {
 				const currentForm = formRef.current;
@@ -390,12 +378,8 @@ export function Form<TValues extends Record<string, any> = Record<string, any>>(
 
 		return () => {
 			for (const dispose of cleanups) dispose();
-			if (channelRef.current === channel) {
-				channelRef.current = null;
-			}
-			client.releaseChannel(channelId);
 		};
-	}, [client, channelId, sendSync]);
+	}, [channel, sendSync]);
 
 	const submitHandler = useMemo(
 		() =>

--- a/packages/pulse-mantine/js/src/form/integration.test.tsx
+++ b/packages/pulse-mantine/js/src/form/integration.test.tsx
@@ -24,7 +24,7 @@ const submitForm = mock(
 mock.module("pulse-ui-client", () => ({
 	submitForm,
 	usePulseClient: () => client,
-	usePulseChannel: () => channel,
+	useChannel: () => channel,
 	usePulseDirectivesSource: () => directivesSource,
 }));
 

--- a/packages/pulse-mantine/js/src/form/integration.test.tsx
+++ b/packages/pulse-mantine/js/src/form/integration.test.tsx
@@ -5,7 +5,7 @@ import { useField } from "./connect";
 import { Checkbox, CheckboxGroup, MultiSelect, TagsInput, TextInput } from "./fields";
 
 const channel = {
-	on: () => () => {},
+	on: mock(() => () => {}),
 	emit: mock(),
 };
 const client = {
@@ -29,6 +29,8 @@ mock.module("pulse-ui-client", () => ({
 }));
 
 const { Form } = await import("./form");
+const { Combobox } = await import("../combobox");
+const { Tree } = await import("../tree");
 
 type Sample = {
 	sample_id: string;
@@ -259,5 +261,43 @@ describe("MantineForm submit values", () => {
 			method: "post",
 			id: "record-1",
 		});
+	});
+});
+
+describe("Mantine channel handlers", () => {
+	it("registers Combobox handlers once across re-renders", () => {
+		channel.on.mockClear();
+		const view = render(
+			<MantineProvider>
+				<Combobox channelId="combobox" />
+			</MantineProvider>,
+		);
+		const registrations = channel.on.mock.calls.length;
+		view.rerender(
+			<MantineProvider>
+				<Combobox channelId="combobox" />
+			</MantineProvider>,
+		);
+		expect(registrations).toBeGreaterThan(0);
+		expect(channel.on).toHaveBeenCalledTimes(registrations);
+		view.unmount();
+	});
+
+	it("registers Tree handlers once across re-renders", () => {
+		channel.on.mockClear();
+		const view = render(
+			<MantineProvider>
+				<Tree channelId="tree" data={[]} />
+			</MantineProvider>,
+		);
+		const registrations = channel.on.mock.calls.length;
+		view.rerender(
+			<MantineProvider>
+				<Tree channelId="tree" data={[]} />
+			</MantineProvider>,
+		);
+		expect(registrations).toBeGreaterThan(0);
+		expect(channel.on).toHaveBeenCalledTimes(registrations);
+		view.unmount();
 	});
 });

--- a/packages/pulse-mantine/js/src/form/integration.test.tsx
+++ b/packages/pulse-mantine/js/src/form/integration.test.tsx
@@ -1,11 +1,19 @@
 import { describe, expect, it, mock } from "bun:test";
-import { MantineProvider } from "@mantine/core";
-import { fireEvent, render } from "@testing-library/react";
+import { Combobox as MantineCombobox, MantineProvider } from "@mantine/core";
+import { act, fireEvent, render } from "@testing-library/react";
 import { useField } from "./connect";
 import { Checkbox, CheckboxGroup, MultiSelect, TagsInput, TextInput } from "./fields";
 
+const channelHandlers = new Map<string, (payload?: any) => any>();
 const channel = {
-	on: mock(() => () => {}),
+	on: mock((event: string, handler: (payload?: any) => any) => {
+		channelHandlers.set(event, handler);
+		return () => {
+			if (channelHandlers.get(event) === handler) {
+				channelHandlers.delete(event);
+			}
+		};
+	}),
 	emit: mock(),
 };
 const client = {
@@ -267,6 +275,7 @@ describe("MantineForm submit values", () => {
 describe("Mantine channel handlers", () => {
 	it("registers Combobox handlers once across re-renders", () => {
 		channel.on.mockClear();
+		channelHandlers.clear();
 		const view = render(
 			<MantineProvider>
 				<Combobox channelId="combobox" />
@@ -285,6 +294,7 @@ describe("Mantine channel handlers", () => {
 
 	it("registers Tree handlers once across re-renders", () => {
 		channel.on.mockClear();
+		channelHandlers.clear();
 		const view = render(
 			<MantineProvider>
 				<Tree channelId="tree" data={[]} />
@@ -298,6 +308,41 @@ describe("Mantine channel handlers", () => {
 		);
 		expect(registrations).toBeGreaterThan(0);
 		expect(channel.on).toHaveBeenCalledTimes(registrations);
+		view.unmount();
+	});
+
+	it("uses Mantine's stable selected-option getter", () => {
+		channel.on.mockClear();
+		channelHandlers.clear();
+		const view = render(
+			<MantineProvider>
+				<Combobox channelId="combobox">
+					<MantineCombobox.Options id="list">
+						<MantineCombobox.Option value="one">One</MantineCombobox.Option>
+					</MantineCombobox.Options>
+				</Combobox>
+			</MantineProvider>,
+		);
+		act(() => {
+			channelHandlers.get("setListId")?.({ listId: "list" });
+			channelHandlers.get("selectOption")?.({ index: 0 });
+		});
+		expect(channelHandlers.get("getSelectedOptionIndex")?.()).toBe(0);
+		view.unmount();
+	});
+
+	it("returns a channel-assigned list id", () => {
+		channel.on.mockClear();
+		channelHandlers.clear();
+		const view = render(
+			<MantineProvider>
+				<Combobox channelId="combobox" />
+			</MantineProvider>,
+		);
+		act(() => {
+			channelHandlers.get("setListId")?.({ listId: "channel-list" });
+		});
+		expect(channelHandlers.get("getListId")?.()).toBe("channel-list");
 		view.unmount();
 	});
 });

--- a/packages/pulse-mantine/js/src/form/integration.test.tsx
+++ b/packages/pulse-mantine/js/src/form/integration.test.tsx
@@ -9,8 +9,9 @@ const channel = {
 	emit: mock(),
 };
 const client = {
-	acquireChannel: () => channel,
-	releaseChannel: () => {},
+	channel: () => channel,
+	attachHandle: () => {},
+	detachHandle: () => {},
 };
 let currentDirectives = {
 	query: { pulse_deployment: "prod-old" },
@@ -23,6 +24,7 @@ const submitForm = mock(
 mock.module("pulse-ui-client", () => ({
 	submitForm,
 	usePulseClient: () => client,
+	usePulseChannel: () => channel,
 	usePulseDirectivesSource: () => directivesSource,
 }));
 

--- a/packages/pulse-mantine/js/src/notifications.tsx
+++ b/packages/pulse-mantine/js/src/notifications.tsx
@@ -5,8 +5,8 @@ import {
 	type NotificationsProps,
 	notifications as notificationsApi,
 } from "@mantine/notifications";
-import { usePulseClient, type ChannelBridge } from "pulse-ui-client";
-import { useEffect, useRef } from "react";
+import { usePulseChannel } from "pulse-ui-client";
+import { useEffect } from "react";
 
 type NotificationUpdatePayload = Parameters<typeof notificationsApi.update>[0];
 type NotificationShowPayload = NotificationData;
@@ -38,14 +38,9 @@ export function Notifications({ channelId, ...props }: PulseNotificationsProps) 
 
 function ConnectedNotifications({ channelId, ...props }: ConnectedNotificationsProps) {
 	const { store = defaultStore, ...rest } = props;
-	const client = usePulseClient();
-	const channelRef = useRef<ChannelBridge | null>(null);
+	const channel = usePulseChannel(channelId);
 
 	useEffect(() => {
-		if (!channelId) return;
-
-		const channel = client.acquireChannel(channelId);
-		channelRef.current = channel;
 		const cleanups = [
 			channel.on("show", (payload: unknown) => {
 				if (!isNotificationData(payload)) return;
@@ -75,15 +70,13 @@ function ConnectedNotifications({ channelId, ...props }: ConnectedNotificationsP
 				notificationsApi.updateState(store, () => next as NotificationData[]);
 			}),
 			store.subscribe((state) => {
-				const currentChannel = channelRef.current;
-				if (!currentChannel) return;
 				const notificationIds = state.notifications
 					.map((item) => item.id)
 					.filter((id): id is string => !!id && id.length > 0);
 				const queueIds = state.queue
 					.map((item) => item.id)
 					.filter((id): id is string => !!id && id.length > 0);
-				currentChannel.emit("stateSync", {
+				channel.emit("stateSync", {
 					notifications: notificationIds,
 					queue: queueIds,
 				});
@@ -94,12 +87,8 @@ function ConnectedNotifications({ channelId, ...props }: ConnectedNotificationsP
 			for (const dispose of cleanups) {
 				dispose();
 			}
-			if (channelRef.current === channel) {
-				channelRef.current = null;
-			}
-			client.releaseChannel(channelId);
 		};
-	}, [client, channelId, store]);
+	}, [channel, store]);
 
 	return <MantineNotifications {...rest} store={store} />;
 }

--- a/packages/pulse-mantine/js/src/notifications.tsx
+++ b/packages/pulse-mantine/js/src/notifications.tsx
@@ -5,7 +5,7 @@ import {
 	type NotificationsProps,
 	notifications as notificationsApi,
 } from "@mantine/notifications";
-import { usePulseChannel } from "pulse-ui-client";
+import { useChannel } from "pulse-ui-client";
 import { useEffect } from "react";
 
 type NotificationUpdatePayload = Parameters<typeof notificationsApi.update>[0];
@@ -38,7 +38,7 @@ export function Notifications({ channelId, ...props }: PulseNotificationsProps) 
 
 function ConnectedNotifications({ channelId, ...props }: ConnectedNotificationsProps) {
 	const { store = defaultStore, ...rest } = props;
-	const channel = usePulseChannel(channelId);
+	const channel = useChannel(channelId);
 
 	useEffect(() => {
 		const cleanups = [

--- a/packages/pulse-mantine/js/src/tree.tsx
+++ b/packages/pulse-mantine/js/src/tree.tsx
@@ -1,5 +1,5 @@
 import { Tree as MantineTree, useTree } from "@mantine/core";
-import { usePulseClient, type ChannelBridge } from "pulse-ui-client";
+import { usePulseChannel } from "pulse-ui-client";
 import { type ComponentPropsWithoutRef, useEffect, useRef } from "react";
 
 type ExpandedState = Record<string, boolean>;
@@ -59,8 +59,9 @@ function ConnectedTree({
 	autoSync = true,
 	...rest
 }: ConnectedTreeProps) {
-	const client = usePulseClient();
-	const channelRef = useRef<ChannelBridge | null>(null);
+	const channel = usePulseChannel(channelId);
+	const channelRef = useRef(channel);
+	channelRef.current = channel;
 
 	// Create controller with initial state and wire auto-sync callbacks
 	const tree = useTree({
@@ -80,9 +81,6 @@ function ConnectedTree({
 
 	// Server -> client imperative API
 	useEffect(() => {
-		if (!channelId) return;
-		const channel = client.acquireChannel(channelId);
-		channelRef.current = channel;
 		const cleanups = [
 			channel.on("toggleExpanded", (payload: { value: string }) => {
 				if (!payload) return;
@@ -160,12 +158,8 @@ function ConnectedTree({
 		];
 		return () => {
 			for (const dispose of cleanups) dispose();
-			if (channelRef.current === channel) {
-				channelRef.current = null;
-			}
-			client.releaseChannel(channelId);
 		};
-	}, [client, channelId, tree]);
+	}, [channel, tree]);
 
 	return <MantineTree {...(rest as any)} tree={tree as any} />;
 }

--- a/packages/pulse-mantine/js/src/tree.tsx
+++ b/packages/pulse-mantine/js/src/tree.tsx
@@ -78,88 +78,84 @@ function ConnectedTree({
 			channelRef.current?.emit("nodeCollapse", { value });
 		},
 	} as any);
+	const treeRef = useRef(tree);
+	treeRef.current = tree;
 
 	// Server -> client imperative API
 	useEffect(() => {
 		const cleanups = [
 			channel.on("toggleExpanded", (payload: { value: string }) => {
 				if (!payload) return;
-				tree.toggleExpanded(payload.value);
+				treeRef.current.toggleExpanded(payload.value);
 			}),
 			channel.on("expand", (payload: { value: string }) => {
 				if (!payload) return;
-				tree.expand(payload.value);
+				treeRef.current.expand(payload.value);
 			}),
 			channel.on("collapse", (payload: { value: string }) => {
 				if (!payload) return;
-				tree.collapse(payload.value);
+				treeRef.current.collapse(payload.value);
 			}),
-			channel.on("expandAllNodes", () => {
-				tree.expandAllNodes();
-			}),
-			channel.on("collapseAllNodes", () => {
-				tree.collapseAllNodes();
-			}),
+			channel.on("expandAllNodes", () => treeRef.current.expandAllNodes()),
+			channel.on("collapseAllNodes", () => treeRef.current.collapseAllNodes()),
 			channel.on("setExpandedState", (payload: { expandedState: ExpandedState }) => {
 				if (!payload) return;
-				tree.setExpandedState(payload.expandedState ?? {});
+				treeRef.current.setExpandedState(payload.expandedState ?? {});
 			}),
-			channel.on("getCheckedNodes", () => tree.getCheckedNodes()),
-			channel.on("getExpandedState", () => tree.expandedState),
+			channel.on("getCheckedNodes", () => treeRef.current.getCheckedNodes()),
+			channel.on("getExpandedState", () => treeRef.current.expandedState),
 			// Selection API
 			channel.on("toggleSelected", (payload: { value: string }) => {
 				if (!payload) return;
-				tree.toggleSelected(payload.value);
+				treeRef.current.toggleSelected(payload.value);
 			}),
 			channel.on("select", (payload: { value: string }) => {
 				if (!payload) return;
-				tree.select(payload.value);
+				treeRef.current.select(payload.value);
 			}),
 			channel.on("deselect", (payload: { value: string }) => {
 				if (!payload) return;
-				tree.deselect(payload.value);
+				treeRef.current.deselect(payload.value);
 			}),
-			channel.on("clearSelected", () => {
-				tree.clearSelected();
-			}),
+			channel.on("clearSelected", () => treeRef.current.clearSelected()),
 			channel.on("setSelectedState", (payload: { selectedState: string[] }) => {
 				if (!payload) return;
-				tree.setSelectedState(payload.selectedState ?? []);
+				treeRef.current.setSelectedState(payload.selectedState ?? []);
 			}),
-			channel.on("getSelectedState", () => tree.selectedState),
-			channel.on("getAnchorNode", () => tree.anchorNode),
+			channel.on("getSelectedState", () => treeRef.current.selectedState),
+			channel.on("getAnchorNode", () => treeRef.current.anchorNode),
 			// Hover API
 			channel.on("setHoveredNode", (payload: { value?: string | null }) => {
-				tree.setHoveredNode(payload?.value ?? null);
+				treeRef.current.setHoveredNode(payload?.value ?? null);
 			}),
-			channel.on("getHoveredNode", () => tree.hoveredNode),
+			channel.on("getHoveredNode", () => treeRef.current.hoveredNode),
 			// Checked API
 			channel.on("checkNode", (payload: { value: string }) => {
 				if (!payload) return;
-				tree.checkNode(payload.value);
+				treeRef.current.checkNode(payload.value);
 			}),
 			channel.on("uncheckNode", (payload: { value: string }) => {
 				if (!payload) return;
-				tree.uncheckNode(payload.value);
+				treeRef.current.uncheckNode(payload.value);
 			}),
-			channel.on("checkAllNodes", () => tree.checkAllNodes()),
-			channel.on("uncheckAllNodes", () => tree.uncheckAllNodes()),
+			channel.on("checkAllNodes", () => treeRef.current.checkAllNodes()),
+			channel.on("uncheckAllNodes", () => treeRef.current.uncheckAllNodes()),
 			channel.on("setCheckedState", (payload: { checkedState: string[] }) => {
 				if (!payload) return;
-				tree.setCheckedState(payload.checkedState ?? []);
+				treeRef.current.setCheckedState(payload.checkedState ?? []);
 			}),
-			channel.on("getCheckedState", () => tree.checkedState),
+			channel.on("getCheckedState", () => treeRef.current.checkedState),
 			channel.on("isNodeChecked", (payload: { value: string }) =>
-				tree.isNodeChecked(payload?.value),
+				treeRef.current.isNodeChecked(payload?.value),
 			),
 			channel.on("isNodeIndeterminate", (payload: { value: string }) =>
-				tree.isNodeIndeterminate(payload?.value),
+				treeRef.current.isNodeIndeterminate(payload?.value),
 			),
 		];
 		return () => {
 			for (const dispose of cleanups) dispose();
 		};
-	}, [channel, tree]);
+	}, [channel]);
 
 	return <MantineTree {...(rest as any)} tree={tree as any} />;
 }

--- a/packages/pulse-mantine/js/src/tree.tsx
+++ b/packages/pulse-mantine/js/src/tree.tsx
@@ -1,5 +1,5 @@
 import { Tree as MantineTree, useTree } from "@mantine/core";
-import { usePulseChannel } from "pulse-ui-client";
+import { useChannel } from "pulse-ui-client";
 import { type ComponentPropsWithoutRef, useEffect, useRef } from "react";
 
 type ExpandedState = Record<string, boolean>;
@@ -59,7 +59,7 @@ function ConnectedTree({
 	autoSync = true,
 	...rest
 }: ConnectedTreeProps) {
-	const channel = usePulseChannel(channelId);
+	const channel = useChannel(channelId);
 	const channelRef = useRef(channel);
 	channelRef.current = channel;
 

--- a/packages/pulse-mantine/js/src/tree.tsx
+++ b/packages/pulse-mantine/js/src/tree.tsx
@@ -1,6 +1,6 @@
 import { Tree as MantineTree, useTree } from "@mantine/core";
 import { useChannel } from "pulse-ui-client";
-import { type ComponentPropsWithoutRef, useEffect, useRef } from "react";
+import { type ComponentPropsWithoutRef, useEffect, useLayoutEffect, useRef } from "react";
 
 type ExpandedState = Record<string, boolean>;
 
@@ -61,7 +61,9 @@ function ConnectedTree({
 }: ConnectedTreeProps) {
 	const channel = useChannel(channelId);
 	const channelRef = useRef(channel);
-	channelRef.current = channel;
+	useLayoutEffect(() => {
+		channelRef.current = channel;
+	}, [channel]);
 
 	// Create controller with initial state and wire auto-sync callbacks
 	const tree = useTree({
@@ -79,7 +81,9 @@ function ConnectedTree({
 		},
 	} as any);
 	const treeRef = useRef(tree);
-	treeRef.current = tree;
+	useLayoutEffect(() => {
+		treeRef.current = tree;
+	});
 
 	// Server -> client imperative API
 	useEffect(() => {

--- a/packages/pulse-mantine/python/src/pulse_mantine/core/feedback/notifications.py
+++ b/packages/pulse-mantine/python/src/pulse_mantine/core/feedback/notifications.py
@@ -188,7 +188,7 @@ class NotificationsStore(ps.State):
 	queued_ids: list[str]
 
 	def __init__(self) -> None:
-		self._channel = ps.channel(NOTIFICATIONS_CHANNEL_ID)
+		self._channel = ps.channel(NOTIFICATIONS_CHANNEL_ID, lifetime="tab")
 		self.registry = {}
 		self.visible_ids = []
 		self.queued_ids = []

--- a/packages/pulse-mantine/python/src/pulse_mantine/form/form.py
+++ b/packages/pulse-mantine/python/src/pulse_mantine/form/form.py
@@ -114,10 +114,6 @@ class MantineForm(ps.State, Generic[TForm]):
 		# Listen for server-side validation requests from the client.
 		self._channel.on("serverValidate", self._on_server_validate)
 
-	def _ensure_channel_open(self) -> None:
-		if self._channel.closed:
-			self._create_channel()
-
 	async def _handle_form_data(self, data: ps.FormData):
 		result = cast(dict[str, Any], data)
 
@@ -138,7 +134,6 @@ class MantineForm(ps.State, Generic[TForm]):
 		onSubmit: ps.EventHandler1[TForm] | None = None,
 		**props: Unpack[ps.HTMLFormProps],  # pyright: ignore[reportGeneralTypeIssues]
 	):
-		self._ensure_channel_open()
 		self._on_submit = onSubmit
 		merged: dict[str, Any] = {**props, **self._mantine_props, **self._form.props()}
 		return FormInternal(
@@ -150,11 +145,9 @@ class MantineForm(ps.State, Generic[TForm]):
 
 	# Public API mapping to Mantine useForm actions
 	async def get_form_values(self):
-		self._ensure_channel_open()
 		return await self._channel.request("getFormValues")
 
 	def set_values(self, values: dict[str, Any]):
-		self._ensure_channel_open()
 		# Optimistically update server state if sync is enabled
 		if self._sync_mode != "none" and isinstance(values, dict):
 			incoming_keys = set(values.keys())
@@ -165,7 +158,6 @@ class MantineForm(ps.State, Generic[TForm]):
 		self._channel.emit("setValues", {"values": values})
 
 	def set_field_value(self, path: str, value: Any):
-		self._ensure_channel_open()
 		# Optimistically update server state if sync is enabled
 		if self._sync_mode != "none" and isinstance(path, str):
 			try:
@@ -176,7 +168,6 @@ class MantineForm(ps.State, Generic[TForm]):
 		self._channel.emit("setFieldValue", {"path": path, "value": value})
 
 	def insert_list_item(self, path: str, item: Any, index: int | None = None):
-		self._ensure_channel_open()
 		msg: dict[str, Any] = {"path": path, "item": item}
 		if index is not None:
 			msg["index"] = index
@@ -209,7 +200,6 @@ class MantineForm(ps.State, Generic[TForm]):
 		self._channel.emit("insertListItem", msg)
 
 	def remove_list_item(self, path: str, index: int):
-		self._ensure_channel_open()
 		# Optimistically update server state if sync is enabled
 		if self._sync_mode != "none" and isinstance(path, str):
 			try:
@@ -229,7 +219,6 @@ class MantineForm(ps.State, Generic[TForm]):
 		self._channel.emit("removeListItem", {"path": path, "index": index})
 
 	def reorder_list_item(self, path: str, frm: int, to: int):
-		self._ensure_channel_open()
 		# Optimistically update server state if sync is enabled
 		if self._sync_mode != "none" and isinstance(path, str):
 			try:
@@ -253,26 +242,21 @@ class MantineForm(ps.State, Generic[TForm]):
 		)
 
 	def set_errors(self, errors: dict[str, Any]):
-		self._ensure_channel_open()
 		self._channel.emit("setErrors", {"errors": errors})
 
 	def set_field_error(self, path: str, error: Any):
-		self._ensure_channel_open()
 		self._channel.emit("setFieldError", {"path": path, "error": error})
 
 	def clear_errors(self, *paths: str):
-		self._ensure_channel_open()
 		if paths:
 			self._channel.emit("clearErrors", {"paths": list(paths)})
 		else:
 			self._channel.emit("clearErrors")
 
 	def set_touched(self, touched: dict[str, bool]):
-		self._ensure_channel_open()
 		self._channel.emit("setTouched", {"touched": touched})
 
 	def validate(self):
-		self._ensure_channel_open()
 		# Trigger client-side validation
 		self._channel.emit("validate")
 		# Also run all server-side validators in the background for current values
@@ -327,7 +311,6 @@ class MantineForm(ps.State, Generic[TForm]):
 			return
 
 	def reset(self, initial_values: dict[str, Any] | None = None):
-		self._ensure_channel_open()
 		if self._sync_mode != "none":
 			values: dict[str, Any]
 			if initial_values is not None:

--- a/packages/pulse-mantine/python/tests/test_combobox_store.py
+++ b/packages/pulse-mantine/python/tests/test_combobox_store.py
@@ -27,6 +27,7 @@ def build_context():
 
 	real_render = ps.RenderSession(render.id, app.routes)
 	real_render.send = render.send  # pyright: ignore[reportAttributeAccessIssue]
+	real_render.connected = True
 
 	app.render_sessions[render.id] = real_render
 	app._render_to_user[render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
@@ -73,11 +74,11 @@ async def test_combobox_store_optional_payloads():
 	assert len(render.sent) == 2
 	open_msg = render.sent[0]
 	assert open_msg["event"] == "openDropdown"
-	assert open_msg["payload"] is None
+	assert open_msg.get("payload") is None
 
 	update_msg = render.sent[1]
 	assert update_msg["event"] == "updateSelectedOptionIndex"
-	assert update_msg["payload"] is None
+	assert update_msg.get("payload") is None
 
 
 @pytest.mark.asyncio
@@ -98,18 +99,16 @@ async def test_combobox_store_request_roundtrip():
 	request_id = request_message.get("requestId")
 	assert request_id
 
-	real_render.channels.handle_client_response(
-		message=cast(
+	real_render.channels.handle_response(
+		cast(
 			ClientChannelResponseMessage,
-			cast(
-				object,
-				{
-					"type": "channel_message",
-					"channel": request_message["channel"],
-					"responseTo": request_id,
-					"payload": True,
-				},
-			),
+			{
+				"type": "channel",
+				"action": "response",
+				"channel": request_message["channel"],
+				"responseTo": request_id,
+				"payload": True,
+			},
 		)
 	)
 
@@ -140,35 +139,32 @@ async def test_combobox_store_callbacks():
 		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
 		render=real_render,
 	):
-		real_render.channels.handle_client_event(
-			render=real_render,
-			session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
-			message={
-				"type": "channel_message",
+		real_render.channels.handle_event(
+			{
+				"type": "channel",
+				"action": "event",
 				"channel": store._channel.id,
 				"event": "openedChange",
 				"payload": {"opened": True},
-			},
+			}
 		)
-		real_render.channels.handle_client_event(
-			render=real_render,
-			session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
-			message={
-				"type": "channel_message",
+		real_render.channels.handle_event(
+			{
+				"type": "channel",
+				"action": "event",
 				"channel": store._channel.id,
 				"event": "dropdownOpen",
 				"payload": {"eventSource": "mouse"},
-			},
+			}
 		)
-		real_render.channels.handle_client_event(
-			render=real_render,
-			session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
-			message={
-				"type": "channel_message",
+		real_render.channels.handle_event(
+			{
+				"type": "channel",
+				"action": "event",
 				"channel": store._channel.id,
 				"event": "dropdownClose",
 				"payload": {"eventSource": "keyboard"},
-			},
+			}
 		)
 
 	await asyncio.sleep(0)

--- a/packages/pulse-mantine/python/tests/test_combobox_store.py
+++ b/packages/pulse-mantine/python/tests/test_combobox_store.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 import pulse as ps
 import pytest
 from pulse.messages import ClientChannelResponseMessage
+from pulse.routing import Route, RouteInfo, RouteTree
 from pulse.user_session import UserSession
 from pulse_mantine.core.combobox.combobox import Combobox, ComboboxStore
 
@@ -21,28 +22,53 @@ class DummyRender:
 
 
 def build_context():
-	app = ps.App()
+	def page():
+		return ps.div()
+
+	route = Route("/", ps.component(page))
+	routes = RouteTree([route])
+	app = ps.App(routes=[route])
 	render = DummyRender()
 	session = SimpleNamespace(sid="session-1")
 
-	real_render = ps.RenderSession(render.id, app.routes)
+	real_render = ps.RenderSession(render.id, routes, server_address="http://localhost")
 	real_render.send = render.send  # pyright: ignore[reportAttributeAccessIssue]
 	real_render.connected = True
+	with ps.PulseContext(app=app):
+		real_render.prerender(
+			["/"],
+			cast(
+				RouteInfo,
+				cast(
+					object,
+					{
+						"pathname": "/",
+						"hash": "",
+						"query": "",
+						"queryParams": {},
+						"pathParams": {},
+						"catchall": [],
+					},
+				),
+			),
+		)
+	route_ctx = real_render.route_mounts["/"].route
 
 	app.render_sessions[render.id] = real_render
 	app._render_to_user[render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
 	app.user_sessions[session.sid] = session  # pyright: ignore[reportArgumentType]
-	return app, render, session, real_render
+	return app, render, session, real_render, route_ctx
 
 
 @pytest.mark.asyncio
 async def test_combobox_store_emits_actions():
-	app, render, session, real_render = build_context()
+	app, render, session, real_render, route = build_context()
 
 	with ps.PulseContext(
 		app=app,
 		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
 		render=real_render,
+		route=route,
 	):
 		store = ComboboxStore()
 		store.open_dropdown("keyboard")
@@ -60,12 +86,13 @@ async def test_combobox_store_emits_actions():
 
 @pytest.mark.asyncio
 async def test_combobox_store_optional_payloads():
-	app, render, session, real_render = build_context()
+	app, render, session, real_render, route = build_context()
 
 	with ps.PulseContext(
 		app=app,
 		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
 		render=real_render,
+		route=route,
 	):
 		store = ComboboxStore()
 		store.open_dropdown()
@@ -83,12 +110,13 @@ async def test_combobox_store_optional_payloads():
 
 @pytest.mark.asyncio
 async def test_combobox_store_request_roundtrip():
-	app, render, session, real_render = build_context()
+	app, render, session, real_render, route = build_context()
 
 	with ps.PulseContext(
 		app=app,
 		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
 		render=real_render,
+		route=route,
 	):
 		store = ComboboxStore()
 		pending = asyncio.create_task(store.get_dropdown_opened())
@@ -118,7 +146,7 @@ async def test_combobox_store_request_roundtrip():
 
 @pytest.mark.asyncio
 async def test_combobox_store_callbacks():
-	app, render, session, real_render = build_context()
+	app, render, session, real_render, route = build_context()
 	opened: list[bool] = []
 	opened_sources: list[str] = []
 	closed_sources: list[str] = []
@@ -127,6 +155,7 @@ async def test_combobox_store_callbacks():
 		app=app,
 		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
 		render=real_render,
+		route=route,
 	):
 		store = ComboboxStore(
 			onOpenedChange=lambda value: opened.append(value),

--- a/packages/pulse-mantine/python/tests/test_form.py
+++ b/packages/pulse-mantine/python/tests/test_form.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 import pulse as ps
 import pytest
 from fastapi import HTTPException
-from pulse.messages import ClientChannelRequestMessage
+from pulse.messages import ClientChannelEventMessage
 from pulse.routing import Route, RouteInfo, RouteTree
 from pulse.serializer import serialize
 from pulse.user_session import UserSession
@@ -75,11 +75,11 @@ def build_context():
 	return app, dummy_render, session, real_render, route_ctx
 
 
-def client_channel_request(message: object) -> ClientChannelRequestMessage:
-	return cast(ClientChannelRequestMessage, message)
+def client_channel_event(message: object) -> ClientChannelEventMessage:
+	return cast(ClientChannelEventMessage, message)
 
 
-def test_form_recreates_channel_after_client_release():
+def test_form_reset_emits_on_mailbox():
 	app, render, session, real_render, route_ctx = build_context()
 
 	with ps.PulseContext(
@@ -93,26 +93,15 @@ def test_form_recreates_channel_after_client_release():
 			syncMode="change",
 			initialValues={"query": ""},
 		)
-		first_channel_id = form._channel.id  # pyright: ignore[reportPrivateUsage]
-
-	assert real_render.channels.release_channel(first_channel_id)
-	assert form._channel.closed  # pyright: ignore[reportPrivateUsage]
-
-	with ps.PulseContext(
-		app=app,
-		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
-		render=real_render,
-		route=route_ctx,
-	):
 		form.reset()
 
-	assert not form._channel.closed  # pyright: ignore[reportPrivateUsage]
-	assert form._channel.id != first_channel_id  # pyright: ignore[reportPrivateUsage]
+	assert render.sent[-1]["type"] == "channel"
+	assert render.sent[-1]["action"] == "event"
 	assert render.sent[-1]["event"] == "reset"
 
 
 @pytest.mark.asyncio
-async def test_form_sync_handler_survives_channel_recreation():
+async def test_form_sync_handler_receives_mailbox_event():
 	app, _render, session, real_render, route_ctx = build_context()
 
 	with ps.PulseContext(
@@ -122,23 +111,12 @@ async def test_form_sync_handler_survives_channel_recreation():
 		route=route_ctx,
 	):
 		form = MantineForm(syncMode="change", initialValues={"query": ""})
-		first_channel_id = form._channel.id  # pyright: ignore[reportPrivateUsage]
-
-	assert real_render.channels.release_channel(first_channel_id)
-
-	with ps.PulseContext(
-		app=app,
-		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
-		render=real_render,
-		route=route_ctx,
-	):
 		form.render()
-		real_render.channels.handle_client_event(
-			render=real_render,
-			session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
-			message=client_channel_request(
+		real_render.channels.handle_event(
+			client_channel_event(
 				{
-					"type": "channel_message",
+					"type": "channel",
+					"action": "event",
 					"channel": form._channel.id,  # pyright: ignore[reportPrivateUsage]
 					"event": "syncValues",
 					"payload": {"values": {"query": "xrd"}},

--- a/packages/pulse/js/README.md
+++ b/packages/pulse/js/README.md
@@ -41,7 +41,7 @@ src/
 ├── form.tsx            # PulseForm component
 ├── helpers.ts          # Route info extraction utilities
 ├── vdom.ts             # VDOM types (VDOMNode, VDOMElement)
-├── usePulseChannel.ts  # React hook for channels
+├── useChannel.ts  # React hook for channels
 │
 └── serialize/          # Data serialization
     ├── serializer.ts   # Main serialize/deserialize
@@ -102,10 +102,10 @@ Socket.IO transport with automatic reconnection, message queuing, connection sta
 Real-time messaging:
 
 ```tsx
-import { usePulseChannel } from "pulse-client";
+import { useChannel } from "pulse-client";
 
 function Chat() {
-  const channel = usePulseChannel("chat");
+  const channel = useChannel("chat");
   channel.on("new_message", (msg) => { /* handle */ });
   channel.emit("message", { text: "Hello" });
 }
@@ -115,7 +115,7 @@ function Chat() {
 
 **Components**: `PulseProvider`, `PulseView`, `PulseForm`, `RenderLazy`
 
-**Hooks**: `usePulseClient()`, `usePulseChannel(name)`
+**Hooks**: `usePulseClient()`, `useChannel(name)`
 
 **Functions**: `serialize`, `deserialize`, `extractServerRouteInfo`, `submitForm`
 

--- a/packages/pulse/js/src/channel.test.ts
+++ b/packages/pulse/js/src/channel.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "bun:test";
 import {
 	ChannelBridge,
-	PulseChannelDetachedError,
 	PulseChannelDisconnectedError,
+	PulseChannelTimeoutError,
 } from "./channel";
 import type { ClientChannelMessage } from "./messages";
 
@@ -16,9 +16,16 @@ function makeBridgeClient(connected = true) {
 		}),
 		attachHandle: vi.fn(),
 		detachHandle: vi.fn(),
-		requestChannel(requestId: string, message: ClientChannelMessage) {
+		requestChannel(requestId: string, message: ClientChannelMessage, timeout?: number) {
 			return new Promise((resolve, reject) => {
 				pending.set(requestId, { resolve, reject });
+				if (timeout !== undefined) {
+					setTimeout(() => {
+						if (!pending.has(requestId)) return;
+						pending.delete(requestId);
+						reject(new PulseChannelTimeoutError(timeout, (message as { event: string }).event));
+					}, timeout);
+				}
 				client.sendMessage(message);
 			});
 		},
@@ -32,7 +39,7 @@ function makeBridgeClient(connected = true) {
 }
 
 describe("ChannelBridge", () => {
-	it("emits mailbox events without lifecycle traffic", () => {
+	it("emits channel events without lifecycle traffic", () => {
 		const { bridge, sent } = makeBridgeClient();
 		bridge.emit("ping", { foo: 1 });
 		expect(sent).toEqual([
@@ -66,10 +73,18 @@ describe("ChannelBridge", () => {
 		expect(sent).toEqual([]);
 	});
 
-	it("raises on() after detach and still emits", () => {
+	it("times out an optional request timeout", async () => {
+		const { bridge } = makeBridgeClient();
+		await expect(bridge.request("echo", undefined, { timeout: 1 })).rejects.toBeInstanceOf(
+			PulseChannelTimeoutError,
+		);
+	});
+
+	it("keeps on() legal after detach and still emits", () => {
 		const { bridge, sent } = makeBridgeClient();
+		const handler = vi.fn();
 		bridge.detach();
-		expect(() => bridge.on("event", vi.fn())).toThrow(PulseChannelDetachedError);
+		expect(() => bridge.on("event", handler)).not.toThrow();
 		bridge.emit("still-routes", 1);
 		expect(sent[0]).toMatchObject({
 			type: "channel",
@@ -83,10 +98,18 @@ describe("ChannelBridge", () => {
 		const handler = vi.fn();
 		bridge.on("ping", handler);
 		bridge.detach();
-		expect(() => bridge.on("other", vi.fn())).toThrow(PulseChannelDetachedError);
-		bridge.attach();
 		expect(() => bridge.on("other", vi.fn())).not.toThrow();
+		bridge.attach();
 		bridge.dispatchEvent("ping", 1);
 		expect(handler).toHaveBeenCalledWith(1);
+	});
+
+	it("registers the same handler only once", () => {
+		const { bridge } = makeBridgeClient();
+		const handler = vi.fn();
+		bridge.on("ping", handler);
+		bridge.on("ping", handler);
+		bridge.dispatchEvent("ping", 1);
+		expect(handler).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/pulse/js/src/channel.test.ts
+++ b/packages/pulse/js/src/channel.test.ts
@@ -79,6 +79,22 @@ describe("ChannelBridge", () => {
 		expect(sent).toEqual([]);
 	});
 
+	it("fails request immediately when detached", async () => {
+		const { bridge, sent } = makeBridgeClient();
+		bridge.detach();
+		await expect(bridge.request("echo")).rejects.toBeInstanceOf(PulseChannelDetachedError);
+		expect(sent).toEqual([]);
+	});
+
+	it("allows requests from a never-attached bridge", async () => {
+		const { bridge, client, sent } = makeBridgeClient();
+		const neverAttached = new ChannelBridge(client as any, "never-attached");
+		const pending = neverAttached.request("echo");
+		const requestId = (sent.at(-1) as { requestId: string }).requestId;
+		client.resolve(requestId, "ok");
+		await expect(pending).resolves.toBe("ok");
+	});
+
 	it("times out an optional request timeout", async () => {
 		const { bridge } = makeBridgeClient();
 		await expect(bridge.request("echo", undefined, { timeout: 1 })).rejects.toBeInstanceOf(
@@ -145,12 +161,17 @@ describe("ChannelBridge", () => {
 	});
 
 	it("warns once when emitting from a detached bridge", () => {
-		const { bridge } = makeBridgeClient();
+		const { bridge, client } = makeBridgeClient();
+		const neverAttached = new ChannelBridge(client as any, "never-attached");
 		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
-		bridge.emit("beforeAttach");
+		neverAttached.emit("beforeAttach");
 		bridge.detach();
 		bridge.emit("afterDetach");
-		expect(warning).toHaveBeenCalledTimes(1);
+		bridge.emit("afterDetachAgain");
+		bridge.attach();
+		bridge.detach();
+		bridge.emit("afterSecondDetach");
+		expect(warning).toHaveBeenCalledTimes(2);
 		warning.mockRestore();
 	});
 });

--- a/packages/pulse/js/src/channel.test.ts
+++ b/packages/pulse/js/src/channel.test.ts
@@ -1,96 +1,92 @@
 import { describe, expect, it, vi } from "bun:test";
-import { ChannelBridge, PulseChannelResetError } from "./channel";
-import { PulseSocketIOClient } from "./client";
+import {
+	ChannelBridge,
+	PulseChannelDetachedError,
+	PulseChannelDisconnectedError,
+} from "./channel";
 import type { ClientChannelMessage } from "./messages";
 
-function makeClient() {
+function makeBridgeClient(connected = true) {
 	const sent: ClientChannelMessage[] = [];
-	const sendMessage = vi.fn(async (message: ClientChannelMessage) => {
-		sent.push(message);
-	});
-	const client = { sendMessage } as any;
-	const bridge = new ChannelBridge(client, "chan-1");
-	return { bridge, sent, sendMessage };
+	const pending = new Map<string, { resolve: (value: any) => void; reject: (error: any) => void }>();
+	const client = {
+		isConnected: () => connected,
+		sendMessage: vi.fn((message: ClientChannelMessage) => {
+			sent.push(message);
+		}),
+		attachHandle: vi.fn(),
+		detachHandle: vi.fn(),
+		requestChannel(requestId: string, message: ClientChannelMessage) {
+			return new Promise((resolve, reject) => {
+				pending.set(requestId, { resolve, reject });
+				client.sendMessage(message);
+			});
+		},
+		resolve(requestId: string, payload: any) {
+			pending.get(requestId)?.resolve(payload);
+		},
+	};
+	const bridge = new ChannelBridge(client as any, "chan-1");
+	bridge.attach();
+	return { bridge, sent, client };
 }
 
 describe("ChannelBridge", () => {
-	it("queues request and resolves on response", async () => {
-		const { bridge, sent } = makeClient();
+	it("emits mailbox events without lifecycle traffic", () => {
+		const { bridge, sent } = makeBridgeClient();
+		bridge.emit("ping", { foo: 1 });
+		expect(sent).toEqual([
+			{
+				type: "channel",
+				action: "event",
+				channel: "chan-1",
+				event: "ping",
+				payload: { foo: 1 },
+			},
+		]);
+	});
+
+	it("queues request and resolves on client pending", async () => {
+		const { bridge, sent, client } = makeBridgeClient();
 		const pending = bridge.request("echo", { foo: 1 });
-		expect(sent).toHaveLength(1);
-		const requestId = sent[0]!.requestId!;
-		bridge.handleServerMessage({
-			type: "channel_message",
+		expect(sent[0]).toMatchObject({
+			type: "channel",
+			action: "request",
 			channel: "chan-1",
-			responseTo: requestId,
-			payload: { foo: 2 },
+			event: "echo",
 		});
+		const requestId = (sent[0] as { requestId: string }).requestId;
+		client.resolve(requestId, { foo: 2 });
 		await expect(pending).resolves.toEqual({ foo: 2 });
 	});
 
-	it("dispatches events to registered handlers", () => {
-		const { bridge } = makeClient();
+	it("fails request immediately when disconnected", async () => {
+		const { bridge, sent } = makeBridgeClient(false);
+		await expect(bridge.request("echo")).rejects.toBeInstanceOf(PulseChannelDisconnectedError);
+		expect(sent).toEqual([]);
+	});
+
+	it("raises on() after detach and still emits", () => {
+		const { bridge, sent } = makeBridgeClient();
+		bridge.detach();
+		expect(() => bridge.on("event", vi.fn())).toThrow(PulseChannelDetachedError);
+		bridge.emit("still-routes", 1);
+		expect(sent[0]).toMatchObject({
+			type: "channel",
+			action: "event",
+			event: "still-routes",
+		});
+	});
+
+	it("reattaches the same handle after StrictMode detach", () => {
+		const { bridge } = makeBridgeClient();
 		const handler = vi.fn();
 		bridge.on("ping", handler);
-		bridge.handleServerMessage({
-			type: "channel_message",
-			channel: "chan-1",
-			event: "ping",
-			payload: { value: 42 },
-		});
-		expect(handler).toHaveBeenCalledWith({ value: 42 });
-	});
-
-	it("responds to server requests", async () => {
-		const { bridge, sendMessage } = makeClient();
-		bridge.on("compute", () => 99);
-		bridge.handleServerMessage({
-			type: "channel_message",
-			channel: "chan-1",
-			event: "compute",
-			requestId: "req-1",
-			payload: {},
-		});
-		await new Promise((resolve) => setTimeout(resolve, 0));
-		expect(sendMessage).toHaveBeenCalledWith(
-			expect.objectContaining({
-				responseTo: "req-1",
-				payload: 99,
-				event: undefined,
-			}),
-		);
-	});
-
-	it("rejects pending requests when closed", async () => {
-		const { bridge } = makeClient();
-		const pending = bridge.request("close-me");
-		bridge.handleServerMessage({
-			type: "channel_message",
-			channel: "chan-1",
-			event: "__close__",
-		});
-		await expect(pending).rejects.toBeInstanceOf(PulseChannelResetError);
-	});
-
-	it("reacquires a fresh bridge after release closes a channel", () => {
-		const client = new PulseSocketIOClient(
-			"http://pulse.test",
-			{},
-			vi.fn() as any,
-			{
-				initialConnectingDelay: 0,
-				initialErrorDelay: 0,
-				reconnectErrorDelay: 0,
-			},
-		);
-
-		const first = client.acquireChannel("chan-1");
-		client.releaseChannel("chan-1");
-
-		expect(() => first.on("event", vi.fn())).toThrow(PulseChannelResetError);
-
-		const second = client.acquireChannel("chan-1");
-		expect(second).not.toBe(first);
-		expect(() => second.on("event", vi.fn())).not.toThrow();
+		bridge.detach();
+		expect(() => bridge.on("other", vi.fn())).toThrow(PulseChannelDetachedError);
+		bridge.attach();
+		expect(() => bridge.on("other", vi.fn())).not.toThrow();
+		bridge.dispatchEvent("ping", 1);
+		expect(handler).toHaveBeenCalledWith(1);
 	});
 });

--- a/packages/pulse/js/src/channel.test.ts
+++ b/packages/pulse/js/src/channel.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "bun:test";
 import {
 	ChannelBridge,
 	PulseChannelDisconnectedError,
+	PulseChannelDetachedError,
 	PulseChannelTimeoutError,
 } from "./channel";
 import type { ClientChannelMessage } from "./messages";
@@ -16,7 +17,12 @@ function makeBridgeClient(connected = true) {
 		}),
 		attachHandle: vi.fn(),
 		detachHandle: vi.fn(),
-		requestChannel(requestId: string, message: ClientChannelMessage, timeout?: number) {
+		requestChannel(
+			requestId: string,
+			message: ClientChannelMessage,
+			_owner: ChannelBridge,
+			timeout?: number,
+		) {
 			return new Promise((resolve, reject) => {
 				pending.set(requestId, { resolve, reject });
 				if (timeout !== undefined) {
@@ -80,6 +86,18 @@ describe("ChannelBridge", () => {
 		);
 	});
 
+	it("times out unanswered requests after the default timeout", async () => {
+		vi.useFakeTimers();
+		try {
+			const { bridge } = makeBridgeClient();
+			const pending = bridge.request("echo");
+			vi.advanceTimersByTime(30_000);
+			await expect(pending).rejects.toBeInstanceOf(PulseChannelTimeoutError);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("keeps on() legal after detach and still emits", () => {
 		const { bridge, sent } = makeBridgeClient();
 		const handler = vi.fn();
@@ -111,5 +129,28 @@ describe("ChannelBridge", () => {
 		bridge.on("ping", handler);
 		bridge.dispatchEvent("ping", 1);
 		expect(handler).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps a duplicate registration after removing one disposer", () => {
+		const { bridge } = makeBridgeClient();
+		const handler = vi.fn();
+		const removeFirst = bridge.on("ping", handler);
+		bridge.on("ping", handler);
+		removeFirst();
+		bridge.dispatchEvent("ping", 1);
+		expect(handler).toHaveBeenCalledTimes(1);
+		removeFirst();
+		bridge.dispatchEvent("ping", 2);
+		expect(handler).toHaveBeenCalledTimes(2);
+	});
+
+	it("warns once when emitting from a detached bridge", () => {
+		const { bridge } = makeBridgeClient();
+		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+		bridge.emit("beforeAttach");
+		bridge.detach();
+		bridge.emit("afterDetach");
+		expect(warning).toHaveBeenCalledTimes(1);
+		warning.mockRestore();
 	});
 });

--- a/packages/pulse/js/src/channel.ts
+++ b/packages/pulse/js/src/channel.ts
@@ -68,6 +68,7 @@ export class ChannelBridge {
 	attach(): void {
 		if (this.#attached) return;
 		this.#detached = false;
+		this.#warnedAboutDetachedEmit = false;
 		this.#attached = true;
 		this.client.attachHandle(this);
 	}
@@ -95,7 +96,7 @@ export class ChannelBridge {
 		if (payload !== undefined) {
 			message.payload = payload;
 		}
-		if ((!this.#attached || this.#detached) && !this.#warnedAboutDetachedEmit) {
+		if (this.#detached && !this.#warnedAboutDetachedEmit) {
 			this.#warnedAboutDetachedEmit = true;
 			console.warn(`Pulse channel ${this.id} emitted while detached`);
 		}
@@ -103,6 +104,9 @@ export class ChannelBridge {
 	}
 
 	request(event: string, payload?: any, options?: ChannelRequestOptions): Promise<any> {
+		if (this.#detached) {
+			return Promise.reject(new PulseChannelDetachedError("Channel handle detached"));
+		}
 		if (!this.client.isConnected()) {
 			return Promise.reject(new PulseChannelDisconnectedError("No render session is connected"));
 		}

--- a/packages/pulse/js/src/channel.ts
+++ b/packages/pulse/js/src/channel.ts
@@ -45,6 +45,8 @@ export type ChannelRequestOptions = {
 	timeout?: number;
 };
 
+const DEFAULT_CHANNEL_REQUEST_TIMEOUT = 30_000;
+
 export function createRandomId(): string {
 	if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
 		return crypto.randomUUID().replace(/-/g, "");
@@ -53,9 +55,10 @@ export function createRandomId(): string {
 }
 
 export class ChannelBridge {
-	#handlers = new Map<string, Set<ChannelEventHandler>>();
+	#handlers = new Map<string, Map<ChannelEventHandler, number>>();
 	#detached = false;
 	#attached = false;
+	#warnedAboutDetachedEmit = false;
 
 	constructor(
 		private client: PulseSocketIOClient,
@@ -92,6 +95,10 @@ export class ChannelBridge {
 		if (payload !== undefined) {
 			message.payload = payload;
 		}
+		if ((!this.#attached || this.#detached) && !this.#warnedAboutDetachedEmit) {
+			this.#warnedAboutDetachedEmit = true;
+			console.warn(`Pulse channel ${this.id} emitted while detached`);
+		}
 		this.client.sendMessage(message);
 	}
 
@@ -117,20 +124,34 @@ export class ChannelBridge {
 		if (payload !== undefined) {
 			message.payload = payload;
 		}
-		return this.client.requestChannel(requestId, message, options?.timeout);
+		return this.client.requestChannel(
+			requestId,
+			message,
+			this,
+			options?.timeout ?? DEFAULT_CHANNEL_REQUEST_TIMEOUT,
+		);
 	}
 
 	on(event: string, handler: ChannelEventHandler): () => void {
 		let bucket = this.#handlers.get(event);
 		if (!bucket) {
-			bucket = new Set();
+			bucket = new Map();
 			this.#handlers.set(event, bucket);
 		}
-		bucket.add(handler);
+		bucket.set(handler, (bucket.get(handler) ?? 0) + 1);
+		let removed = false;
 		return () => {
+			if (removed) return;
+			removed = true;
 			const set = this.#handlers.get(event);
 			if (!set) return;
-			set.delete(handler);
+			const count = set.get(handler);
+			if (count === undefined) return;
+			if (count === 1) {
+				set.delete(handler);
+			} else {
+				set.set(handler, count - 1);
+			}
 			if (set.size === 0) {
 				this.#handlers.delete(event);
 			}
@@ -146,7 +167,7 @@ export class ChannelBridge {
 		if (this.#detached || !this.#attached) return;
 		const handlers = this.#handlers.get(event);
 		if (!handlers) return;
-		for (const handler of handlers) {
+		for (const handler of handlers.keys()) {
 			try {
 				const result = handler(payload);
 				if (result && typeof (result as Promise<any>).then === "function") {
@@ -165,7 +186,7 @@ export class ChannelBridge {
 		if (!handlers || handlers.size === 0) {
 			return undefined;
 		}
-		const handler = handlers.values().next().value;
+		const handler = handlers.keys().next().value;
 		if (!handler) {
 			return undefined;
 		}
@@ -179,10 +200,6 @@ export function useChannel(channelId: string): ChannelBridge {
 	}
 	const client = usePulseClient();
 	const bridge = useMemo(() => client.channel(channelId), [client, channelId]);
-	// Register during render so a live-socket emit in the same turn is not dropped
-	// waiting for useEffect. Effect cleanup still detaches; the next render/effect
-	// re-attaches the same handle.
-	bridge.attach();
 	useEffect(() => {
 		bridge.attach();
 		return () => {

--- a/packages/pulse/js/src/channel.ts
+++ b/packages/pulse/js/src/channel.ts
@@ -160,10 +160,10 @@ export class ChannelBridge {
 	}
 }
 
-export function usePulseChannel(channelId: string): ChannelBridge {
+export function useChannel(channelId: string): ChannelBridge {
 	const client = usePulseClient();
 	if (!channelId) {
-		throw new Error("usePulseChannel requires a non-empty channelId");
+		throw new Error("useChannel requires a non-empty channelId");
 	}
 	const bridge = useMemo(() => client.channel(channelId), [client, channelId]);
 	useEffect(() => {

--- a/packages/pulse/js/src/channel.ts
+++ b/packages/pulse/js/src/channel.ts
@@ -27,7 +27,23 @@ export class PulseChannelRemoteError extends Error {
 	}
 }
 
+export class PulseChannelTimeoutError extends Error {
+	timeout: number;
+	event: string;
+
+	constructor(timeout: number, event: string) {
+		super(`Channel request timed out after ${timeout}ms: ${event}`);
+		this.name = "PulseChannelTimeoutError";
+		this.timeout = timeout;
+		this.event = event;
+	}
+}
+
 export type ChannelEventHandler = (payload: any) => any | Promise<any>;
+
+export type ChannelRequestOptions = {
+	timeout?: number;
+};
 
 export function createRandomId(): string {
 	if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
@@ -79,7 +95,7 @@ export class ChannelBridge {
 		this.client.sendMessage(message);
 	}
 
-	request(event: string, payload?: any): Promise<any> {
+	request(event: string, payload?: any, options?: ChannelRequestOptions): Promise<any> {
 		if (!this.client.isConnected()) {
 			return Promise.reject(new PulseChannelDisconnectedError("No render session is connected"));
 		}
@@ -101,13 +117,10 @@ export class ChannelBridge {
 		if (payload !== undefined) {
 			message.payload = payload;
 		}
-		return this.client.requestChannel(requestId, message);
+		return this.client.requestChannel(requestId, message, options?.timeout);
 	}
 
 	on(event: string, handler: ChannelEventHandler): () => void {
-		if (this.#detached) {
-			throw new PulseChannelDetachedError(`Channel ${this.id} is detached`);
-		}
 		let bucket = this.#handlers.get(event);
 		if (!bucket) {
 			bucket = new Set();
@@ -161,11 +174,15 @@ export class ChannelBridge {
 }
 
 export function useChannel(channelId: string): ChannelBridge {
-	const client = usePulseClient();
 	if (!channelId) {
 		throw new Error("useChannel requires a non-empty channelId");
 	}
+	const client = usePulseClient();
 	const bridge = useMemo(() => client.channel(channelId), [client, channelId]);
+	// Register during render so a live-socket emit in the same turn is not dropped
+	// waiting for useEffect. Effect cleanup still detaches; the next render/effect
+	// re-attaches the same handle.
+	bridge.attach();
 	useEffect(() => {
 		bridge.attach();
 		return () => {

--- a/packages/pulse/js/src/channel.ts
+++ b/packages/pulse/js/src/channel.ts
@@ -1,25 +1,33 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo } from "react";
 import type { PulseSocketIOClient } from "./client";
-import type {
-	ServerChannelMessage,
-	ServerChannelRequestMessage,
-	ServerChannelResponseMessage,
-} from "./messages";
+import type { ChannelErrorCode } from "./messages";
 import { usePulseClient } from "./pulse";
 
-export class PulseChannelResetError extends Error {
+export class PulseChannelDetachedError extends Error {
 	constructor(message: string) {
 		super(message);
-		this.name = "PulseChannelResetError";
+		this.name = "PulseChannelDetachedError";
+	}
+}
+
+export class PulseChannelDisconnectedError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "PulseChannelDisconnectedError";
+	}
+}
+
+export class PulseChannelRemoteError extends Error {
+	code: ChannelErrorCode;
+
+	constructor(code: ChannelErrorCode, message: string) {
+		super(`${code}: ${message}`);
+		this.name = "PulseChannelRemoteError";
+		this.code = code;
 	}
 }
 
 export type ChannelEventHandler = (payload: any) => any | Promise<any>;
-
-interface PendingRequest {
-	resolve: (value: any) => void;
-	reject: (error: any) => void;
-}
 
 export function createRandomId(): string {
 	if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
@@ -28,147 +36,106 @@ export function createRandomId(): string {
 	return Math.random().toString(16).slice(2) + Math.random().toString(16).slice(2);
 }
 
-function formatError(error: unknown): string {
-	if (error instanceof Error) return error.message;
-	if (typeof error === "string") return error;
-	try {
-		return JSON.stringify(error);
-	} catch {
-		return String(error);
-	}
-}
-
-function isServerResponseMessage(
-	message: ServerChannelMessage,
-): message is ServerChannelResponseMessage {
-	return typeof (message as ServerChannelResponseMessage).responseTo === "string";
-}
-
-function isServerRequestMessage(
-	message: ServerChannelMessage,
-): message is ServerChannelRequestMessage {
-	return typeof (message as ServerChannelRequestMessage).event === "string";
-}
-
 export class ChannelBridge {
-	private handlers = new Map<string, Set<ChannelEventHandler>>();
-	private pending = new Map<string, PendingRequest>();
-	private backlog: ServerChannelRequestMessage[] = [];
-	private closed = false;
+	#handlers = new Map<string, Set<ChannelEventHandler>>();
+	#detached = false;
+	#attached = false;
 
 	constructor(
 		private client: PulseSocketIOClient,
 		public readonly id: string,
 	) {}
 
+	attach(): void {
+		if (this.#attached) return;
+		this.#detached = false;
+		this.#attached = true;
+		this.client.attachHandle(this);
+	}
+
+	detach(): void {
+		if (!this.#attached && this.#detached) return;
+		this.#attached = false;
+		this.#detached = true;
+		this.client.detachHandle(this);
+	}
+
 	emit(event: string, payload?: any): void {
-		this.ensureOpen();
-		this.client.sendMessage({
-			type: "channel_message",
+		const message: {
+			type: "channel";
+			action: "event";
+			channel: string;
+			event: string;
+			payload?: any;
+		} = {
+			type: "channel",
+			action: "event",
 			channel: this.id,
 			event,
-			payload,
-		});
+		};
+		if (payload !== undefined) {
+			message.payload = payload;
+		}
+		this.client.sendMessage(message);
 	}
 
 	request(event: string, payload?: any): Promise<any> {
-		this.ensureOpen();
+		if (!this.client.isConnected()) {
+			return Promise.reject(new PulseChannelDisconnectedError("No render session is connected"));
+		}
 		const requestId = createRandomId();
-		return new Promise((resolve, reject) => {
-			this.pending.set(requestId, { resolve, reject });
-			this.client.sendMessage({
-				type: "channel_message",
-				channel: this.id,
-				event,
-				payload,
-				requestId,
-			});
-		});
+		const message: {
+			type: "channel";
+			action: "request";
+			channel: string;
+			event: string;
+			requestId: string;
+			payload?: any;
+		} = {
+			type: "channel",
+			action: "request",
+			channel: this.id,
+			event,
+			requestId,
+		};
+		if (payload !== undefined) {
+			message.payload = payload;
+		}
+		return this.client.requestChannel(requestId, message);
 	}
 
 	on(event: string, handler: ChannelEventHandler): () => void {
-		this.ensureOpen();
-		let bucket = this.handlers.get(event);
+		if (this.#detached) {
+			throw new PulseChannelDetachedError(`Channel ${this.id} is detached`);
+		}
+		let bucket = this.#handlers.get(event);
 		if (!bucket) {
 			bucket = new Set();
-			this.handlers.set(event, bucket);
+			this.#handlers.set(event, bucket);
 		}
 		bucket.add(handler);
-		this.flushBacklog(event);
 		return () => {
-			const set = this.handlers.get(event);
+			const set = this.#handlers.get(event);
 			if (!set) return;
 			set.delete(handler);
 			if (set.size === 0) {
-				this.handlers.delete(event);
+				this.#handlers.delete(event);
 			}
 		};
 	}
 
-	handleServerMessage(message: ServerChannelMessage): boolean {
-		if (isServerResponseMessage(message)) {
-			this.resolvePending(message);
-			return this.closed;
-		}
-		if (this.closed) {
-			return true;
-		}
-		if (!isServerRequestMessage(message)) {
-			return this.closed;
-		}
-
-		if (message.event === "__close__") {
-			this.close(new PulseChannelResetError("Channel closed by server"));
-			return true;
-		}
-		if (message.requestId) {
-			void this.dispatchRequest(
-				message as ServerChannelRequestMessage & {
-					requestId: string;
-				},
-			);
-		} else {
-			this.dispatchEvent(message);
-		}
-		return this.closed;
+	hasHandler(event: string): boolean {
+		const handlers = this.#handlers.get(event);
+		return !!handlers && handlers.size > 0;
 	}
 
-	handleDisconnect(reason: PulseChannelResetError): void {
-		this.close(reason);
-	}
-
-	dispose(reason: PulseChannelResetError): void {
-		this.close(reason);
-	}
-
-	private ensureOpen(): void {
-		if (this.closed) {
-			throw new PulseChannelResetError("Channel is closed");
-		}
-	}
-
-	private flushBacklog(event: string): void {
-		if (this.backlog.length === 0) return;
-		const remaining: ServerChannelRequestMessage[] = [];
-		for (const item of this.backlog) {
-			if (item.event === event) {
-				this.dispatchEvent(item);
-			} else {
-				remaining.push(item);
-			}
-		}
-		this.backlog = remaining;
-	}
-
-	private dispatchEvent(message: ServerChannelRequestMessage): void {
-		const handlers = this.handlers.get(message.event);
-		if (!handlers || handlers.size === 0) {
-			this.backlog.push(message);
-			return;
-		}
+	dispatchEvent(event: string, payload: any): void {
+		if (this.#detached || !this.#attached) return;
+		const handlers = this.#handlers.get(event);
+		if (!handlers) return;
 		for (const handler of handlers) {
 			try {
-				const result = handler(message.payload);
+				const result = handler(payload);
 				if (result && typeof (result as Promise<any>).then === "function") {
 					void (result as Promise<any>).catch((err) => {
 						console.error("Pulse channel handler error", err);
@@ -180,89 +147,30 @@ export class ChannelBridge {
 		}
 	}
 
-	private async dispatchRequest(
-		message: ServerChannelRequestMessage & { requestId: string },
-	): Promise<void> {
-		const handlers = this.handlers.get(message.event);
-		let response: any;
-		let error: any;
-		if (handlers && handlers.size > 0) {
-			for (const handler of handlers) {
-				try {
-					const result = handler(message.payload);
-					response = await Promise.resolve(result);
-					if (response !== undefined) {
-						break;
-					}
-				} catch (err) {
-					error = err;
-					break;
-				}
-			}
+	async dispatchRequest(event: string, payload: any): Promise<any> {
+		const handlers = this.#handlers.get(event);
+		if (!handlers || handlers.size === 0) {
+			return undefined;
 		}
-		if (error) {
-			this.client.sendMessage({
-				type: "channel_message",
-				channel: this.id,
-				event: undefined,
-				responseTo: message.requestId,
-				error: formatError(error),
-			});
-			return;
+		const handler = handlers.values().next().value;
+		if (!handler) {
+			return undefined;
 		}
-		this.client.sendMessage({
-			type: "channel_message",
-			channel: this.id,
-			event: undefined,
-			responseTo: message.requestId,
-			payload: response,
-		});
-	}
-
-	private resolvePending(message: ServerChannelResponseMessage): void {
-		const entry = message.responseTo ? this.pending.get(message.responseTo) : undefined;
-		if (!entry) {
-			return;
-		}
-		this.pending.delete(message.responseTo!);
-		if (message.error !== undefined && message.error !== null) {
-			entry.reject(new PulseChannelResetError(String(message.error)));
-		} else {
-			entry.resolve(message.payload);
-		}
-	}
-
-	private close(reason: PulseChannelResetError): void {
-		if (this.closed) {
-			return;
-		}
-		this.closed = true;
-		for (const request of this.pending.values()) {
-			request.reject(reason);
-		}
-		this.pending.clear();
-		this.handlers.clear();
-		this.backlog = [];
-		// No-op: owning client manages registry lifecycle.
+		return await Promise.resolve(handler(payload));
 	}
 }
 
-export function usePulseChannel(channelId: string): ChannelBridge | null {
+export function usePulseChannel(channelId: string): ChannelBridge {
 	const client = usePulseClient();
-
-	const [bridge, setBridge] = useState<ChannelBridge | null>(null);
-
+	if (!channelId) {
+		throw new Error("usePulseChannel requires a non-empty channelId");
+	}
+	const bridge = useMemo(() => client.channel(channelId), [client, channelId]);
 	useEffect(() => {
-		if (!channelId) {
-			throw new Error("usePulseChannel requires a non-empty channelId");
-		}
-		const acquired = client.acquireChannel(channelId);
-		setBridge(acquired);
+		bridge.attach();
 		return () => {
-			setBridge((current) => (current === acquired ? null : current));
-			client.releaseChannel(channelId);
+			bridge.detach();
 		};
-	}, [client, channelId]);
-
+	}, [bridge]);
 	return bridge;
 }

--- a/packages/pulse/js/src/client.test.ts
+++ b/packages/pulse/js/src/client.test.ts
@@ -551,6 +551,26 @@ describe("PulseSocketIOClient channels", () => {
 		});
 	});
 
+	it("does not flush RPC after a disconnected request", async () => {
+		const { PulseChannelDisconnectedError } = await import("./channel");
+		const client = await makeClient();
+		const bridge = client.acquireChannel("rpc");
+		bridge.emit("ping", { n: 1 });
+		await expect(bridge.request("echo")).rejects.toBeInstanceOf(PulseChannelDisconnectedError);
+		const connected = client.connect();
+		socket.trigger("connect");
+		await connected;
+		expect(sentMessages().filter((message) => message.type === "channel")).toEqual([
+			{
+				type: "channel",
+				action: "event",
+				channel: "rpc",
+				event: "ping",
+				payload: { n: 1 },
+			},
+		]);
+	});
+
 	it("attach and detach send no wire messages", async () => {
 		const client = await makeClient();
 		const connected = client.connect();

--- a/packages/pulse/js/src/client.test.ts
+++ b/packages/pulse/js/src/client.test.ts
@@ -406,6 +406,74 @@ describe("PulseSocketIOClient attach ack", () => {
 			body: { ok: true },
 		});
 	});
+
+	it("delivers unmatched server_error to all active views", async () => {
+		const client = await makeClient();
+		const dashView = {
+			routeInfo: { ...routeInfo, pathname: "/dash" },
+			onInit: vi.fn(),
+			onUpdate: vi.fn(),
+			onJsExec: vi.fn(),
+			onServerError: vi.fn(),
+		};
+		const connected = client.connect();
+		client.attach("/dash", dashView);
+		socket.trigger("connect");
+		await connected;
+
+		socket.trigger(
+			"message",
+			serialize({
+				type: "server_error",
+				path: "/",
+				error: {
+					message: "tab boom",
+					phase: "channel",
+					details: {},
+				},
+			}),
+		);
+
+		expect(dashView.onServerError).toHaveBeenCalledWith(
+			expect.objectContaining({ message: "tab boom", phase: "channel" }),
+		);
+	});
+
+	it("delivers matching server_error only to that view", async () => {
+		const client = await makeClient();
+		const rootView = {
+			...view,
+			onServerError: vi.fn(),
+		};
+		const dashView = {
+			routeInfo: { ...routeInfo, pathname: "/dash" },
+			onInit: vi.fn(),
+			onUpdate: vi.fn(),
+			onJsExec: vi.fn(),
+			onServerError: vi.fn(),
+		};
+		const connected = client.connect();
+		client.attach("/", rootView);
+		client.attach("/dash", dashView);
+		socket.trigger("connect");
+		await connected;
+
+		socket.trigger(
+			"message",
+			serialize({
+				type: "server_error",
+				path: "/dash",
+				error: {
+					message: "route boom",
+					phase: "callback",
+					details: {},
+				},
+			}),
+		);
+
+		expect(dashView.onServerError).toHaveBeenCalledTimes(1);
+		expect(rootView.onServerError).not.toHaveBeenCalled();
+	});
 });
 
 describe("PulseProvider connection handling", () => {

--- a/packages/pulse/js/src/client.test.ts
+++ b/packages/pulse/js/src/client.test.ts
@@ -614,6 +614,7 @@ describe("PulseSocketIOClient channels", () => {
 		const firstPending = first.request("echo");
 		const firstRequest = sentMessages().at(-1) as { requestId: string };
 		first.detach();
+		await Promise.resolve();
 		await expect(firstPending).rejects.toBeInstanceOf(PulseChannelDetachedError);
 
 		const secondPending = second.request("echo");
@@ -641,6 +642,30 @@ describe("PulseSocketIOClient channels", () => {
 			}),
 		);
 		await expect(secondPending).resolves.toBe("live");
+	});
+
+	it("keeps a pending RPC across an immediate detach and reattach", async () => {
+		const client = await makeClient();
+		const connected = client.connect();
+		socket.trigger("connect");
+		await connected;
+		const bridge = client.acquireChannel("rpc");
+		const pending = bridge.request("echo");
+		const request = sentMessages().at(-1) as { requestId: string };
+		bridge.detach();
+		bridge.attach();
+		await Promise.resolve();
+		socket.trigger(
+			"message",
+			serialize({
+				type: "channel",
+				action: "response",
+				channel: "rpc",
+				responseTo: request.requestId,
+				payload: "live",
+			}),
+		);
+		await expect(pending).resolves.toBe("live");
 	});
 
 	it("queues emit while disconnected on the global client queue", async () => {
@@ -674,6 +699,31 @@ describe("PulseSocketIOClient channels", () => {
 		expect(events).toHaveLength(100);
 		expect(events[0]).toMatchObject({ payload: { n: 1 } });
 		expect(events.at(-1)).toMatchObject({ payload: { n: 100 } });
+	});
+
+	it("caps queued events independently per channel", async () => {
+		const client = await makeClient();
+		const chatty = client.acquireChannel("chatty");
+		const quiet = client.acquireChannel("quiet");
+		for (let n = 0; n < 101; n++) {
+			chatty.emit("ping", { n });
+		}
+		quiet.emit("ping", { n: 1 });
+		const connected = client.connect();
+		socket.trigger("connect");
+		await connected;
+		const events = sentMessages().filter(
+			(message) => message.type === "channel" && message.action === "event",
+		);
+		const chattyEvents = events.filter((message) => message.channel === "chatty");
+		expect(chattyEvents).toHaveLength(100);
+		expect(chattyEvents[0]).toMatchObject({ payload: { n: 1 } });
+		expect(events).toContainEqual(
+			expect.objectContaining({
+				channel: "quiet",
+				payload: { n: 1 },
+			}),
+		);
 	});
 
 	it("does not flush RPC after a disconnected request", async () => {

--- a/packages/pulse/js/src/client.test.ts
+++ b/packages/pulse/js/src/client.test.ts
@@ -454,3 +454,113 @@ describe("PulseProvider connection handling", () => {
 		consoleError.mockRestore();
 	});
 });
+
+describe("PulseSocketIOClient channels", () => {
+	beforeEach(() => {
+		io.mockClear();
+	});
+
+	it("fans events out to two attached handles", async () => {
+		const client = await makeClient();
+		const connected = client.connect();
+		socket.trigger("connect");
+		await connected;
+		const a = client.acquireChannel("shared");
+		const b = client.acquireChannel("shared");
+		const seen: string[] = [];
+		a.on("ping", () => seen.push("a"));
+		b.on("ping", () => seen.push("b"));
+		socket.trigger(
+			"message",
+			serialize({
+				type: "channel",
+				action: "event",
+				channel: "shared",
+				event: "ping",
+			}),
+		);
+		expect(seen).toEqual(["a", "b"]);
+	});
+
+	it("NACKs requests with no handler", async () => {
+		const client = await makeClient();
+		const connected = client.connect();
+		socket.trigger("connect");
+		await connected;
+		client.acquireChannel("empty");
+		const before = sentMessages().length;
+		socket.trigger(
+			"message",
+			serialize({
+				type: "channel",
+				action: "request",
+				channel: "empty",
+				event: "missing",
+				requestId: "req-1",
+			}),
+		);
+		expect(sentMessages().slice(before)).toEqual([
+			{
+				type: "channel",
+				action: "response",
+				channel: "empty",
+				responseTo: "req-1",
+				error: {
+					code: "no_handler",
+					message: "No handler for 'missing' on channel 'empty'",
+				},
+			},
+		]);
+	});
+
+	it("rejects pending RPC on transport drop and stays silent on reconnect", async () => {
+		const { PulseChannelDisconnectedError } = await import("./channel");
+		const client = await makeClient();
+		const connected = client.connect();
+		socket.trigger("connect");
+		await connected;
+		const firstSocket = socket;
+		const bridge = client.acquireChannel("rpc");
+		const pending = bridge.request("echo");
+		const channelTraffic = sentMessages().filter((message) => message.type === "channel");
+		expect(channelTraffic).toEqual([
+			expect.objectContaining({ action: "request", event: "echo" }),
+		]);
+		firstSocket.trigger("disconnect");
+		await expect(pending).rejects.toBeInstanceOf(PulseChannelDisconnectedError);
+
+		firstSocket.trigger("connect");
+		expect(sentMessages().filter((message) => message.type === "channel")).toEqual(
+			channelTraffic,
+		);
+	});
+
+	it("queues emit while disconnected on the global client queue", async () => {
+		const client = await makeClient();
+		const bridge = client.acquireChannel("queued");
+		bridge.emit("ping", { n: 1 });
+		const connected = client.connect();
+		socket.trigger("connect");
+		await connected;
+		expect(sentMessages()).toContainEqual({
+			type: "channel",
+			action: "event",
+			channel: "queued",
+			event: "ping",
+			payload: { n: 1 },
+		});
+	});
+
+	it("attach and detach send no wire messages", async () => {
+		const client = await makeClient();
+		const connected = client.connect();
+		socket.trigger("connect");
+		await connected;
+		const before = sentMessages().length;
+		const bridge = client.channel("silent");
+		bridge.attach();
+		bridge.detach();
+		bridge.attach();
+		expect(sentMessages().slice(before)).toEqual([]);
+	});
+});

--- a/packages/pulse/js/src/client.test.ts
+++ b/packages/pulse/js/src/client.test.ts
@@ -603,6 +603,46 @@ describe("PulseSocketIOClient channels", () => {
 		);
 	});
 
+	it("rejects only a detached handle's RPC and ignores its late response", async () => {
+		const { PulseChannelDetachedError } = await import("./channel");
+		const client = await makeClient();
+		const connected = client.connect();
+		socket.trigger("connect");
+		await connected;
+		const first = client.acquireChannel("rpc");
+		const second = client.acquireChannel("rpc");
+		const firstPending = first.request("echo");
+		const firstRequest = sentMessages().at(-1) as { requestId: string };
+		first.detach();
+		await expect(firstPending).rejects.toBeInstanceOf(PulseChannelDetachedError);
+
+		const secondPending = second.request("echo");
+		const secondRequest = sentMessages().at(-1) as { requestId: string };
+		expect(() =>
+			socket.trigger(
+				"message",
+				serialize({
+					type: "channel",
+					action: "response",
+					channel: "rpc",
+					responseTo: firstRequest.requestId,
+					payload: "late",
+				}),
+			),
+		).not.toThrow();
+		socket.trigger(
+			"message",
+			serialize({
+				type: "channel",
+				action: "response",
+				channel: "rpc",
+				responseTo: secondRequest.requestId,
+				payload: "live",
+			}),
+		);
+		await expect(secondPending).resolves.toBe("live");
+	});
+
 	it("queues emit while disconnected on the global client queue", async () => {
 		const client = await makeClient();
 		const bridge = client.acquireChannel("queued");
@@ -617,6 +657,23 @@ describe("PulseSocketIOClient channels", () => {
 			event: "ping",
 			payload: { n: 1 },
 		});
+	});
+
+	it("caps queued channel events by dropping the oldest event", async () => {
+		const client = await makeClient();
+		const bridge = client.acquireChannel("queued");
+		for (let n = 0; n < 101; n++) {
+			bridge.emit("ping", { n });
+		}
+		const connected = client.connect();
+		socket.trigger("connect");
+		await connected;
+		const events = sentMessages().filter(
+			(message) => message.type === "channel" && message.action === "event",
+		);
+		expect(events).toHaveLength(100);
+		expect(events[0]).toMatchObject({ payload: { n: 1 } });
+		expect(events.at(-1)).toMatchObject({ payload: { n: 100 } });
 	});
 
 	it("does not flush RPC after a disconnected request", async () => {

--- a/packages/pulse/js/src/client.tsx
+++ b/packages/pulse/js/src/client.tsx
@@ -3,6 +3,7 @@ import { io, type Socket } from "socket.io-client";
 import {
 	ChannelBridge,
 	createRandomId,
+	PulseChannelDetachedError,
 	PulseChannelDisconnectedError,
 	PulseChannelRemoteError,
 	PulseChannelTimeoutError,
@@ -36,6 +37,7 @@ function browserIsOnline(): boolean {
 
 const PAGE_INSTANCE_AUTH_KEY = "__pulse_page_instance_id";
 const RENDER_ID_COLLISION_CODE = "render_id_collision";
+const OFFLINE_CHANNEL_EVENT_QUEUE_LIMIT = 100;
 const pageWindow =
 	typeof window === "undefined"
 		? undefined
@@ -89,7 +91,14 @@ export class PulseSocketIOClient {
 	#messageQueue: ClientMessage[];
 	#connectionListeners: Set<ConnectionStatusListener> = new Set();
 	#handles: Map<string, Set<ChannelBridge>> = new Map();
-	#pending = new Map<string, { resolve: (value: any) => void; reject: (error: any) => void }>();
+	#pending = new Map<
+		string,
+		{
+			owner: ChannelBridge;
+			resolve: (value: any) => void;
+			reject: (error: any) => void;
+		}
+	>();
 	#url: string;
 	#frameworkNavigate: NavigateFunction;
 	#directives: Directives;
@@ -293,6 +302,20 @@ export class PulseSocketIOClient {
 		}
 		if (payload.type === "channel" && (payload.action === "request" || payload.action === "response")) {
 			return;
+		}
+		// The protocol has no session identity, so cap rather than drop all offline events.
+		if (payload.type === "channel" && payload.action === "event") {
+			const queuedEvents = this.#messageQueue.filter(
+				(message) => message.type === "channel" && message.action === "event",
+			);
+			if (queuedEvents.length >= OFFLINE_CHANNEL_EVENT_QUEUE_LIMIT) {
+				const oldestEvent = this.#messageQueue.findIndex(
+					(message) => message.type === "channel" && message.action === "event",
+				);
+				if (oldestEvent !== -1) {
+					this.#messageQueue.splice(oldestEvent, 1);
+				}
+			}
 		}
 		this.#messageQueue.push(payload);
 	}
@@ -578,16 +601,23 @@ export class PulseSocketIOClient {
 
 	detachHandle(bridge: ChannelBridge): void {
 		const handles = this.#handles.get(bridge.id);
-		if (!handles) return;
-		handles.delete(bridge);
-		if (handles.size === 0) {
-			this.#handles.delete(bridge.id);
+		if (handles) {
+			handles.delete(bridge);
+			if (handles.size === 0) {
+				this.#handles.delete(bridge.id);
+			}
+		}
+		for (const [requestId, pending] of this.#pending) {
+			if (pending.owner !== bridge) continue;
+			this.#pending.delete(requestId);
+			pending.reject(new PulseChannelDetachedError("Channel handle detached"));
 		}
 	}
 
 	requestChannel(
 		requestId: string,
 		message: ClientChannelRequestMessage,
+		owner: ChannelBridge,
 		timeout?: number,
 	): Promise<any> {
 		if (!this.isConnected()) {
@@ -602,6 +632,7 @@ export class PulseSocketIOClient {
 				fn(value);
 			};
 			this.#pending.set(requestId, {
+				owner,
 				resolve: (value) => finish(resolve, value),
 				reject: (error) => finish(reject, error),
 			});
@@ -609,7 +640,7 @@ export class PulseSocketIOClient {
 				timer = setTimeout(() => {
 					if (!this.#pending.has(requestId)) return;
 					this.#pending.delete(requestId);
-					reject(new PulseChannelTimeoutError(timeout, message.event));
+					finish(reject, new PulseChannelTimeoutError(timeout, message.event));
 				}, timeout);
 			}
 			this.sendMessage(message);

--- a/packages/pulse/js/src/client.tsx
+++ b/packages/pulse/js/src/client.tsx
@@ -13,6 +13,7 @@ import { pulseFetch } from "./http";
 import type {
 	ClientApiResultMessage,
 	ClientCallbackMessage,
+	ClientChannelEventMessage,
 	ClientChannelRequestMessage,
 	ClientJsResultMessage,
 	ClientMessage,
@@ -89,8 +90,10 @@ export class PulseSocketIOClient {
 	#pendingCallbacks: Map<string, ClientCallbackMessage[]>;
 	#socket: Socket | null = null;
 	#messageQueue: ClientMessage[];
+	#channelEventQueues = new Map<string, ClientChannelEventMessage[]>();
 	#connectionListeners: Set<ConnectionStatusListener> = new Set();
 	#handles: Map<string, Set<ChannelBridge>> = new Map();
+	#scheduledDetachSweeps = new Set<ChannelBridge>();
 	#pending = new Map<
 		string,
 		{
@@ -249,6 +252,12 @@ export class PulseSocketIOClient {
 					socket.emit("message", serialize(payload));
 				}
 				this.#messageQueue = [];
+				for (const events of this.#channelEventQueues.values()) {
+					for (const event of events) {
+						socket.emit("message", serialize(event));
+					}
+				}
+				this.#channelEventQueues.clear();
 
 				this.#handleConnected();
 				resolve();
@@ -303,19 +312,17 @@ export class PulseSocketIOClient {
 		if (payload.type === "channel" && (payload.action === "request" || payload.action === "response")) {
 			return;
 		}
-		// The protocol has no session identity, so cap rather than drop all offline events.
 		if (payload.type === "channel" && payload.action === "event") {
-			const queuedEvents = this.#messageQueue.filter(
-				(message) => message.type === "channel" && message.action === "event",
-			);
-			if (queuedEvents.length >= OFFLINE_CHANNEL_EVENT_QUEUE_LIMIT) {
-				const oldestEvent = this.#messageQueue.findIndex(
-					(message) => message.type === "channel" && message.action === "event",
-				);
-				if (oldestEvent !== -1) {
-					this.#messageQueue.splice(oldestEvent, 1);
-				}
+			// The protocol has no session identity, so cap rather than drop all offline events.
+			// Channel events flush after other queued messages rather than interleaved.
+			let events = this.#channelEventQueues.get(payload.channel);
+			if (!events) {
+				events = [];
+				this.#channelEventQueues.set(payload.channel, events);
 			}
+			if (events.length >= OFFLINE_CHANNEL_EVENT_QUEUE_LIMIT) events.shift();
+			events.push(payload);
+			return;
 		}
 		this.#messageQueue.push(payload);
 	}
@@ -373,6 +380,7 @@ export class PulseSocketIOClient {
 		this.#clearTimeouts();
 		this.#closeSocket();
 		this.#messageQueue = [];
+		this.#channelEventQueues.clear();
 		this.#connectionListeners.clear();
 		this.#activeViews.clear();
 		this.#activeAttachIds.clear();
@@ -607,11 +615,18 @@ export class PulseSocketIOClient {
 				this.#handles.delete(bridge.id);
 			}
 		}
-		for (const [requestId, pending] of this.#pending) {
-			if (pending.owner !== bridge) continue;
-			this.#pending.delete(requestId);
-			pending.reject(new PulseChannelDetachedError("Channel handle detached"));
-		}
+		if (this.#scheduledDetachSweeps.has(bridge)) return;
+		this.#scheduledDetachSweeps.add(bridge);
+		queueMicrotask(() => {
+			this.#scheduledDetachSweeps.delete(bridge);
+			const currentHandles = this.#handles.get(bridge.id);
+			if (currentHandles?.has(bridge)) return;
+			for (const [requestId, pending] of this.#pending) {
+				if (pending.owner !== bridge) continue;
+				this.#pending.delete(requestId);
+				pending.reject(new PulseChannelDetachedError("Channel handle detached"));
+			}
+		});
 	}
 
 	requestChannel(

--- a/packages/pulse/js/src/client.tsx
+++ b/packages/pulse/js/src/client.tsx
@@ -1,11 +1,17 @@
 import type { NavigateFunction } from "react-router";
 import { io, type Socket } from "socket.io-client";
-import { ChannelBridge, createRandomId, PulseChannelResetError } from "./channel";
+import {
+	ChannelBridge,
+	createRandomId,
+	PulseChannelDisconnectedError,
+	PulseChannelRemoteError,
+} from "./channel";
 import type { RouteInfo } from "./helpers";
 import { pulseFetch } from "./http";
 import type {
 	ClientApiResultMessage,
 	ClientCallbackMessage,
+	ClientChannelRequestMessage,
 	ClientJsResultMessage,
 	ClientMessage,
 	ServerApiCallMessage,
@@ -81,7 +87,8 @@ export class PulseSocketIOClient {
 	#socket: Socket | null = null;
 	#messageQueue: ClientMessage[];
 	#connectionListeners: Set<ConnectionStatusListener> = new Set();
-	#channels: Map<string, { bridge: ChannelBridge; refCount: number }> = new Map();
+	#mailboxes: Map<string, Set<ChannelBridge>> = new Map();
+	#pending = new Map<string, { resolve: (value: any) => void; reject: (error: any) => void }>();
 	#url: string;
 	#frameworkNavigate: NavigateFunction;
 	#directives: Directives;
@@ -346,10 +353,12 @@ export class PulseSocketIOClient {
 		this.#activeAttachIds.clear();
 		this.#ackedAttachIds.clear();
 		this.#pendingCallbacks.clear();
-		for (const { bridge } of this.#channels.values()) {
-			bridge.dispose(new PulseChannelResetError("Client disconnected"));
+		this.#failPending(new PulseChannelDisconnectedError("Client disconnected"));
+		const leftover = [...this.#mailboxes.values()].flatMap((handles) => [...handles]);
+		this.#mailboxes.clear();
+		for (const bridge of leftover) {
+			bridge.detach();
 		}
-		this.#channels.clear();
 		this.#currentStatus = "ok";
 		this.#hasConnectedOnce = false;
 	}
@@ -443,7 +452,7 @@ export class PulseSocketIOClient {
 				this.#handleAttachAck(message.path, message.attachId);
 				break;
 			}
-			case "channel_message": {
+			case "channel": {
 				this.#routeChannelMessage(message);
 				break;
 			}
@@ -539,58 +548,123 @@ export class PulseSocketIOClient {
 		this.sendMessage(msg);
 	}
 
+	public channel(id: string): ChannelBridge {
+		return new ChannelBridge(this, id);
+	}
+
 	public acquireChannel(id: string): ChannelBridge {
-		const entry = this.#ensureChannelEntry(id);
-		entry.refCount += 1;
-		return entry.bridge;
+		const bridge = this.channel(id);
+		bridge.attach();
+		return bridge;
 	}
 
-	public releaseChannel(id: string): void {
-		const entry = this.#channels.get(id);
-		if (!entry) {
-			return;
+	public releaseChannel(bridge: ChannelBridge): void {
+		bridge.detach();
+	}
+
+	attachHandle(bridge: ChannelBridge): void {
+		let mailbox = this.#mailboxes.get(bridge.id);
+		if (!mailbox) {
+			mailbox = new Set();
+			this.#mailboxes.set(bridge.id, mailbox);
 		}
-		entry.refCount = Math.max(0, entry.refCount - 1);
-		if (entry.refCount === 0) {
-			entry.bridge.dispose(new PulseChannelResetError("Channel released"));
-			this.sendMessage({
-				type: "channel_message",
-				channel: id,
-				event: "__close__",
-				payload: { reason: "refcount_zero" },
-			});
-			this.#channels.delete(id);
+		mailbox.add(bridge);
+	}
+
+	detachHandle(bridge: ChannelBridge): void {
+		const mailbox = this.#mailboxes.get(bridge.id);
+		if (!mailbox) return;
+		mailbox.delete(bridge);
+		if (mailbox.size === 0) {
+			this.#mailboxes.delete(bridge.id);
 		}
 	}
 
-	#ensureChannelEntry(id: string): {
-		bridge: ChannelBridge;
-		refCount: number;
-	} {
-		let entry = this.#channels.get(id);
-		if (!entry) {
-			entry = {
-				bridge: new ChannelBridge(this, id),
-				refCount: 0,
-			};
-			this.#channels.set(id, entry);
+	requestChannel(requestId: string, message: ClientChannelRequestMessage): Promise<any> {
+		return new Promise((resolve, reject) => {
+			this.#pending.set(requestId, { resolve, reject });
+			this.sendMessage(message);
+		});
+	}
+
+	#failPending(reason: PulseChannelDisconnectedError): void {
+		const pending = [...this.#pending.values()];
+		this.#pending.clear();
+		for (const entry of pending) {
+			entry.reject(reason);
 		}
-		return entry;
 	}
 
 	#routeChannelMessage(message: ServerChannelMessage): void {
-		const entry = this.#ensureChannelEntry(message.channel);
-		const closed = entry.bridge.handleServerMessage(message);
-		if (closed && entry.refCount === 0) {
-			this.#channels.delete(message.channel);
+		if (message.action === "response") {
+			const pending = this.#pending.get(message.responseTo);
+			if (!pending) return;
+			this.#pending.delete(message.responseTo);
+			if (message.error) {
+				pending.reject(new PulseChannelRemoteError(message.error.code, message.error.message));
+				return;
+			}
+			pending.resolve(message.payload);
+			return;
+		}
+		const handles = [...(this.#mailboxes.get(message.channel) ?? [])];
+		if (message.action === "event") {
+			if (handles.length === 0) {
+				console.debug(
+					`[Pulse] Dropping event ${message.event} on mailbox ${message.channel} (no listeners)`,
+				);
+				return;
+			}
+			for (const handle of handles) {
+				handle.dispatchEvent(message.event, message.payload);
+			}
+			return;
+		}
+		for (const handle of handles) {
+			if (!handle.hasHandler(message.event)) continue;
+			void this.#dispatchChannelRequest(handle, message);
+			return;
+		}
+		this.sendMessage({
+			type: "channel",
+			action: "response",
+			channel: message.channel,
+			responseTo: message.requestId,
+			error: {
+				code: "no_handler",
+				message: `No handler for '${message.event}' on channel '${message.channel}'`,
+			},
+		});
+	}
+
+	async #dispatchChannelRequest(
+		handle: ChannelBridge,
+		message: Extract<ServerChannelMessage, { action: "request" }>,
+	): Promise<void> {
+		try {
+			const payload = await handle.dispatchRequest(message.event, message.payload);
+			this.sendMessage({
+				type: "channel",
+				action: "response",
+				channel: message.channel,
+				responseTo: message.requestId,
+				payload,
+			});
+		} catch (err) {
+			console.error("Pulse channel handler error", err);
+			this.sendMessage({
+				type: "channel",
+				action: "response",
+				channel: message.channel,
+				responseTo: message.requestId,
+				error: { code: "handler_error", message: "Channel handler failed" },
+			});
 		}
 	}
 
 	#handleTransportDisconnect(): void {
 		this.#ackedAttachIds.clear();
-		for (const entry of this.#channels.values()) {
-			entry.bridge.handleDisconnect(new PulseChannelResetError("Connection lost"));
-		}
+		this.#failPending(new PulseChannelDisconnectedError("Connection lost"));
 	}
 
 	#sendAttach(path: string, routeInfo: RouteInfo, socket?: Socket): void {
@@ -635,12 +709,5 @@ export class PulseSocketIOClient {
 		for (const message of queue) {
 			this.sendMessage(message);
 		}
-	}
-
-	_ensureChannelEntry(id: string): {
-		bridge: ChannelBridge;
-		refCount: number;
-	} {
-		return this.#ensureChannelEntry(id);
 	}
 }

--- a/packages/pulse/js/src/client.tsx
+++ b/packages/pulse/js/src/client.tsx
@@ -391,8 +391,15 @@ export class PulseSocketIOClient {
 			}
 			case "server_error": {
 				const route = this.#activeViews.get(message.path);
-				if (!route) return; // discard for inactive paths
-				route.onServerError(message.error);
+				if (route) {
+					route.onServerError(message.error);
+					break;
+				}
+				// Tab / connect errors are often tagged "/" even when that
+				// view is not mounted — deliver to every live view.
+				for (const view of this.#activeViews.values()) {
+					view.onServerError(message.error);
+				}
 				break;
 			}
 			case "api_call": {

--- a/packages/pulse/js/src/client.tsx
+++ b/packages/pulse/js/src/client.tsx
@@ -5,6 +5,7 @@ import {
 	createRandomId,
 	PulseChannelDisconnectedError,
 	PulseChannelRemoteError,
+	PulseChannelTimeoutError,
 } from "./channel";
 import type { RouteInfo } from "./helpers";
 import { pulseFetch } from "./http";
@@ -87,7 +88,7 @@ export class PulseSocketIOClient {
 	#socket: Socket | null = null;
 	#messageQueue: ClientMessage[];
 	#connectionListeners: Set<ConnectionStatusListener> = new Set();
-	#mailboxes: Map<string, Set<ChannelBridge>> = new Map();
+	#handles: Map<string, Set<ChannelBridge>> = new Map();
 	#pending = new Map<string, { resolve: (value: any) => void; reject: (error: any) => void }>();
 	#url: string;
 	#frameworkNavigate: NavigateFunction;
@@ -287,12 +288,13 @@ export class PulseSocketIOClient {
 
 	public sendMessage(payload: ClientMessage) {
 		if (this.isConnected()) {
-			// console.log("[SocketIOTransport] Sending:", payload);
 			this.#socket!.emit("message", serialize(payload as any));
-		} else {
-			// console.log("[SocketIOTransport] Queuing message:", payload);
-			this.#messageQueue.push(payload);
+			return;
 		}
+		if (payload.type === "channel" && (payload.action === "request" || payload.action === "response")) {
+			return;
+		}
+		this.#messageQueue.push(payload);
 	}
 
 	public attach(path: string, view: MountedView) {
@@ -354,8 +356,8 @@ export class PulseSocketIOClient {
 		this.#ackedAttachIds.clear();
 		this.#pendingCallbacks.clear();
 		this.#failPending(new PulseChannelDisconnectedError("Client disconnected"));
-		const leftover = [...this.#mailboxes.values()].flatMap((handles) => [...handles]);
-		this.#mailboxes.clear();
+		const leftover = [...this.#handles.values()].flatMap((handles) => [...handles]);
+		this.#handles.clear();
 		for (const bridge of leftover) {
 			bridge.detach();
 		}
@@ -558,31 +560,51 @@ export class PulseSocketIOClient {
 		return bridge;
 	}
 
-	public releaseChannel(bridge: ChannelBridge): void {
-		bridge.detach();
-	}
-
 	attachHandle(bridge: ChannelBridge): void {
-		let mailbox = this.#mailboxes.get(bridge.id);
-		if (!mailbox) {
-			mailbox = new Set();
-			this.#mailboxes.set(bridge.id, mailbox);
+		let handles = this.#handles.get(bridge.id);
+		if (!handles) {
+			handles = new Set();
+			this.#handles.set(bridge.id, handles);
 		}
-		mailbox.add(bridge);
+		handles.add(bridge);
 	}
 
 	detachHandle(bridge: ChannelBridge): void {
-		const mailbox = this.#mailboxes.get(bridge.id);
-		if (!mailbox) return;
-		mailbox.delete(bridge);
-		if (mailbox.size === 0) {
-			this.#mailboxes.delete(bridge.id);
+		const handles = this.#handles.get(bridge.id);
+		if (!handles) return;
+		handles.delete(bridge);
+		if (handles.size === 0) {
+			this.#handles.delete(bridge.id);
 		}
 	}
 
-	requestChannel(requestId: string, message: ClientChannelRequestMessage): Promise<any> {
+	requestChannel(
+		requestId: string,
+		message: ClientChannelRequestMessage,
+		timeout?: number,
+	): Promise<any> {
+		if (!this.isConnected()) {
+			return Promise.reject(new PulseChannelDisconnectedError("No render session is connected"));
+		}
 		return new Promise((resolve, reject) => {
-			this.#pending.set(requestId, { resolve, reject });
+			let timer: ReturnType<typeof setTimeout> | undefined;
+			const finish = (fn: (value: any) => void, value: any) => {
+				if (timer !== undefined) {
+					clearTimeout(timer);
+				}
+				fn(value);
+			};
+			this.#pending.set(requestId, {
+				resolve: (value) => finish(resolve, value),
+				reject: (error) => finish(reject, error),
+			});
+			if (timeout !== undefined) {
+				timer = setTimeout(() => {
+					if (!this.#pending.has(requestId)) return;
+					this.#pending.delete(requestId);
+					reject(new PulseChannelTimeoutError(timeout, message.event));
+				}, timeout);
+			}
 			this.sendMessage(message);
 		});
 	}
@@ -607,11 +629,11 @@ export class PulseSocketIOClient {
 			pending.resolve(message.payload);
 			return;
 		}
-		const handles = [...(this.#mailboxes.get(message.channel) ?? [])];
+		const handles = [...(this.#handles.get(message.channel) ?? [])];
 		if (message.action === "event") {
 			if (handles.length === 0) {
 				console.debug(
-					`[Pulse] Dropping event ${message.event} on mailbox ${message.channel} (no listeners)`,
+					`[Pulse] Dropping event ${message.event} on channel ${message.channel} (no listeners)`,
 				);
 				return;
 			}

--- a/packages/pulse/js/src/index.ts
+++ b/packages/pulse/js/src/index.ts
@@ -5,7 +5,7 @@ export {
 	PulseChannelDetachedError,
 	PulseChannelDisconnectedError,
 	PulseChannelRemoteError,
-	usePulseChannel,
+	useChannel,
 } from "./channel";
 // Client implementation (types only - implementation is internal)
 export type {

--- a/packages/pulse/js/src/index.ts
+++ b/packages/pulse/js/src/index.ts
@@ -1,7 +1,12 @@
 // Public API surface for pulse-client
 
 export type { ChannelBridge } from "./channel";
-export { PulseChannelResetError, usePulseChannel } from "./channel";
+export {
+	PulseChannelDetachedError,
+	PulseChannelDisconnectedError,
+	PulseChannelRemoteError,
+	usePulseChannel,
+} from "./channel";
 // Client implementation (types only - implementation is internal)
 export type {
 	ConnectionStatusListener,
@@ -19,6 +24,9 @@ export type {
 	ClientApiResultMessage,
 	ClientAttachMessage,
 	ClientCallbackMessage,
+	ChannelError,
+	ChannelErrorCode,
+	ClientChannelEventMessage,
 	ClientChannelMessage,
 	ClientChannelRequestMessage,
 	ClientChannelResponseMessage,
@@ -26,6 +34,7 @@ export type {
 	ClientMessage,
 	ClientUpdateMessage,
 	ServerApiCallMessage,
+	ServerChannelEventMessage,
 	ServerChannelMessage,
 	ServerChannelRequestMessage,
 	ServerChannelResponseMessage,

--- a/packages/pulse/js/src/index.ts
+++ b/packages/pulse/js/src/index.ts
@@ -5,8 +5,10 @@ export {
 	PulseChannelDetachedError,
 	PulseChannelDisconnectedError,
 	PulseChannelRemoteError,
+	PulseChannelTimeoutError,
 	useChannel,
 } from "./channel";
+export type { ChannelRequestOptions } from "./channel";
 // Client implementation (types only - implementation is internal)
 export type {
 	ConnectionStatusListener,

--- a/packages/pulse/js/src/messages.ts
+++ b/packages/pulse/js/src/messages.ts
@@ -21,7 +21,16 @@ export interface ServerUpdateMessage {
 export interface ServerError {
 	message: string;
 	stack?: string;
-	phase: "render" | "callback" | "mount" | "unmount" | "navigate" | "server";
+	phase:
+		| "render"
+		| "callback"
+		| "mount"
+		| "unmount"
+		| "navigate"
+		| "server"
+		| "effect"
+		| "connect"
+		| "channel";
 	details?: Record<string, any>;
 }
 

--- a/packages/pulse/js/src/messages.ts
+++ b/packages/pulse/js/src/messages.ts
@@ -41,27 +41,43 @@ export interface ServerApiCallMessage {
 	credentials: "include" | "omit";
 }
 
-export interface ServerChannelRequestMessage {
-	type: "channel_message";
+export type ChannelErrorCode = "no_handler" | "denied" | "handler_error";
+
+export interface ChannelError {
+	code: ChannelErrorCode;
+	message: string;
+}
+
+export interface ServerChannelEventMessage {
+	type: "channel";
+	action: "event";
 	channel: string;
 	event: string;
 	payload?: any;
-	requestId?: string;
-	responseTo?: never;
-	error?: any;
+}
+
+export interface ServerChannelRequestMessage {
+	type: "channel";
+	action: "request";
+	channel: string;
+	event: string;
+	requestId: string;
+	payload?: any;
 }
 
 export interface ServerChannelResponseMessage {
-	type: "channel_message";
+	type: "channel";
+	action: "response";
 	channel: string;
-	event?: undefined;
 	responseTo: string;
 	payload?: any;
-	error?: any;
-	requestId?: never;
+	error?: ChannelError;
 }
 
-export type ServerChannelMessage = ServerChannelRequestMessage | ServerChannelResponseMessage;
+export type ServerChannelMessage =
+	| ServerChannelEventMessage
+	| ServerChannelRequestMessage
+	| ServerChannelResponseMessage;
 
 export interface ServerNavigateToMessage {
 	type: "navigate_to";
@@ -98,8 +114,7 @@ export type ServerMessage =
 	| ServerNavigateToMessage
 	| ServerReloadMessage
 	| ServerAttachAckMessage
-	| ServerChannelRequestMessage
-	| ServerChannelResponseMessage
+	| ServerChannelMessage
 	| ServerJsExecMessage;
 
 export interface ClientCallbackMessage {
@@ -134,27 +149,36 @@ export interface ClientApiResultMessage {
 	body: any | null;
 }
 
-export interface ClientChannelRequestMessage {
-	type: "channel_message";
+export interface ClientChannelEventMessage {
+	type: "channel";
+	action: "event";
 	channel: string;
 	event: string;
 	payload?: any;
-	requestId?: string;
-	responseTo?: never;
-	error?: any;
+}
+
+export interface ClientChannelRequestMessage {
+	type: "channel";
+	action: "request";
+	channel: string;
+	event: string;
+	requestId: string;
+	payload?: any;
 }
 
 export interface ClientChannelResponseMessage {
-	type: "channel_message";
+	type: "channel";
+	action: "response";
 	channel: string;
-	event?: undefined;
 	responseTo: string;
 	payload?: any;
-	error?: any;
-	requestId?: never;
+	error?: ChannelError;
 }
 
-export type ClientChannelMessage = ClientChannelRequestMessage | ClientChannelResponseMessage;
+export type ClientChannelMessage =
+	| ClientChannelEventMessage
+	| ClientChannelRequestMessage
+	| ClientChannelResponseMessage;
 
 export interface ClientJsResultMessage {
 	type: "js_result";
@@ -169,6 +193,5 @@ export type ClientMessage =
 	| ClientUpdateMessage
 	| ClientDetachMessage
 	| ClientApiResultMessage
-	| ClientChannelRequestMessage
-	| ClientChannelResponseMessage
+	| ClientChannelMessage
 	| ClientJsResultMessage;

--- a/packages/pulse/js/src/ref.test.ts
+++ b/packages/pulse/js/src/ref.test.ts
@@ -28,6 +28,8 @@ class FakeBridge {
 		this.emitted.push({ event, payload });
 	}
 
+	detach(): void {}
+
 	trigger(event: string, payload: any): any {
 		const handlers = this.handlers.get(event);
 		let result: any;

--- a/packages/pulse/js/src/ref.tsx
+++ b/packages/pulse/js/src/ref.tsx
@@ -231,6 +231,7 @@ export class RefRegistry {
 		for (const fn of this.#cleanup) fn();
 		this.#cleanup = [];
 		this.#entries.clear();
+		this.#bridge?.detach();
 		this.#bridge = null;
 		this.#channelId = null;
 	}

--- a/packages/pulse/js/src/renderer.test.tsx
+++ b/packages/pulse/js/src/renderer.test.tsx
@@ -20,13 +20,17 @@ describe("VDOMRenderer", () => {
 		const client: any = {
 			sendMessage,
 			invokeCallback,
-			_ensureChannelEntry: (id: string) => {
+			isConnected: () => true,
+			attachHandle: () => {},
+			detachHandle: () => {},
+			acquireChannel: (id: string) => {
 				let bridge = bridges.get(id);
 				if (!bridge) {
 					bridge = new ChannelBridge(client, id);
+					bridge.attach();
 					bridges.set(id, bridge);
 				}
-				return { bridge, refCount: 0 };
+				return bridge;
 			},
 		};
 		return { client, invokeCallback, sent };
@@ -104,11 +108,12 @@ describe("VDOMRenderer", () => {
 			(input.props as any).ref({});
 		}
 		const mounted = sent.filter(
-			(message) => message.type === "channel_message" && message.event === "ref:mounted",
+			(message) => message.type === "channel" && message.event === "ref:mounted",
 		);
 		expect(mounted).toEqual([
 			{
-				type: "channel_message",
+				type: "channel",
+				action: "event",
 				channel: "chan-1",
 				event: "ref:mounted",
 				payload: { refId: "ref-1" },
@@ -169,7 +174,7 @@ describe("VDOMRenderer", () => {
 		elB.props.ref({});
 
 		const mountedChannels = shared.sent
-			.filter((message) => message.type === "channel_message" && message.event === "ref:mounted")
+			.filter((message) => message.type === "channel" && message.event === "ref:mounted")
 			.map((message) => message.channel);
 
 		expect(mountedChannels).toEqual(["chan-a", "chan-b"]);

--- a/packages/pulse/js/src/renderer.tsx
+++ b/packages/pulse/js/src/renderer.tsx
@@ -72,7 +72,7 @@ export class VDOMRenderer {
 		this.#callbackEntries = new Set();
 		this.#metaMap = new WeakMap();
 		this.#refRegistry = new RefRegistry((channelId) => {
-			return this.#client._ensureChannelEntry(channelId).bridge;
+			return this.#client.acquireChannel(channelId);
 		});
 	}
 

--- a/packages/pulse/js/src/useChannel.test.tsx
+++ b/packages/pulse/js/src/useChannel.test.tsx
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it, mock, vi } from "bun:test";
-import React, { useEffect } from "react";
+import React, { Component, StrictMode, useEffect } from "react";
 import { render } from "@testing-library/react";
 import { ChannelBridge } from "./channel";
 
 const attachHandle = vi.fn();
 const detachHandle = vi.fn();
+const handles = new Set<ChannelBridge>();
 
 const mockClient = {
 	channel(id: string) {
@@ -25,6 +26,9 @@ describe("useChannel", () => {
 	beforeEach(() => {
 		attachHandle.mockClear();
 		detachHandle.mockClear();
+		handles.clear();
+		attachHandle.mockImplementation((bridge: ChannelBridge) => handles.add(bridge));
+		detachHandle.mockImplementation((bridge: ChannelBridge) => handles.delete(bridge));
 	});
 
 	it("throws on an empty id before other hooks", async () => {
@@ -36,7 +40,7 @@ describe("useChannel", () => {
 		expect(() => render(React.createElement(Bad))).toThrow("useChannel requires a non-empty channelId");
 	});
 
-	it("registers the handle during render", async () => {
+	it("attaches in an effect after render", async () => {
 		const { useChannel } = await import("./channel");
 		const order: string[] = [];
 		attachHandle.mockImplementation(() => {
@@ -51,8 +55,52 @@ describe("useChannel", () => {
 			return null;
 		}
 		render(React.createElement(Probe));
-		expect(order[0]).toBe("attach");
 		expect(order).toContain("render");
-		expect(order.indexOf("attach")).toBeLessThan(order.indexOf("render"));
+		expect(order.indexOf("attach")).toBeGreaterThan(order.indexOf("render"));
+	});
+
+	it("does not attach a discarded render", async () => {
+		const { useChannel } = await import("./channel");
+		class Boundary extends Component<{ children: React.ReactNode }, { failed: boolean }> {
+			override state = { failed: false };
+
+			static getDerivedStateFromError() {
+				return { failed: true };
+			}
+
+			override render() {
+				return this.state.failed ? null : this.props.children;
+			}
+		}
+		function Broken(): React.ReactNode {
+			useChannel("chat");
+			throw new Error("discarded");
+		}
+		expect(() =>
+			render(
+				<Boundary>
+					<Broken />
+				</Boundary>,
+			),
+		).not.toThrow();
+		expect(handles).toHaveLength(0);
+		expect(attachHandle).not.toHaveBeenCalled();
+	});
+
+	it("keeps one live handle through StrictMode cleanup and detaches on unmount", async () => {
+		const { useChannel } = await import("./channel");
+		function Probe() {
+			useChannel("chat");
+			return null;
+		}
+		const view = render(
+			<StrictMode>
+				<Probe />
+			</StrictMode>,
+		);
+		expect(handles).toHaveLength(1);
+		view.unmount();
+		expect(handles).toHaveLength(0);
+		expect(detachHandle).toHaveBeenCalled();
 	});
 });

--- a/packages/pulse/js/src/useChannel.test.tsx
+++ b/packages/pulse/js/src/useChannel.test.tsx
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, mock, vi } from "bun:test";
+import React, { useEffect } from "react";
+import { render } from "@testing-library/react";
+import { ChannelBridge } from "./channel";
+
+const attachHandle = vi.fn();
+const detachHandle = vi.fn();
+
+const mockClient = {
+	channel(id: string) {
+		return new ChannelBridge(mockClient as any, id);
+	},
+	attachHandle,
+	detachHandle,
+	isConnected: () => true,
+	sendMessage: vi.fn(),
+	requestChannel: vi.fn(),
+};
+
+mock.module("./pulse", () => ({
+	usePulseClient: () => mockClient,
+}));
+
+describe("useChannel", () => {
+	beforeEach(() => {
+		attachHandle.mockClear();
+		detachHandle.mockClear();
+	});
+
+	it("throws on an empty id before other hooks", async () => {
+		const { useChannel } = await import("./channel");
+		function Bad() {
+			useChannel("");
+			return null;
+		}
+		expect(() => render(React.createElement(Bad))).toThrow("useChannel requires a non-empty channelId");
+	});
+
+	it("registers the handle during render", async () => {
+		const { useChannel } = await import("./channel");
+		const order: string[] = [];
+		attachHandle.mockImplementation(() => {
+			order.push("attach");
+		});
+		function Probe() {
+			useChannel("chat");
+			order.push("render");
+			useEffect(() => {
+				order.push("effect");
+			}, []);
+			return null;
+		}
+		render(React.createElement(Probe));
+		expect(order[0]).toBe("attach");
+		expect(order).toContain("render");
+		expect(order.indexOf("attach")).toBeLessThan(order.indexOf("render"));
+	});
+});

--- a/packages/pulse/python/src/pulse/__init__.py
+++ b/packages/pulse/python/src/pulse/__init__.py
@@ -26,7 +26,13 @@ from pulse.channel import (
 	Channel as Channel,
 )
 from pulse.channel import (
-	ChannelClosed as ChannelClosed,
+	ChannelDetached as ChannelDetached,
+)
+from pulse.channel import (
+	ChannelDisconnected as ChannelDisconnected,
+)
+from pulse.channel import (
+	ChannelRemoteError as ChannelRemoteError,
 )
 from pulse.channel import (
 	ChannelTimeout as ChannelTimeout,

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -1119,17 +1119,25 @@ class App:
 		self, render: RenderSession, session: UserSession, msg: ClientChannelMessage
 	) -> None:
 		action = msg.get("action")
-		if action == "response":
-			render.channels.handle_response(cast(ClientChannelResponseMessage, msg))
-			return
-		if action not in ("event", "request"):
+		if action not in ("event", "request", "response"):
 			logger.warning("Unknown channel action received: %s", msg)
 			return
 
 		channel_id = msg.get("channel")
+		if not isinstance(channel_id, str):
+			logger.warning("Dropping channel message without channel: %s", msg)
+			return
+
+		if action == "response":
+			if not isinstance(msg.get("responseTo"), str):
+				logger.warning("Dropping channel response without responseTo: %s", msg)
+				return
+			render.channels.handle_response(cast(ClientChannelResponseMessage, msg))
+			return
+
 		event = msg.get("event")
-		if not isinstance(channel_id, str) or not isinstance(event, str):
-			logger.warning("Dropping malformed channel message: %s", msg)
+		if not isinstance(event, str):
+			logger.warning("Dropping channel message without event: %s", msg)
 			return
 		request_id = None
 		if action == "request":

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -1129,7 +1129,6 @@ class App:
 				render.execute_callback(msg["path"], msg["callback"], msg["args"])
 			elif msg["type"] == "detach":
 				render.detach(msg["path"])
-				render.channels.detach_route(msg["path"])
 			elif msg["type"] == "api_result":
 				render.handle_api_result(dict(msg))
 			elif msg["type"] == "js_result":
@@ -1188,10 +1187,24 @@ class App:
 		async def _next() -> Ok[None]:
 			if action == "event":
 				render.channels.handle_event(cast(ClientChannelEventMessage, inbound))
-			else:
-				await render.channels.handle_request(
-					cast(ClientChannelRequestMessage, inbound)
-				)
+				return Ok(None)
+			request_msg = cast(ClientChannelRequestMessage, inbound)
+
+			def _on_done(task: asyncio.Task[Any]) -> None:
+				if task.cancelled():
+					return
+				try:
+					exc = task.exception()
+				except asyncio.CancelledError:
+					return
+				if exc is not None:
+					render.report_error("/", "channel", exc)
+
+			render.create_task(
+				render.channels.handle_request(request_msg),
+				name=f"channel-request:{channel_id}:{event}",
+				on_done=_on_done,
+			)
 			return Ok(None)
 
 		def _normalize_message_response(res: Any) -> Ok[None] | Deny:
@@ -1199,16 +1212,24 @@ class App:
 				return res  # type: ignore[return-value]
 			return Ok(None)
 
-		with PulseContext.update(session=session, render=render):
-			res = await self.middleware.channel(
-				channel_id=channel_id,
-				event=event,
-				payload=inbound.get("payload"),
-				request_id=request_id,
-				session=session.data,
-				next=_next,
-			)
-			res = _normalize_message_response(res)
+		try:
+			with PulseContext.update(session=session, render=render):
+				res = await self.middleware.channel(
+					channel_id=channel_id,
+					event=event,
+					payload=inbound.get("payload"),
+					request_id=request_id,
+					session=session.data,
+					next=_next,
+				)
+				res = _normalize_message_response(res)
+		except Exception as e:
+			if action == "request" and request_id:
+				render.channels.send_error(
+					channel_id, request_id, "handler_error", "Channel handler failed"
+				)
+			render.report_error("/", "channel", e)
+			return
 
 		if isinstance(res, Deny) and action == "request" and request_id:
 			render.channels.send_error(channel_id, request_id, "denied", "Denied")

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -50,6 +50,7 @@ from pulse.helpers import (
 )
 from pulse.hooks.core import hooks
 from pulse.messages import (
+	ClientChannelEventMessage,
 	ClientChannelMessage,
 	ClientChannelRequestMessage,
 	ClientChannelResponseMessage,
@@ -1099,7 +1100,7 @@ class App:
 			if render.connected:
 				self._cancel_render_cleanup(rid)
 			try:
-				if msg["type"] == "channel_message":
+				if msg["type"] == "channel":
 					await self._handle_channel_message(render, session, msg)
 				else:
 					await self._handle_pulse_message(render, session, msg)
@@ -1128,7 +1129,7 @@ class App:
 				render.execute_callback(msg["path"], msg["callback"], msg["args"])
 			elif msg["type"] == "detach":
 				render.detach(msg["path"])
-				render.channels.remove_route(msg["path"])
+				render.channels.detach_route(msg["path"])
 			elif msg["type"] == "api_result":
 				render.handle_api_result(dict(msg))
 			elif msg["type"] == "js_result":
@@ -1167,39 +1168,50 @@ class App:
 	async def _handle_channel_message(
 		self, render: RenderSession, session: UserSession, msg: ClientChannelMessage
 	) -> None:
-		if msg.get("responseTo"):
-			msg = cast(ClientChannelResponseMessage, msg)
-			render.channels.handle_client_response(msg)
-		else:
-			channel_id = str(msg.get("channel", ""))
-			msg = cast(ClientChannelRequestMessage, msg)
+		action = msg.get("action")
+		if action == "response":
+			render.channels.handle_response(cast(ClientChannelResponseMessage, msg))
+			return
+		if action not in ("event", "request"):
+			logger.warning("Unknown channel action received: %s", msg)
+			return
 
-			async def _next() -> Ok[None]:
-				render.channels.handle_client_event(
-					render=render, session=session, message=msg
+		inbound = (
+			cast(ClientChannelEventMessage, msg)
+			if action == "event"
+			else cast(ClientChannelRequestMessage, msg)
+		)
+		channel_id = inbound["channel"]
+		event = inbound["event"]
+		request_id = inbound.get("requestId") if action == "request" else None
+
+		async def _next() -> Ok[None]:
+			if action == "event":
+				render.channels.handle_event(cast(ClientChannelEventMessage, inbound))
+			else:
+				await render.channels.handle_request(
+					cast(ClientChannelRequestMessage, inbound)
 				)
-				return Ok(None)
+			return Ok(None)
 
-			def _normalize_message_response(res: Any) -> Ok[None] | Deny:
-				if isinstance(res, (Ok, Deny)):
-					return res  # type: ignore[return-value]
-				# Treat any other value as allow
-				return Ok(None)
+		def _normalize_message_response(res: Any) -> Ok[None] | Deny:
+			if isinstance(res, (Ok, Deny)):
+				return res  # type: ignore[return-value]
+			return Ok(None)
 
-			with PulseContext.update(session=session, render=render):
-				res = await self.middleware.channel(
-					channel_id=channel_id,
-					event=msg.get("event", ""),
-					payload=msg.get("payload"),
-					request_id=msg.get("requestId"),
-					session=session.data,
-					next=_next,
-				)
-				res = _normalize_message_response(res)
+		with PulseContext.update(session=session, render=render):
+			res = await self.middleware.channel(
+				channel_id=channel_id,
+				event=event,
+				payload=inbound.get("payload"),
+				request_id=request_id,
+				session=session.data,
+				next=_next,
+			)
+			res = _normalize_message_response(res)
 
-			if isinstance(res, Deny):
-				if req_id := msg.get("requestId"):
-					render.channels.send_error(channel_id, req_id, "Denied")
+		if isinstance(res, Deny) and action == "request" and request_id:
+			render.channels.send_error(channel_id, request_id, "denied", "Denied")
 
 	def get_route(self, path: str):
 		return self.routes.find(path)

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -974,7 +974,7 @@ class App:
 					self._cancel_render_cleanup(rid)
 
 					if connect_error is not None:
-						render.report_error("/", "connect", connect_error)
+						render.report_error(None, "connect", connect_error)
 			except Exception:
 				owns_connect_attempt = (
 					self._render_connect_attempts.get(rid) is connect_attempt
@@ -1198,7 +1198,7 @@ class App:
 				except asyncio.CancelledError:
 					return
 				if exc is not None:
-					render.report_error("/", "channel", exc)
+					render.report_error(None, "channel", exc)
 
 			render.create_task(
 				render.channels.handle_request(request_msg),
@@ -1228,7 +1228,7 @@ class App:
 				render.channels.send_error(
 					channel_id, request_id, "handler_error", "Channel handler failed"
 				)
-			render.report_error("/", "channel", e)
+			render.report_error(None, "channel", e)
 			return
 
 		if isinstance(res, Deny) and action == "request" and request_id:

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -1163,7 +1163,7 @@ class App:
 			return Ok(None)
 
 		try:
-			with PulseContext.update(session=session, render=render):
+			with PulseContext(app=self, session=session, render=render):
 				res = await self.middleware.channel(
 					channel_id=channel_id,
 					event=event,
@@ -1186,25 +1186,26 @@ class App:
 				render.channels.send_error(channel_id, request_id, "denied", "Denied")
 			return
 
-		if action == "event":
-			render.channels.handle_event(cast(ClientChannelEventMessage, msg))
-			return
-
-		def _on_done(task: asyncio.Task[Any]) -> None:
-			if task.cancelled():
+		with PulseContext(app=self, session=session, render=render):
+			if action == "event":
+				render.channels.handle_event(cast(ClientChannelEventMessage, msg))
 				return
-			try:
-				exc = task.exception()
-			except asyncio.CancelledError:
-				return
-			if exc is not None:
-				render.report_error(None, "channel", exc)
 
-		render.create_task(
-			render.channels.handle_request(cast(ClientChannelRequestMessage, msg)),
-			name=f"channel-request:{channel_id}:{event}",
-			on_done=_on_done,
-		)
+			def _on_done(task: asyncio.Task[Any]) -> None:
+				if task.cancelled():
+					return
+				try:
+					exc = task.exception()
+				except asyncio.CancelledError:
+					return
+				if exc is not None:
+					render.report_error(None, "channel", exc)
+
+			render.create_task(
+				render.channels.handle_request(cast(ClientChannelRequestMessage, msg)),
+				name=f"channel-request:{channel_id}:{event}",
+				on_done=_on_done,
+			)
 
 	def get_route(self, path: str):
 		return self.routes.find(path)

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -1126,36 +1126,27 @@ class App:
 			logger.warning("Unknown channel action received: %s", msg)
 			return
 
-		inbound = (
-			cast(ClientChannelEventMessage, msg)
-			if action == "event"
-			else cast(ClientChannelRequestMessage, msg)
-		)
-		channel_id = inbound["channel"]
-		event = inbound["event"]
-		request_id = inbound.get("requestId") if action == "request" else None
+		channel_id = msg.get("channel")
+		event = msg.get("event")
+		if not isinstance(channel_id, str) or not isinstance(event, str):
+			logger.warning("Dropping malformed channel message: %s", msg)
+			return
+		request_id = None
+		if action == "request":
+			request_id = msg.get("requestId")
+			if not isinstance(request_id, str):
+				# Cannot NACK what we cannot address.
+				logger.warning("Dropping channel request without requestId: %s", msg)
+				return
+
+		# Dispatch happens after the chain resolves, never inside `_next`: a
+		# middleware that awaits next() and then denies (or raises) must not
+		# produce a second response nor let the handler commit side effects.
+		reached_end = False
 
 		async def _next() -> Ok[None]:
-			if action == "event":
-				render.channels.handle_event(cast(ClientChannelEventMessage, inbound))
-				return Ok(None)
-			request_msg = cast(ClientChannelRequestMessage, inbound)
-
-			def _on_done(task: asyncio.Task[Any]) -> None:
-				if task.cancelled():
-					return
-				try:
-					exc = task.exception()
-				except asyncio.CancelledError:
-					return
-				if exc is not None:
-					render.report_error(None, "channel", exc)
-
-			render.create_task(
-				render.channels.handle_request(request_msg),
-				name=f"channel-request:{channel_id}:{event}",
-				on_done=_on_done,
-			)
+			nonlocal reached_end
+			reached_end = True
 			return Ok(None)
 
 		def _normalize_message_response(res: Any) -> Ok[None] | Deny:
@@ -1168,22 +1159,44 @@ class App:
 				res = await self.middleware.channel(
 					channel_id=channel_id,
 					event=event,
-					payload=inbound.get("payload"),
+					payload=msg.get("payload"),
 					request_id=request_id,
 					session=session.data,
 					next=_next,
 				)
 				res = _normalize_message_response(res)
 		except Exception as e:
-			if action == "request" and request_id:
+			if request_id is not None:
 				render.channels.send_error(
 					channel_id, request_id, "handler_error", "Channel handler failed"
 				)
 			render.report_error(None, "channel", e)
 			return
 
-		if isinstance(res, Deny) and action == "request" and request_id:
-			render.channels.send_error(channel_id, request_id, "denied", "Denied")
+		if isinstance(res, Deny) or not reached_end:
+			if request_id is not None:
+				render.channels.send_error(channel_id, request_id, "denied", "Denied")
+			return
+
+		if action == "event":
+			render.channels.handle_event(cast(ClientChannelEventMessage, msg))
+			return
+
+		def _on_done(task: asyncio.Task[Any]) -> None:
+			if task.cancelled():
+				return
+			try:
+				exc = task.exception()
+			except asyncio.CancelledError:
+				return
+			if exc is not None:
+				render.report_error(None, "channel", exc)
+
+		render.create_task(
+			render.channels.handle_request(cast(ClientChannelRequestMessage, msg)),
+			name=f"channel-request:{channel_id}:{event}",
+			on_done=_on_done,
+		)
 
 	def get_route(self, path: str):
 		return self.routes.find(path)

--- a/packages/pulse/python/src/pulse/channel.py
+++ b/packages/pulse/python/src/pulse/channel.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 ChannelLifetime = Literal["route", "tab"]
+ChannelInternKey = tuple[ChannelLifetime, str, str | None]
 ChannelHandler = Callable[[Any], Any | Awaitable[Any]]
 ChannelHandlerRemover = Callable[[], None]
 
@@ -63,7 +64,7 @@ class ChannelRemoteError(Exception):
 
 
 class Channel:
-	"""A local handle on a mailbox. Messages route by `id`."""
+	"""A local handle on a channel name. Messages route by `id`."""
 
 	_session: RenderSession
 	_id: str
@@ -102,7 +103,8 @@ class Channel:
 	def on(self, event: str, handler: ChannelHandler) -> ChannelHandlerRemover:
 		self._assert_attached()
 		handlers = self._handlers.setdefault(event, [])
-		handlers.append(handler)
+		if handler not in handlers:
+			handlers.append(handler)
 
 		def remove() -> None:
 			if handler in handlers:
@@ -145,6 +147,17 @@ class Channel:
 		self._handlers.clear()
 		self._session.channels.forget_handle(self)
 
+	def _report_task_error(self, task: asyncio.Task[Any]) -> None:
+		if task.cancelled():
+			return
+		try:
+			exc = task.exception()
+		except asyncio.CancelledError:
+			return
+		if exc is None:
+			return
+		self._session.report_error(self._route_path or "/", "channel", exc)
+
 	def dispatch_event(self, event: str, payload: Any) -> None:
 		if self._detached:
 			return
@@ -152,6 +165,7 @@ class Channel:
 			self._session.create_task(
 				self._invoke_handler(handler, payload, required=False),
 				name=f"channel:{self._id}:{event}",
+				on_done=self._report_task_error,
 			)
 
 	async def dispatch_request(self, event: str, payload: Any) -> Any:
@@ -204,12 +218,9 @@ class ChannelsManager:
 
 	def __init__(self, session: RenderSession):
 		self._session = session
-		self._handles: set[Channel] = set()
-		self._mailboxes: dict[str, list[Channel]] = {}
-		self._route_handles: dict[tuple[str, str], Channel] = {}
-		self._handles_by_route: dict[str, set[Channel]] = {}
-		self._tab_handles: dict[str, Channel] = {}
-		self._unscoped_handles: dict[str, Channel] = {}
+		# (lifetime, channel_id, route_path) → live handle
+		self._intern: dict[ChannelInternKey, Channel] = {}
+		self._by_name: dict[str, list[Channel]] = {}
 		self._pending: dict[str, asyncio.Future[Any]] = {}
 
 	def can_request(self) -> bool:
@@ -219,9 +230,12 @@ class ChannelsManager:
 		route = PulseContext.get().route
 		return route.route_path if route is not None else None
 
+	def _intern_key(self, handle: Channel) -> ChannelInternKey:
+		return (handle.lifetime, handle.id, handle._route_path)
+
 	def _register(self, handle: Channel) -> None:
-		self._handles.add(handle)
-		self._mailboxes.setdefault(handle.id, []).append(handle)
+		self._intern[self._intern_key(handle)] = handle
+		self._by_name.setdefault(handle.id, []).append(handle)
 
 	def acquire(
 		self, identifier: str | None = None, *, lifetime: ChannelLifetime = "route"
@@ -229,73 +243,42 @@ class ChannelsManager:
 		if identifier is not None and identifier == "":
 			raise ValueError("Channel identifier cannot be empty")
 		channel_id = identifier or str(uuid.uuid4())
-		route_path = self._current_route_path()
 		if lifetime == "tab":
-			existing = self._tab_handles.get(channel_id)
-			if existing is not None and not existing.is_detached():
-				return existing
-			handle = Channel(self._session, channel_id, "tab")
-			self._tab_handles[channel_id] = handle
-			self._register(handle)
-			return handle
-		if route_path is None:
-			existing = self._unscoped_handles.get(channel_id)
-			if existing is not None and not existing.is_detached():
-				return existing
-			handle = Channel(self._session, channel_id, "route")
-			self._unscoped_handles[channel_id] = handle
-			self._register(handle)
-			return handle
-		key = (channel_id, route_path)
-		existing = self._route_handles.get(key)
+			route_path = None
+		else:
+			route_path = self._current_route_path()
+			if route_path is None:
+				raise RuntimeError(
+					"channel(..., lifetime='route') requires a route context"
+				)
+		key = (lifetime, channel_id, route_path)
+		existing = self._intern.get(key)
 		if existing is not None and not existing.is_detached():
 			return existing
-		handle = Channel(self._session, channel_id, "route", route_path=route_path)
-		self._route_handles[key] = handle
-		self._handles_by_route.setdefault(route_path, set()).add(handle)
+		handle = Channel(
+			self._session, channel_id, lifetime, route_path=route_path
+		)
 		self._register(handle)
-		return handle
-
-	def open_handle(
-		self, identifier: str, *, lifetime: ChannelLifetime = "route"
-	) -> Channel:
-		"""Always create a new handle on the mailbox (no intern)."""
-		if identifier == "":
-			raise ValueError("Channel identifier cannot be empty")
-		route_path = self._current_route_path() if lifetime == "route" else None
-		handle = Channel(self._session, identifier, lifetime, route_path=route_path)
-		self._register(handle)
-		if lifetime == "route" and route_path is not None:
-			self._handles_by_route.setdefault(route_path, set()).add(handle)
 		return handle
 
 	def forget_handle(self, handle: Channel) -> None:
-		self._handles.discard(handle)
-		mailbox = self._mailboxes.get(handle.id)
-		if mailbox is not None:
-			if handle in mailbox:
-				mailbox.remove(handle)
-			if not mailbox:
-				del self._mailboxes[handle.id]
-		if self._tab_handles.get(handle.id) is handle:
-			del self._tab_handles[handle.id]
+		key = self._intern_key(handle)
+		if self._intern.get(key) is handle:
+			del self._intern[key]
+		bucket = self._by_name.get(handle.id)
+		if bucket is None:
 			return
-		if self._unscoped_handles.get(handle.id) is handle:
-			del self._unscoped_handles[handle.id]
-			return
-		for key, existing in list(self._route_handles.items()):
-			if existing is not handle:
-				continue
-			del self._route_handles[key]
-			route_handles = self._handles_by_route.get(key[1])
-			if route_handles is not None:
-				route_handles.discard(handle)
-				if not route_handles:
-					del self._handles_by_route[key[1]]
-			return
+		if handle in bucket:
+			bucket.remove(handle)
+		if not bucket:
+			del self._by_name[handle.id]
 
 	def detach_route(self, route_path: str) -> None:
-		handles = list(self._handles_by_route.pop(route_path, set()))
+		handles = [
+			handle
+			for handle in self._intern.values()
+			if handle.lifetime == "route" and handle._route_path == route_path
+		]
 		for handle in handles:
 			handle.detach()
 
@@ -365,17 +348,13 @@ class ChannelsManager:
 
 	def reset(self) -> None:
 		self.fail_pending()
-		for handle in list(self._handles):
+		for handle in list(self._intern.values()):
 			handle.detach()
-		self._handles.clear()
-		self._mailboxes.clear()
-		self._route_handles.clear()
-		self._handles_by_route.clear()
-		self._tab_handles.clear()
-		self._unscoped_handles.clear()
+		self._intern.clear()
+		self._by_name.clear()
 
 	def _handles_for(self, channel_id: str) -> list[Channel]:
-		return [h for h in self._mailboxes.get(channel_id, []) if not h.is_detached()]
+		return [h for h in self._by_name.get(channel_id, []) if not h.is_detached()]
 
 	def handle_event(self, message: ClientChannelEventMessage) -> None:
 		channel_id = message["channel"]
@@ -384,7 +363,7 @@ class ChannelsManager:
 		handles = self._handles_for(channel_id)
 		if not handles:
 			logger.debug(
-				"Dropping event %s on mailbox %s (no listeners)", event, channel_id
+				"Dropping event %s on channel %s (no listeners)", event, channel_id
 			)
 			return
 		for handle in handles:
@@ -436,7 +415,7 @@ def _serialize_payload(payload: Any) -> Any:
 def channel(
 	identifier: str | None = None, *, lifetime: ChannelLifetime = "route"
 ) -> Channel:
-	"""Return a handle on a mailbox. Empty identifier raises. None generates a UUID."""
+	"""Return a handle on a channel name. Empty identifier raises. None generates a UUID."""
 	ctx = PulseContext.get()
 	if ctx.render is None:
 		raise RuntimeError("channel() requires a render session")

--- a/packages/pulse/python/src/pulse/channel.py
+++ b/packages/pulse/python/src/pulse/channel.py
@@ -1,618 +1,443 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import uuid
-from collections import defaultdict
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal
 
 from pulse.context import PulseContext
 from pulse.messages import (
+	ChannelError,
+	ChannelErrorCode,
+	ClientChannelEventMessage,
 	ClientChannelRequestMessage,
 	ClientChannelResponseMessage,
-	ServerChannelMessage,
+	ServerChannelEventMessage,
 	ServerChannelRequestMessage,
 	ServerChannelResponseMessage,
 )
-from pulse.scheduling import create_future
+from pulse.reactive_extensions import (
+	ReactiveDict,
+	ReactiveList,
+	ReactiveSet,
+	unwrap,
+)
 
 if TYPE_CHECKING:
 	from pulse.render_session import RenderSession
-	from pulse.user_session import UserSession
 
 logger = logging.getLogger(__name__)
 
-
+ChannelLifetime = Literal["route", "tab"]
 ChannelHandler = Callable[[Any], Any | Awaitable[Any]]
-"""Handler function for channel events. Can be sync or async.
-
-Type alias for ``Callable[[Any], Any | Awaitable[Any]]``.
-"""
+ChannelHandlerRemover = Callable[[], None]
 
 
-class ChannelClosed(RuntimeError):
-	"""Raised when interacting with a channel that has been closed.
+class ChannelTimeout(Exception):
+	timeout: float
+	event: str
 
-	This exception is raised when attempting to call ``on()``, ``emit()``,
-	or ``request()`` on a channel that has already been closed.
-
-	Example:
-
-	```python
-	ch = ps.channel("my-channel")
-	ch.close()
-	ch.emit("event")  # Raises ChannelClosed
-	```
-	"""
+	def __init__(self, timeout: float, event: str):
+		self.timeout = timeout
+		self.event = event
+		super().__init__(f"Channel request timed out after {timeout}s: {event}")
 
 
-class ChannelTimeout(asyncio.TimeoutError):
-	"""Raised when a channel request times out waiting for a response.
-
-	This exception is raised by ``Channel.request()`` when the specified
-	timeout elapses before receiving a response from the client.
-
-	Example:
-
-	```python
-	result = await ch.request("get_value", timeout=5.0)  # Raises if no response in 5s
-	```
-	"""
+class ChannelDetached(Exception):
+	"""Raised when `on()` is called on a detached handle."""
 
 
-@dataclass(slots=True)
-class PendingRequest:
-	future: asyncio.Future[Any]
-	channel_id: str
+class ChannelDisconnected(Exception):
+	"""Raised when a request cannot complete because the socket is down or died."""
 
 
-class ChannelsManager:
-	"""Coordinates creation, routing, and cleanup of Pulse channels."""
+class ChannelRemoteError(Exception):
+	code: ChannelErrorCode
+	message: str
 
-	_render_session: "RenderSession"
-	_channels: dict[str, "Channel"]
-	_channels_by_route: dict[str, set[str]]
-	pending_requests: dict[str, PendingRequest]
-
-	def __init__(self, render_session: "RenderSession") -> None:
-		self._render_session = render_session
-		self._channels = {}
-		self._channels_by_route = defaultdict(set)
-		self.pending_requests = {}
-
-	# ------------------------------------------------------------------
-	def create(
-		self, identifier: str | None = None, *, bind_route: bool = True
-	) -> "Channel":
-		ctx = PulseContext.get()
-		render = ctx.render
-		session = ctx.session
-		if render is None or session is None:
-			raise RuntimeError("Channels require an active render and session")
-
-		channel_id = identifier or uuid.uuid4().hex
-		if channel_id in self._channels:
-			raise ValueError(f"Channel id '{channel_id}' is already in use")
-
-		route_path: str | None = None
-		if bind_route and ctx.route is not None:
-			route_path = ctx.route.route_path
-
-		channel = Channel(
-			self,
-			channel_id,
-			render_id=render.id,
-			session_id=session.sid,
-			route_path=route_path,
-		)
-		self._channels[channel_id] = channel
-		if route_path is not None:
-			self._channels_by_route[route_path].add(channel_id)
-		return channel
-
-	# ------------------------------------------------------------------
-	def remove_route(self, path: str) -> None:
-		# route_path is already an absolute path
-		route_channels = list(self._channels_by_route.get(path, set()))
-		# if route_channels:
-		# 	print(f"Disposing {len(route_channels)} channel(s) for route {route_path}")
-		for channel_id in route_channels:
-			channel = self._channels.get(channel_id)
-			if channel is None:
-				continue
-			channel.closed = True
-			self.dispose_channel(channel, reason="route.unmount")
-		self._channels_by_route.pop(path, None)
-
-	# ------------------------------------------------------------------
-	def handle_client_response(self, message: ClientChannelResponseMessage) -> None:
-		response_to = message.get("responseTo")
-		if not response_to:
-			return
-
-		error = message.get("error")
-		if error is not None:
-			self.resolve_pending_error(response_to, error)
-		else:
-			self._resolve_pending_success(response_to, message.get("payload"))
-
-	def handle_client_event(
-		self,
-		*,
-		render: "RenderSession",
-		session: "UserSession",
-		message: ClientChannelRequestMessage,
-	) -> None:
-		channel_id = str(message.get("channel"))
-		channel = self._channels.get(channel_id)
-		if channel is None:
-			if request_id := message.get("requestId"):
-				self._send_error_response(channel_id, request_id, "Channel closed")
-			return
-
-		if channel.render_id != render.id or channel.session_id != session.sid:
-			logger.warning(
-				"Ignoring channel message for mismatched context: %s", channel_id
-			)
-			return
-
-		event = message["event"]
-		payload = message.get("payload")
-		request_id = message.get("requestId")
-
-		if event == "__close__":
-			reason: str | None = None
-			if isinstance(payload, str):
-				reason = payload
-			elif isinstance(payload, dict):
-				raw_reason = cast(Any, payload.get("reason"))
-				if raw_reason is not None:
-					reason = str(raw_reason)
-			self.release_channel(channel.id, reason=reason)
-			return
-
-		route_ctx = None
-		source_mount_id = None
-		if channel.route_path is not None:
-			try:
-				mount = render.get_route_mount(channel.route_path)
-				route_ctx = mount.route
-				source_mount_id = mount.mount_id
-			except Exception:
-				route_ctx = None
-
-		async def _invoke() -> None:
-			try:
-				with PulseContext.update(
-					session=session,
-					render=render,
-					route=route_ctx,
-					source_route_path=(
-						route_ctx.route_path if route_ctx is not None else None
-					),
-					source_path=route_ctx.pathname if route_ctx is not None else None,
-					source_mount_id=source_mount_id,
-				):
-					result = await channel.dispatch(event, payload, request_id)
-			except Exception as exc:
-				if request_id:
-					self._send_error_response(channel.id, request_id, str(exc))
-				else:
-					logger.exception("Unhandled error in channel handler")
-				return
-
-			if request_id:
-				msg = ServerChannelResponseMessage(
-					type="channel_message",
-					channel=channel.id,
-					event=None,
-					responseTo=request_id,
-					payload=result,
-				)
-				self.send_to_client(
-					channel=channel,
-					msg=msg,
-				)
-
-		render.create_task(_invoke(), name=f"channel:{channel_id}:{event}")
-
-	# ------------------------------------------------------------------
-	def register_pending(
-		self,
-		request_id: str,
-		future: asyncio.Future[Any],
-		channel_id: str,
-	) -> None:
-		self.pending_requests[request_id] = PendingRequest(
-			future=future, channel_id=channel_id
-		)
-
-	def _resolve_pending_success(self, request_id: str, payload: Any) -> None:
-		pending = self.pending_requests.pop(request_id, None)
-		if not pending:
-			return
-		if pending.future.done():
-			return
-		pending.future.set_result(payload)
-
-	def resolve_pending_error(self, request_id: str, error: Any) -> None:
-		pending = self.pending_requests.pop(request_id, None)
-		if not pending:
-			return
-		if pending.future.done():
-			return
-		if isinstance(error, Exception):
-			pending.future.set_exception(error)
-		else:
-			pending.future.set_exception(RuntimeError(str(error)))
-
-	def _send_error_response(
-		self, channel_id: str, request_id: str, message: str
-	) -> None:
-		channel = self._channels.get(channel_id)
-		if channel is None:
-			self.resolve_pending_error(request_id, ChannelClosed(message))
-			return
-		try:
-			msg = ServerChannelResponseMessage(
-				type="channel_message",
-				channel=channel.id,
-				event=None,
-				responseTo=request_id,
-				payload=None,
-				error=message,
-			)
-			self.send_to_client(
-				channel=channel,
-				msg=msg,
-			)
-		except ChannelClosed:
-			self.resolve_pending_error(request_id, ChannelClosed(message))
-
-	def send_error(self, channel_id: str, request_id: str, message: str) -> None:
-		self._send_error_response(channel_id, request_id, message)
-
-	def _cancel_pending_for_channel(self, channel_id: str) -> None:
-		for key, pending in list(self.pending_requests.items()):
-			if pending.channel_id != channel_id:
-				continue
-			if not pending.future.done():
-				pending.future.set_exception(ChannelClosed("Channel closed"))
-			self.pending_requests.pop(key, None)
-
-	# ------------------------------------------------------------------
-	def release_channel(
-		self,
-		channel_id: str,
-		*,
-		reason: str | None = None,
-	) -> bool:
-		channel = self._channels.get(channel_id)
-		if channel is None:
-			return False
-		if channel.closed:
-			# Already closed but still tracked; ensure cleanup completes.
-			self.dispose_channel(channel, reason=reason or "client.close")
-			return True
-
-		channel.closed = True
-		self.dispose_channel(channel, reason=reason or "client.close")
-		return True
-
-	# ------------------------------------------------------------------
-	def _cleanup_channel_refs(self, channel: "Channel") -> None:
-		if channel.route_path is not None:
-			route_bucket = self._channels_by_route.get(channel.route_path)
-			if route_bucket is not None:
-				route_bucket.discard(channel.id)
-				if not route_bucket:
-					self._channels_by_route.pop(channel.route_path, None)
-
-	def dispose_channel(
-		self,
-		channel: "Channel",
-		*,
-		reason: str | None = None,
-	) -> None:
-		# pending = sum(
-		# 	1
-		# 	for pending in self.pending_requests.values()
-		# 	if pending.channel_id == channel.id
-		# )
-		# print(f"Disposing channel id={channel.id} render={channel.render_id} session={channel.session_id} route={channel.route_path} reason={reason or 'unspecified'} pending={pending}")
-		self._cleanup_channel_refs(channel)
-		self._cancel_pending_for_channel(channel.id)
-		self._channels.pop(channel.id, None)
-		# Notify client that the channel has been closed
-		try:
-			msg = ServerChannelRequestMessage(
-				type="channel_message",
-				channel=channel.id,
-				event="__close__",
-				payload=None,
-			)
-			self.send_to_client(
-				channel=channel,
-				msg=msg,
-			)
-		except Exception:
-			print(f"Failed to send close notification for channel {channel.id}")
-
-	def send_to_client(
-		self,
-		*,
-		channel: "Channel",
-		msg: ServerChannelMessage,
-	) -> None:
-		self._render_session.send(msg)
+	def __init__(self, code: ChannelErrorCode, message: str):
+		self.code = code
+		self.message = message
+		super().__init__(f"{code}: {message}")
 
 
 class Channel:
-	"""Bidirectional communication channel bound to a render session.
+	"""A local handle on a mailbox. Messages route by `id`."""
 
-	Channels enable real-time messaging between server and client. Use
-	``ps.channel()`` to create a channel within a component.
-
-	Attributes:
-		id: Channel identifier (auto-generated UUID or user-provided).
-		render_id: Associated render session ID.
-		session_id: Associated user session ID.
-		route_path: Route path this channel is bound to, or None.
-		closed: Whether the channel has been closed.
-
-	Example:
-
-	```python
-	@ps.component
-	def ChatRoom():
-	    ch = ps.channel("chat")
-
-	    @ch.on("message")
-	    def handle_message(payload):
-	        ch.emit("broadcast", payload)
-
-	    return ps.div("Chat room")
-	```
-	"""
-
-	_manager: ChannelsManager
-	id: str
-	render_id: str
-	session_id: str
-	route_path: str | None
+	_session: RenderSession
+	_id: str
+	_lifetime: ChannelLifetime
+	_route_path: str | None
 	_handlers: dict[str, list[ChannelHandler]]
-	closed: bool
+	_detached: bool
 
 	def __init__(
 		self,
-		manager: ChannelsManager,
+		session: RenderSession,
 		identifier: str,
+		lifetime: ChannelLifetime,
 		*,
-		render_id: str,
-		session_id: str,
-		route_path: str | None,
-	) -> None:
-		self._manager = manager
-		self.id = identifier
-		self.render_id = render_id
-		self.session_id = session_id
-		self.route_path = route_path
-		self._handlers = defaultdict(list)
-		self.closed = False
+		route_path: str | None = None,
+	):
+		self._session = session
+		self._id = identifier
+		self._lifetime = lifetime
+		self._route_path = route_path
+		self._handlers = {}
+		self._detached = False
 
-	# ---------------------------------------------------------------------
-	# Registration
-	# ---------------------------------------------------------------------
-	def on(self, event: str, handler: ChannelHandler) -> Callable[[], None]:
-		"""Register a handler for an incoming event.
+	@property
+	def id(self) -> str:
+		return self._id
 
-		Args:
-			event: Event name to listen for.
-			handler: Callback function ``(payload: Any) -> Any | Awaitable[Any]``.
+	@property
+	def lifetime(self) -> ChannelLifetime:
+		return self._lifetime
 
-		Returns:
-			Callable that removes the handler when invoked.
+	def _assert_attached(self) -> None:
+		if self._detached:
+			raise ChannelDetached(f"Channel {self._id} is detached")
 
-		Raises:
-			ChannelClosed: If the channel is closed.
+	def on(self, event: str, handler: ChannelHandler) -> ChannelHandlerRemover:
+		self._assert_attached()
+		handlers = self._handlers.setdefault(event, [])
+		handlers.append(handler)
 
-		Example:
-
-		```python
-		ch = ps.channel()
-		remove_handler = ch.on("data", lambda payload: print(payload))
-		# Later, to unregister:
-		remove_handler()
-		```
-		"""
-
-		self._ensure_open()
-		bucket = self._handlers[event]
-		bucket.append(handler)
-
-		def _remove() -> None:
-			handlers = self._handlers.get(event)
-			if not handlers:
-				return
-			try:
+		def remove() -> None:
+			if handler in handlers:
 				handlers.remove(handler)
-			except ValueError:
-				return
 			if not handlers:
 				self._handlers.pop(event, None)
 
-		return _remove
+		return remove
 
-	# ---------------------------------------------------------------------
-	# Outgoing messages
-	# ---------------------------------------------------------------------
 	def emit(self, event: str, payload: Any = None) -> None:
-		"""Send a fire-and-forget event to the client.
-
-		Args:
-			event: Event name.
-			payload: Data to send (optional).
-
-		Raises:
-			ChannelClosed: If the channel is closed.
-
-		Example:
-
-		```python
-		ch.emit("notification", {"message": "Hello"})
-		```
-		"""
-
-		self._ensure_open()
-		msg = ServerChannelRequestMessage(
-			type="channel_message",
-			channel=self.id,
-			event=event,
-			payload=payload,
-		)
-		self._manager.send_to_client(
-			channel=self,
-			msg=msg,
-		)
+		self._session.channels.send_event(self._id, event, payload)
 
 	async def request(
-		self,
-		event: str,
-		payload: Any = None,
-		*,
-		timeout: float | None = None,
+		self, event: str, payload: Any = None, *, timeout: float | None = None
 	) -> Any:
-		"""Send a request to the client and await the response.
-
-		Args:
-			event: Event name.
-			payload: Data to send (optional).
-			timeout: Timeout in seconds (optional).
-
-		Returns:
-			Response payload from client.
-
-		Raises:
-			ChannelClosed: If the channel is closed.
-			ChannelTimeout: If the request times out.
-
-		Example:
-
-		```python
-		result = await ch.request("get_value", timeout=5.0)
-		```
-		"""
-
-		self._ensure_open()
-		request_id = uuid.uuid4().hex
-		fut = create_future()
-		self._manager.register_pending(request_id, fut, self.id)
-		msg = ServerChannelRequestMessage(
-			type="channel_message",
-			channel=self.id,
-			event=event,
-			payload=payload,
-			requestId=request_id,
-		)
-		self._manager.send_to_client(
-			channel=self,
-			msg=msg,
-		)
+		if not self._session.channels.can_request():
+			raise ChannelDisconnected("No render session is connected")
+		request_id = str(uuid.uuid4())
+		future: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
+		self._session.channels.register_pending(request_id, future)
+		self._session.channels.send_request(self._id, event, payload, request_id)
 		try:
 			if timeout is None:
-				return await fut
-			return await asyncio.wait_for(fut, timeout=timeout)
-		except TimeoutError as exc:
-			self._manager.resolve_pending_error(
-				request_id,
-				ChannelTimeout("Channel request timed out"),
-			)
-			raise ChannelTimeout("Channel request timed out") from exc
-		finally:
-			self._manager.pending_requests.pop(request_id, None)
+				return await future
+			return await asyncio.wait_for(future, timeout)
+		except TimeoutError:
+			self._session.channels.cancel_pending(request_id)
+			raise ChannelTimeout(timeout or 0, event) from None
 
-	# ---------------------------------------------------------------------
-	def close(self) -> None:
-		"""Close the channel and clean up resources.
+	def is_detached(self) -> bool:
+		return self._detached
 
-		After closing, any further operations on the channel will raise
-		``ChannelClosed``. Pending requests will be cancelled.
-		"""
-		if self.closed:
+	def has_handler(self, event: str) -> bool:
+		return event in self._handlers
+
+	def detach(self) -> None:
+		if self._detached:
 			return
-		self.closed = True
+		self._detached = True
 		self._handlers.clear()
-		self._manager.dispose_channel(self, reason="channel.close")
+		self._session.channels.forget_handle(self)
 
-	# ---------------------------------------------------------------------
-	def _ensure_open(self) -> None:
-		if self.closed:
-			raise ChannelClosed(f"Channel '{self.id}' is closed")
+	def dispatch_event(self, event: str, payload: Any) -> None:
+		if self._detached:
+			return
+		for handler in list(self._handlers.get(event, [])):
+			self._session.create_task(
+				self._invoke_handler(handler, payload, required=False),
+				name=f"channel:{self._id}:{event}",
+			)
 
-	async def dispatch(
-		self, event: str, payload: Any, request_id: str | None
-	) -> Any | None:
-		handlers = list(self._handlers.get(event, ()))
+	async def dispatch_request(self, event: str, payload: Any) -> Any:
+		if self._detached:
+			return None
+		handlers = list(self._handlers.get(event, []))
 		if not handlers:
 			return None
+		return await self._invoke_handler(handlers[0], payload, required=True)
 
-		last_result: Any | None = None
-		for handler in handlers:
-			try:
-				result = handler(payload)
-				if asyncio.iscoroutine(result):
-					result = await result
-			except Exception as exc:
-				logger.exception(
-					"Error in channel handler '%s' for event '%s'", self.id, event
+	async def _invoke_handler(
+		self, handler: ChannelHandler, payload: Any, *, required: bool
+	) -> Any:
+		from pulse.context import PULSE_CONTEXT
+		from pulse.helpers import maybe_await
+
+		render = self._session
+		route_ctx = None
+		source_mount_id = None
+		if self._lifetime == "route" and self._route_path:
+			mount = render.route_mounts.get(self._route_path)
+			if mount is None:
+				if not required:
+					logger.debug(
+						"Skipping channel %s handler; route %s is gone",
+						self._id,
+						self._route_path,
+					)
+					return None
+				raise RuntimeError(
+					f"Route {self._route_path} is gone for channel {self._id}"
 				)
-				raise exc
-			if request_id is not None and result is not None:
-				return result
-			if result is not None:
-				last_result = result
-		return last_result
+			route_ctx = mount.route
+			source_mount_id = mount.mount_id
+
+		if PULSE_CONTEXT.get() is None:
+			return await maybe_await(handler(payload))
+		with PulseContext.update(
+			render=render,
+			route=route_ctx,
+			source_route_path=route_ctx.route_path if route_ctx is not None else None,
+			source_path=route_ctx.pathname if route_ctx is not None else None,
+			source_mount_id=source_mount_id,
+		):
+			return await maybe_await(handler(payload))
 
 
-def channel(identifier: str | None = None) -> Channel:
-	"""Create a channel bound to the current render session.
+class ChannelsManager:
+	_session: RenderSession
 
-	Args:
-		identifier: Optional channel ID. Auto-generated UUID if not provided.
+	def __init__(self, session: RenderSession):
+		self._session = session
+		self._handles: set[Channel] = set()
+		self._mailboxes: dict[str, list[Channel]] = {}
+		self._route_handles: dict[tuple[str, str], Channel] = {}
+		self._handles_by_route: dict[str, set[Channel]] = {}
+		self._tab_handles: dict[str, Channel] = {}
+		self._unscoped_handles: dict[str, Channel] = {}
+		self._pending: dict[str, asyncio.Future[Any]] = {}
 
-	Returns:
-		Channel instance.
+	def can_request(self) -> bool:
+		return self._session.connected
 
-	Raises:
-		RuntimeError: If called outside an active render session.
+	def _current_route_path(self) -> str | None:
+		route = PulseContext.get().route
+		return route.route_path if route is not None else None
 
-	Example:
+	def _register(self, handle: Channel) -> None:
+		self._handles.add(handle)
+		self._mailboxes.setdefault(handle.id, []).append(handle)
 
-	```python
-	import pulse as ps
+	def acquire(
+		self, identifier: str | None = None, *, lifetime: ChannelLifetime = "route"
+	) -> Channel:
+		if identifier is not None and identifier == "":
+			raise ValueError("Channel identifier cannot be empty")
+		channel_id = identifier or str(uuid.uuid4())
+		route_path = self._current_route_path()
+		if lifetime == "tab":
+			existing = self._tab_handles.get(channel_id)
+			if existing is not None and not existing.is_detached():
+				return existing
+			handle = Channel(self._session, channel_id, "tab")
+			self._tab_handles[channel_id] = handle
+			self._register(handle)
+			return handle
+		if route_path is None:
+			existing = self._unscoped_handles.get(channel_id)
+			if existing is not None and not existing.is_detached():
+				return existing
+			handle = Channel(self._session, channel_id, "route")
+			self._unscoped_handles[channel_id] = handle
+			self._register(handle)
+			return handle
+		key = (channel_id, route_path)
+		existing = self._route_handles.get(key)
+		if existing is not None and not existing.is_detached():
+			return existing
+		handle = Channel(self._session, channel_id, "route", route_path=route_path)
+		self._route_handles[key] = handle
+		self._handles_by_route.setdefault(route_path, set()).add(handle)
+		self._register(handle)
+		return handle
 
-	@ps.component
-	def ChatRoom():
-	    ch = ps.channel("chat")
+	def open_handle(
+		self, identifier: str, *, lifetime: ChannelLifetime = "route"
+	) -> Channel:
+		"""Always create a new handle on the mailbox (no intern)."""
+		if identifier == "":
+			raise ValueError("Channel identifier cannot be empty")
+		route_path = self._current_route_path() if lifetime == "route" else None
+		handle = Channel(self._session, identifier, lifetime, route_path=route_path)
+		self._register(handle)
+		if lifetime == "route" and route_path is not None:
+			self._handles_by_route.setdefault(route_path, set()).add(handle)
+		return handle
 
-	    @ch.on("message")
-	    def handle_message(payload):
-	        ch.emit("broadcast", payload)
+	def forget_handle(self, handle: Channel) -> None:
+		self._handles.discard(handle)
+		mailbox = self._mailboxes.get(handle.id)
+		if mailbox is not None:
+			if handle in mailbox:
+				mailbox.remove(handle)
+			if not mailbox:
+				del self._mailboxes[handle.id]
+		if self._tab_handles.get(handle.id) is handle:
+			del self._tab_handles[handle.id]
+			return
+		if self._unscoped_handles.get(handle.id) is handle:
+			del self._unscoped_handles[handle.id]
+			return
+		for key, existing in list(self._route_handles.items()):
+			if existing is not handle:
+				continue
+			del self._route_handles[key]
+			route_handles = self._handles_by_route.get(key[1])
+			if route_handles is not None:
+				route_handles.discard(handle)
+				if not route_handles:
+					del self._handles_by_route[key[1]]
+			return
 
-	    return ps.div("Chat room")
-	```
-	"""
+	def detach_route(self, route_path: str) -> None:
+		handles = list(self._handles_by_route.pop(route_path, set()))
+		for handle in handles:
+			handle.detach()
 
+	def send_event(self, channel_id: str, event: str, payload: Any) -> None:
+		message: ServerChannelEventMessage = {
+			"type": "channel",
+			"action": "event",
+			"channel": channel_id,
+			"event": event,
+		}
+		if payload is not None:
+			message["payload"] = _serialize_payload(payload)
+		self._session.send(message)
+
+	def send_request(
+		self, channel_id: str, event: str, payload: Any, request_id: str
+	) -> None:
+		message: ServerChannelRequestMessage = {
+			"type": "channel",
+			"action": "request",
+			"channel": channel_id,
+			"event": event,
+			"requestId": request_id,
+		}
+		if payload is not None:
+			message["payload"] = _serialize_payload(payload)
+		self._session.send(message)
+
+	def send_response(
+		self,
+		channel_id: str,
+		request_id: str,
+		payload: Any = None,
+		error: ChannelError | None = None,
+	) -> None:
+		message: ServerChannelResponseMessage = {
+			"type": "channel",
+			"action": "response",
+			"channel": channel_id,
+			"responseTo": request_id,
+		}
+		if error is not None:
+			message["error"] = error
+		elif payload is not None:
+			message["payload"] = _serialize_payload(payload)
+		self._session.send(message)
+
+	def send_error(
+		self, channel_id: str, request_id: str, code: ChannelErrorCode, message: str
+	) -> None:
+		self.send_response(
+			channel_id, request_id, error={"code": code, "message": message}
+		)
+
+	def register_pending(self, request_id: str, future: asyncio.Future[Any]) -> None:
+		self._pending[request_id] = future
+
+	def cancel_pending(self, request_id: str) -> None:
+		self._pending.pop(request_id, None)
+
+	def fail_pending(self) -> None:
+		pending = list(self._pending.values())
+		self._pending.clear()
+		for future in pending:
+			if not future.done():
+				future.set_exception(ChannelDisconnected("Render session disconnected"))
+
+	def reset(self) -> None:
+		self.fail_pending()
+		for handle in list(self._handles):
+			handle.detach()
+		self._handles.clear()
+		self._mailboxes.clear()
+		self._route_handles.clear()
+		self._handles_by_route.clear()
+		self._tab_handles.clear()
+		self._unscoped_handles.clear()
+
+	def _handles_for(self, channel_id: str) -> list[Channel]:
+		return [h for h in self._mailboxes.get(channel_id, []) if not h.is_detached()]
+
+	def handle_event(self, message: ClientChannelEventMessage) -> None:
+		channel_id = message["channel"]
+		event = message["event"]
+		payload = message.get("payload")
+		handles = self._handles_for(channel_id)
+		if not handles:
+			logger.debug(
+				"Dropping event %s on mailbox %s (no listeners)", event, channel_id
+			)
+			return
+		for handle in handles:
+			handle.dispatch_event(event, payload)
+
+	async def handle_request(self, message: ClientChannelRequestMessage) -> None:
+		channel_id = message["channel"]
+		event = message["event"]
+		payload = message.get("payload")
+		request_id = message["requestId"]
+		for handle in self._handles_for(channel_id):
+			if not handle.has_handler(event):
+				continue
+			try:
+				result = await handle.dispatch_request(event, payload)
+			except Exception:
+				logger.exception("Channel %s handler for %s failed", channel_id, event)
+				self.send_error(
+					channel_id, request_id, "handler_error", "Channel handler failed"
+				)
+				return
+			self.send_response(channel_id, request_id, result)
+			return
+		self.send_error(
+			channel_id,
+			request_id,
+			"no_handler",
+			f"No handler for '{event}' on channel '{channel_id}'",
+		)
+
+	def handle_response(self, message: ClientChannelResponseMessage) -> None:
+		request_id = message["responseTo"]
+		future = self._pending.pop(request_id, None)
+		if future is None or future.done():
+			return
+		error = message.get("error")
+		if error is not None:
+			future.set_exception(ChannelRemoteError(error["code"], error["message"]))
+			return
+		future.set_result(message.get("payload"))
+
+
+def _serialize_payload(payload: Any) -> Any:
+	if isinstance(payload, ReactiveDict | ReactiveList | ReactiveSet):
+		return unwrap(payload)
+	return payload
+
+
+def channel(
+	identifier: str | None = None, *, lifetime: ChannelLifetime = "route"
+) -> Channel:
+	"""Return a handle on a mailbox. Empty identifier raises. None generates a UUID."""
 	ctx = PulseContext.get()
 	if ctx.render is None:
-		raise RuntimeError("Channels require an active render session")
-	return ctx.render.channels.create(identifier)
-
-
-__all__ = [
-	"ChannelsManager",
-	"Channel",
-	"ChannelClosed",
-	"ChannelTimeout",
-	"channel",
-]
+		raise RuntimeError("channel() requires a render session")
+	return ctx.render.channels.acquire(identifier, lifetime=lifetime)

--- a/packages/pulse/python/src/pulse/channel.py
+++ b/packages/pulse/python/src/pulse/channel.py
@@ -160,7 +160,7 @@ class Channel:
 			return
 		if exc is None:
 			return
-		self._session.report_error(self._route_path or "/", "channel", exc)
+		self._session.report_error(self._route_path, "channel", exc)
 
 	def dispatch_event(self, event: str, payload: Any) -> None:
 		if self._detached:

--- a/packages/pulse/python/src/pulse/channel.py
+++ b/packages/pulse/python/src/pulse/channel.py
@@ -96,6 +96,10 @@ class Channel:
 	def lifetime(self) -> ChannelLifetime:
 		return self._lifetime
 
+	@property
+	def route_path(self) -> str | None:
+		return self._route_path
+
 	def _assert_attached(self) -> None:
 		if self._detached:
 			raise ChannelDetached(f"Channel {self._id} is detached")
@@ -231,7 +235,7 @@ class ChannelsManager:
 		return route.route_path if route is not None else None
 
 	def _intern_key(self, handle: Channel) -> ChannelInternKey:
-		return (handle.lifetime, handle.id, handle._route_path)
+		return (handle.lifetime, handle.id, handle.route_path)
 
 	def _register(self, handle: Channel) -> None:
 		self._intern[self._intern_key(handle)] = handle
@@ -255,9 +259,7 @@ class ChannelsManager:
 		existing = self._intern.get(key)
 		if existing is not None and not existing.is_detached():
 			return existing
-		handle = Channel(
-			self._session, channel_id, lifetime, route_path=route_path
-		)
+		handle = Channel(self._session, channel_id, lifetime, route_path=route_path)
 		self._register(handle)
 		return handle
 
@@ -277,7 +279,7 @@ class ChannelsManager:
 		handles = [
 			handle
 			for handle in self._intern.values()
-			if handle.lifetime == "route" and handle._route_path == route_path
+			if handle.lifetime == "route" and handle.route_path == route_path
 		]
 		for handle in handles:
 			handle.detach()

--- a/packages/pulse/python/src/pulse/channel.py
+++ b/packages/pulse/python/src/pulse/channel.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
+from collections import deque
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -23,6 +24,7 @@ from pulse.reactive_extensions import (
 	ReactiveSet,
 	unwrap,
 )
+from pulse.serializer import serialize
 
 if TYPE_CHECKING:
 	from pulse.render_session import RenderSession
@@ -72,6 +74,8 @@ class Channel:
 	_route_path: str | None
 	_handlers: dict[str, list[ChannelHandler]]
 	_detached: bool
+	_events: deque[tuple[str, Any]]
+	_pump: asyncio.Task[None] | None
 
 	def __init__(
 		self,
@@ -87,6 +91,8 @@ class Channel:
 		self._route_path = route_path
 		self._handlers = {}
 		self._detached = False
+		self._events = deque()
+		self._pump = None
 
 	@property
 	def id(self) -> str:
@@ -119,24 +125,31 @@ class Channel:
 		return remove
 
 	def emit(self, event: str, payload: Any = None) -> None:
+		# Emits legitimately race detach (background tasks): no-op instead of raising.
+		if self._detached:
+			logger.debug("Dropping emit %s on detached channel %s", event, self._id)
+			return
 		self._session.channels.send_event(self._id, event, payload)
 
 	async def request(
 		self, event: str, payload: Any = None, *, timeout: float | None = None
 	) -> Any:
+		self._assert_attached()
 		if not self._session.channels.can_request():
 			raise ChannelDisconnected("No render session is connected")
 		request_id = str(uuid.uuid4())
 		future: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
-		self._session.channels.register_pending(request_id, future)
-		self._session.channels.send_request(self._id, event, payload, request_id)
+		self._session.channels.register_pending(request_id, self._id, future)
 		try:
+			self._session.channels.send_request(self._id, event, payload, request_id)
 			if timeout is None:
 				return await future
 			return await asyncio.wait_for(future, timeout)
 		except TimeoutError:
-			self._session.channels.cancel_pending(request_id)
 			raise ChannelTimeout(timeout or 0, event) from None
+		finally:
+			# Covers timeout, caller cancellation and send failures alike.
+			self._session.channels.forget_pending(request_id)
 
 	def is_detached(self) -> bool:
 		return self._detached
@@ -149,6 +162,7 @@ class Channel:
 			return
 		self._detached = True
 		self._handlers.clear()
+		self._events.clear()
 		self._session.channels.forget_handle(self)
 
 	def _report_task_error(self, task: asyncio.Task[Any]) -> None:
@@ -163,16 +177,32 @@ class Channel:
 		self._session.report_error(self._route_path, "channel", exc)
 
 	def dispatch_event(self, event: str, payload: Any) -> None:
+		"""Queue an event. One serial pump per handle keeps events in arrival order."""
 		if self._detached:
 			return
-		for handler in list(self._handlers.get(event, [])):
-			self._session.create_task(
-				self._invoke_handler(handler, payload, required=False),
-				name=f"channel:{self._id}:{event}",
-				on_done=self._report_task_error,
-			)
+		self._events.append((event, payload))
+		if self._pump is not None and not self._pump.done():
+			return
+		self._pump = self._session.create_task(
+			self._pump_events(),
+			name=f"channel:{self._id}",
+			on_done=self._report_task_error,
+		)
+
+	async def _pump_events(self) -> None:
+		while self._events:
+			event, payload = self._events.popleft()
+			for handler in list(self._handlers.get(event, [])):
+				# Detach can land while an earlier handler was awaiting.
+				if self._detached:
+					return
+				try:
+					await self._invoke_handler(handler, payload, required=False)
+				except Exception as exc:
+					self._session.report_error(self._route_path, "channel", exc)
 
 	async def dispatch_request(self, event: str, payload: Any) -> Any:
+		"""Runs outside the event pump: request handlers may await client RPCs."""
 		if self._detached:
 			return None
 		handlers = list(self._handlers.get(event, []))
@@ -225,7 +255,8 @@ class ChannelsManager:
 		# (lifetime, channel_id, route_path) → live handle
 		self._intern: dict[ChannelInternKey, Channel] = {}
 		self._by_name: dict[str, list[Channel]] = {}
-		self._pending: dict[str, asyncio.Future[Any]] = {}
+		# request id → (channel id, future)
+		self._pending: dict[str, tuple[str, asyncio.Future[Any]]] = {}
 
 	def can_request(self) -> bool:
 		return self._session.connected
@@ -294,7 +325,7 @@ class ChannelsManager:
 			"event": event,
 		}
 		if payload is not None:
-			message["payload"] = _serialize_payload(payload)
+			message["payload"] = _wire_payload(channel_id, event, payload)
 		self._session.send(message)
 
 	def send_request(
@@ -308,7 +339,7 @@ class ChannelsManager:
 			"requestId": request_id,
 		}
 		if payload is not None:
-			message["payload"] = _serialize_payload(payload)
+			message["payload"] = _wire_payload(channel_id, event, payload)
 		self._session.send(message)
 
 	def send_response(
@@ -327,7 +358,7 @@ class ChannelsManager:
 		if error is not None:
 			message["error"] = error
 		elif payload is not None:
-			message["payload"] = _serialize_payload(payload)
+			message["payload"] = _wire_payload(channel_id, request_id, payload)
 		self._session.send(message)
 
 	def send_error(
@@ -337,14 +368,16 @@ class ChannelsManager:
 			channel_id, request_id, error={"code": code, "message": message}
 		)
 
-	def register_pending(self, request_id: str, future: asyncio.Future[Any]) -> None:
-		self._pending[request_id] = future
+	def register_pending(
+		self, request_id: str, channel_id: str, future: asyncio.Future[Any]
+	) -> None:
+		self._pending[request_id] = (channel_id, future)
 
-	def cancel_pending(self, request_id: str) -> None:
+	def forget_pending(self, request_id: str) -> None:
 		self._pending.pop(request_id, None)
 
 	def fail_pending(self) -> None:
-		pending = list(self._pending.values())
+		pending = [future for _, future in self._pending.values()]
 		self._pending.clear()
 		for future in pending:
 			if not future.done():
@@ -399,8 +432,20 @@ class ChannelsManager:
 
 	def handle_response(self, message: ClientChannelResponseMessage) -> None:
 		request_id = message["responseTo"]
-		future = self._pending.pop(request_id, None)
-		if future is None or future.done():
+		entry = self._pending.get(request_id)
+		if entry is None:
+			return
+		channel_id, future = entry
+		if message["channel"] != channel_id:
+			logger.warning(
+				"Ignoring response for %s: claims channel %s, expected %s",
+				request_id,
+				message["channel"],
+				channel_id,
+			)
+			return
+		del self._pending[request_id]
+		if future.done():
 			return
 		error = message.get("error")
 		if error is not None:
@@ -409,9 +454,17 @@ class ChannelsManager:
 		future.set_result(message.get("payload"))
 
 
-def _serialize_payload(payload: Any) -> Any:
+def _wire_payload(channel_id: str, label: str, payload: Any) -> Any:
 	if isinstance(payload, ReactiveDict | ReactiveList | ReactiveSet):
-		return unwrap(payload)
+		payload = unwrap(payload)
+	# Serialize eagerly to fail at the emitter: a bad payload sitting on the
+	# disconnect queue would otherwise blow up at flush time, far from its origin.
+	try:
+		serialize(payload)
+	except (TypeError, ValueError) as exc:
+		raise TypeError(
+			f"Channel {channel_id!r} payload for {label!r} is not serializable: {exc}"
+		) from exc
 	return payload
 
 

--- a/packages/pulse/python/src/pulse/channel.py
+++ b/packages/pulse/python/src/pulse/channel.py
@@ -113,7 +113,7 @@ class Channel:
 		def remove() -> None:
 			if handler in handlers:
 				handlers.remove(handler)
-			if not handlers:
+			if self._handlers.get(event) is handlers and not handlers:
 				self._handlers.pop(event, None)
 
 		return remove
@@ -246,6 +246,8 @@ class ChannelsManager:
 	) -> Channel:
 		if identifier is not None and identifier == "":
 			raise ValueError("Channel identifier cannot be empty")
+		if lifetime not in ("route", "tab"):
+			raise ValueError(f"Invalid channel lifetime {lifetime!r}")
 		channel_id = identifier or str(uuid.uuid4())
 		if lifetime == "tab":
 			route_path = None
@@ -381,13 +383,12 @@ class ChannelsManager:
 				continue
 			try:
 				result = await handle.dispatch_request(event, payload)
+				self.send_response(channel_id, request_id, result)
 			except Exception:
 				logger.exception("Channel %s handler for %s failed", channel_id, event)
 				self.send_error(
 					channel_id, request_id, "handler_error", "Channel handler failed"
 				)
-				return
-			self.send_response(channel_id, request_id, result)
 			return
 		self.send_error(
 			channel_id,

--- a/packages/pulse/python/src/pulse/channel.py
+++ b/packages/pulse/python/src/pulse/channel.py
@@ -36,6 +36,10 @@ ChannelInternKey = tuple[ChannelLifetime, str, str | None]
 ChannelHandler = Callable[[Any], Any | Awaitable[Any]]
 ChannelHandlerRemover = Callable[[], None]
 
+# Cap on events waiting on a handle's serial pump (drop-oldest past this): a
+# handler that awaits for a long time must not grow the backlog without bound.
+MAX_QUEUED_EVENTS = 500
+
 
 class ChannelTimeout(Exception):
 	timeout: float
@@ -76,6 +80,7 @@ class Channel:
 	_detached: bool
 	_events: deque[tuple[str, Any]]
 	_pump: asyncio.Task[None] | None
+	_events_overflowed: bool
 
 	def __init__(
 		self,
@@ -91,8 +96,9 @@ class Channel:
 		self._route_path = route_path
 		self._handlers = {}
 		self._detached = False
-		self._events = deque()
+		self._events = deque(maxlen=MAX_QUEUED_EVENTS)
 		self._pump = None
+		self._events_overflowed = False
 
 	@property
 	def id(self) -> str:
@@ -163,6 +169,9 @@ class Channel:
 		self._detached = True
 		self._handlers.clear()
 		self._events.clear()
+		if self._pump is not None:
+			self._pump.cancel()
+			self._pump = None
 		self._session.channels.forget_handle(self)
 
 	def _report_task_error(self, task: asyncio.Task[Any]) -> None:
@@ -180,6 +189,14 @@ class Channel:
 		"""Queue an event. One serial pump per handle keeps events in arrival order."""
 		if self._detached:
 			return
+		if len(self._events) == MAX_QUEUED_EVENTS and not self._events_overflowed:
+			# Nothing sensible to do but shed load: a handler is holding the pump.
+			self._events_overflowed = True
+			logger.warning(
+				"Channel %s event backlog hit %d; dropping oldest events",
+				self._id,
+				MAX_QUEUED_EVENTS,
+			)
 		self._events.append((event, payload))
 		if self._pump is not None and not self._pump.done():
 			return
@@ -325,7 +342,7 @@ class ChannelsManager:
 			"event": event,
 		}
 		if payload is not None:
-			message["payload"] = _wire_payload(channel_id, event, payload)
+			message["payload"] = self._wire_payload(channel_id, event, payload)
 		self._session.send(message)
 
 	def send_request(
@@ -339,7 +356,7 @@ class ChannelsManager:
 			"requestId": request_id,
 		}
 		if payload is not None:
-			message["payload"] = _wire_payload(channel_id, event, payload)
+			message["payload"] = self._wire_payload(channel_id, event, payload)
 		self._session.send(message)
 
 	def send_response(
@@ -358,7 +375,7 @@ class ChannelsManager:
 		if error is not None:
 			message["error"] = error
 		elif payload is not None:
-			message["payload"] = _wire_payload(channel_id, request_id, payload)
+			message["payload"] = self._wire_payload(channel_id, request_id, payload)
 		self._session.send(message)
 
 	def send_error(
@@ -453,19 +470,20 @@ class ChannelsManager:
 			return
 		future.set_result(message.get("payload"))
 
-
-def _wire_payload(channel_id: str, label: str, payload: Any) -> Any:
-	if isinstance(payload, ReactiveDict | ReactiveList | ReactiveSet):
-		payload = unwrap(payload)
-	# Serialize eagerly to fail at the emitter: a bad payload sitting on the
-	# disconnect queue would otherwise blow up at flush time, far from its origin.
-	try:
-		serialize(payload)
-	except (TypeError, ValueError) as exc:
-		raise TypeError(
-			f"Channel {channel_id!r} payload for {label!r} is not serializable: {exc}"
-		) from exc
-	return payload
+	def _wire_payload(self, channel_id: str, label: str, payload: Any) -> Any:
+		if isinstance(payload, ReactiveDict | ReactiveList | ReactiveSet):
+			payload = unwrap(payload)
+		if not self._session.connected:
+			# The message goes on the disconnect queue, where a serialization
+			# failure would only surface at flush time, far from its origin.
+			# While connected the socket serializes it here, in the caller's frame.
+			try:
+				serialize(payload)
+			except (TypeError, ValueError) as exc:
+				raise TypeError(
+					f"Channel {channel_id!r} payload for {label!r} is not serializable: {exc}"
+				) from exc
+		return payload
 
 
 def channel(

--- a/packages/pulse/python/src/pulse/channel.py
+++ b/packages/pulse/python/src/pulse/channel.py
@@ -230,7 +230,6 @@ class Channel:
 	async def _invoke_handler(
 		self, handler: ChannelHandler, payload: Any, *, required: bool
 	) -> Any:
-		from pulse.context import PULSE_CONTEXT
 		from pulse.helpers import maybe_await
 
 		render = self._session
@@ -252,8 +251,6 @@ class Channel:
 			route_ctx = mount.route
 			source_mount_id = mount.mount_id
 
-		if PULSE_CONTEXT.get() is None:
-			return await maybe_await(handler(payload))
 		with PulseContext.update(
 			render=render,
 			route=route_ctx,

--- a/packages/pulse/python/src/pulse/js/pulse.py
+++ b/packages/pulse/python/src/pulse/js/pulse.py
@@ -4,7 +4,7 @@ Pulse UI client bindings for channel communication.
 Usage:
 
 ```python
-from pulse.js.pulse import usePulseChannel, ChannelBridge, PulseChannelResetError
+from pulse.js.pulse import usePulseChannel, ChannelBridge
 
 @ps.javascript(jsx=True)
 def MyChannelComponent(*, channel_id: str):
@@ -12,19 +12,16 @@ def MyChannelComponent(*, channel_id: str):
 
     # Subscribe to events
     useEffect(
-        lambda: bridge and bridge.on("server:notify", lambda payload: console.log(payload)),
+        lambda: bridge.on("server:notify", lambda payload: console.log(payload)),
         [bridge],
     )
 
     # Emit events to server
     def send_ping():
-        if bridge:
-            bridge.emit("client:ping", {"message": "hello"})
+        bridge.emit("client:ping", {"message": "hello"})
 
     # Make requests to server
     async def send_request():
-        if not bridge:
-            return
         response = await bridge.request("client:request", {"data": 123})
         console.log(response)
 
@@ -45,18 +42,26 @@ from pulse.transpiler.js_module import JsModule
 T = _TypeVar("T")
 
 
-class PulseChannelResetError(Exception):
-	"""Error raised when a channel is closed or reset."""
+class PulseChannelDetachedError(Exception):
+	"""Raised when `on()` is called on a detached handle."""
+
+	pass
+
+
+class PulseChannelDisconnectedError(Exception):
+	"""Raised when a request cannot complete because the socket is down."""
+
+	pass
+
+
+class PulseChannelRemoteError(Exception):
+	"""Raised when the peer responds with an error."""
 
 	pass
 
 
 class ChannelBridge:
-	"""A bridge for bidirectional communication between client and server.
-
-	Provides methods for emitting events, making requests, and subscribing
-	to server events on a specific channel.
-	"""
+	"""A local handle on a mailbox. Messages route by `id`."""
 
 	@property
 	def id(self) -> str:
@@ -99,17 +104,17 @@ class ChannelBridge:
 		...
 
 
-def usePulseChannel(channel_id: str) -> ChannelBridge | None:
-	"""React hook to connect to a Pulse channel.
+def usePulseChannel(channel_id: str) -> ChannelBridge:
+	"""React hook to attach a handle to a Pulse mailbox.
 
-	Must be called from within a React component. The channel connection
-	is automatically managed based on component lifecycle.
+	Must be called from within a React component. Client lifetime is React
+	placement (route component vs layout).
 
 	Args:
-	    channel_id: The unique identifier for the channel to connect to.
+	    channel_id: The mailbox identifier.
 
 	Returns:
-	    A ChannelBridge instance for interacting with the channel.
+	    A ChannelBridge handle for that mailbox.
 	"""
 	...
 

--- a/packages/pulse/python/src/pulse/js/pulse.py
+++ b/packages/pulse/python/src/pulse/js/pulse.py
@@ -43,7 +43,7 @@ T = _TypeVar("T")
 
 
 class PulseChannelDetachedError(Exception):
-	"""Raised when `on()` is called on a detached handle."""
+	"""Kept for the JS export. Client `on()` is legal while detached."""
 
 	pass
 
@@ -60,8 +60,14 @@ class PulseChannelRemoteError(Exception):
 	pass
 
 
+class PulseChannelTimeoutError(Exception):
+	"""Raised when a client request exceeds `options.timeout` (milliseconds)."""
+
+	pass
+
+
 class ChannelBridge:
-	"""A local handle on a mailbox. Messages route by `id`."""
+	"""A local handle on a channel name. Messages route by `id`."""
 
 	@property
 	def id(self) -> str:
@@ -77,12 +83,15 @@ class ChannelBridge:
 		"""
 		...
 
-	def request(self, event: str, payload: _Any = None) -> _Awaitable[_Any]:
+	def request(
+		self, event: str, payload: _Any = None, options: dict[str, _Any] | None = None
+	) -> _Awaitable[_Any]:
 		"""Make a request to the server and await a response.
 
 		Args:
 		    event: The event name to send.
 		    payload: Optional data to send with the request.
+		    options: Optional `{ timeout }` in milliseconds.
 
 		Returns:
 		    A Promise that resolves with the server's response.
@@ -105,16 +114,17 @@ class ChannelBridge:
 
 
 def useChannel(channel_id: str) -> ChannelBridge:
-	"""React hook to attach a handle to a Pulse mailbox.
+	"""React hook to attach a handle to a Pulse channel.
 
 	Must be called from within a React component. Client lifetime is React
-	placement (route component vs layout).
+	placement (route component vs layout). Registers the handle during render
+	so a live-socket emit is not dropped waiting for useEffect.
 
 	Args:
-	    channel_id: The mailbox identifier.
+	    channel_id: The channel identifier.
 
 	Returns:
-	    A ChannelBridge handle for that mailbox.
+	    A ChannelBridge handle for that channel.
 	"""
 	...
 

--- a/packages/pulse/python/src/pulse/js/pulse.py
+++ b/packages/pulse/python/src/pulse/js/pulse.py
@@ -4,11 +4,11 @@ Pulse UI client bindings for channel communication.
 Usage:
 
 ```python
-from pulse.js.pulse import usePulseChannel, ChannelBridge
+from pulse.js.pulse import useChannel, ChannelBridge
 
 @ps.javascript(jsx=True)
 def MyChannelComponent(*, channel_id: str):
-    bridge = usePulseChannel(channel_id)
+    bridge = useChannel(channel_id)
 
     # Subscribe to events
     useEffect(
@@ -104,7 +104,7 @@ class ChannelBridge:
 		...
 
 
-def usePulseChannel(channel_id: str) -> ChannelBridge:
+def useChannel(channel_id: str) -> ChannelBridge:
 	"""React hook to attach a handle to a Pulse mailbox.
 
 	Must be called from within a React component. Client lifetime is React

--- a/packages/pulse/python/src/pulse/messages.py
+++ b/packages/pulse/python/src/pulse/messages.py
@@ -20,7 +20,15 @@ class ServerUpdateMessage(TypedDict):
 
 
 ServerErrorPhase = Literal[
-	"render", "callback", "mount", "unmount", "navigate", "server", "effect", "connect"
+	"render",
+	"callback",
+	"mount",
+	"unmount",
+	"navigate",
+	"server",
+	"effect",
+	"connect",
+	"channel",
 ]
 
 

--- a/packages/pulse/python/src/pulse/messages.py
+++ b/packages/pulse/python/src/pulse/messages.py
@@ -74,22 +74,38 @@ class ServerApiCallMessage(TypedDict):
 	credentials: Literal["include", "omit"]
 
 
-class ServerChannelRequestMessage(TypedDict):
-	type: Literal["channel_message"]
+ChannelErrorCode = Literal["no_handler", "denied", "handler_error"]
+
+
+class ChannelError(TypedDict):
+	code: ChannelErrorCode
+	message: str
+
+
+class ServerChannelEventMessage(TypedDict):
+	type: Literal["channel"]
+	action: Literal["event"]
 	channel: str
 	event: str
-	payload: Any
-	requestId: NotRequired[str]
-	error: NotRequired[Any]
+	payload: NotRequired[Any]
+
+
+class ServerChannelRequestMessage(TypedDict):
+	type: Literal["channel"]
+	action: Literal["request"]
+	channel: str
+	event: str
+	requestId: str
+	payload: NotRequired[Any]
 
 
 class ServerChannelResponseMessage(TypedDict):
-	type: Literal["channel_message"]
+	type: Literal["channel"]
+	action: Literal["response"]
 	channel: str
-	event: None
 	responseTo: str
-	payload: Any
-	error: NotRequired[Any]
+	payload: NotRequired[Any]
+	error: NotRequired[ChannelError]
 
 
 class ServerJsExecMessage(TypedDict):
@@ -138,22 +154,30 @@ class ClientApiResultMessage(TypedDict):
 	body: Any | None
 
 
-class ClientChannelRequestMessage(TypedDict):
-	type: Literal["channel_message"]
+class ClientChannelEventMessage(TypedDict):
+	type: Literal["channel"]
+	action: Literal["event"]
 	channel: str
 	event: str
-	payload: Any
-	requestId: NotRequired[str]
-	error: NotRequired[Any]
+	payload: NotRequired[Any]
+
+
+class ClientChannelRequestMessage(TypedDict):
+	type: Literal["channel"]
+	action: Literal["request"]
+	channel: str
+	event: str
+	requestId: str
+	payload: NotRequired[Any]
 
 
 class ClientChannelResponseMessage(TypedDict):
-	type: Literal["channel_message"]
+	type: Literal["channel"]
+	action: Literal["response"]
 	channel: str
-	event: None
 	responseTo: str
-	payload: Any
-	error: NotRequired[Any]
+	payload: NotRequired[Any]
+	error: NotRequired[ChannelError]
 
 
 class ClientJsResultMessage(TypedDict):
@@ -165,7 +189,11 @@ class ClientJsResultMessage(TypedDict):
 	error: str | None
 
 
-ServerChannelMessage = ServerChannelRequestMessage | ServerChannelResponseMessage
+ServerChannelMessage = (
+	ServerChannelEventMessage
+	| ServerChannelRequestMessage
+	| ServerChannelResponseMessage
+)
 ServerMessage = (
 	ServerInitMessage
 	| ServerUpdateMessage
@@ -187,7 +215,11 @@ ClientPulseMessage = (
 	| ClientApiResultMessage
 	| ClientJsResultMessage
 )
-ClientChannelMessage = ClientChannelRequestMessage | ClientChannelResponseMessage
+ClientChannelMessage = (
+	ClientChannelEventMessage
+	| ClientChannelRequestMessage
+	| ClientChannelResponseMessage
+)
 ClientMessage = ClientPulseMessage | ClientChannelMessage
 
 

--- a/packages/pulse/python/src/pulse/middleware.py
+++ b/packages/pulse/python/src/pulse/middleware.py
@@ -84,6 +84,9 @@ PrerenderResponse = Ok[Prerender] | Redirect | NotFound
 ConnectResponse = Ok[None] | Deny
 """Response type for WebSocket connection: ``Ok[None] | Deny``."""
 
+MessageDecision = Ok[None] | Deny
+"""Allow or deny a socket / channel message: ``Ok[None] | Deny``."""
+
 
 class PulseMiddleware:
 	"""Base middleware class with pass-through defaults.
@@ -167,8 +170,8 @@ class PulseMiddleware:
 		*,
 		data: ClientMessage,
 		session: dict[str, Any],
-		next: Callable[[], Awaitable[Ok[None]]],
-	) -> Ok[None] | Deny:
+		next: Callable[[], Awaitable[MessageDecision]],
+	) -> MessageDecision:
 		"""Handle per-message authorization.
 
 		Args:
@@ -189,8 +192,8 @@ class PulseMiddleware:
 		payload: Any,
 		request_id: str | None,
 		session: dict[str, Any],
-		next: Callable[[], Awaitable[Ok[None]]],
-	) -> Ok[None] | Deny:
+		next: Callable[[], Awaitable[MessageDecision]],
+	) -> MessageDecision:
 		"""Handle channel message authorization.
 
 		Args:
@@ -292,21 +295,15 @@ class MiddlewareStack(PulseMiddleware):
 		*,
 		data: ClientMessage,
 		session: dict[str, Any],
-		next: Callable[[], Awaitable[Ok[None]]],
-	) -> Ok[None] | Deny:
-		async def dispatch(index: int) -> Ok[None] | Deny:
+		next: Callable[[], Awaitable[MessageDecision]],
+	) -> MessageDecision:
+		async def dispatch(index: int) -> MessageDecision:
 			if index >= len(self._middlewares):
 				return await next()
 			mw = self._middlewares[index]
 
-			async def _next() -> Ok[None]:
-				result = await dispatch(index + 1)
-				# If dispatch returns Deny, the middleware should have short-circuited
-				# This should only be called when continuing the chain
-				if isinstance(result, Deny):
-					# This shouldn't happen, but handle it gracefully
-					return Ok(None)
-				return result
+			async def _next() -> MessageDecision:
+				return await dispatch(index + 1)
 
 			return await mw.message(session=session, data=data, next=_next)
 
@@ -321,21 +318,15 @@ class MiddlewareStack(PulseMiddleware):
 		payload: Any,
 		request_id: str | None,
 		session: dict[str, Any],
-		next: Callable[[], Awaitable[Ok[None]]],
-	) -> Ok[None] | Deny:
-		async def dispatch(index: int) -> Ok[None] | Deny:
+		next: Callable[[], Awaitable[MessageDecision]],
+	) -> MessageDecision:
+		async def dispatch(index: int) -> MessageDecision:
 			if index >= len(self._middlewares):
 				return await next()
 			mw = self._middlewares[index]
 
-			async def _next() -> Ok[None]:
-				result = await dispatch(index + 1)
-				# If dispatch returns Deny, the middleware should have short-circuited
-				# This should only be called when continuing the chain
-				if isinstance(result, Deny):
-					# This shouldn't happen, but handle it gracefully
-					return Ok(None)
-				return result
+			async def _next() -> MessageDecision:
+				return await dispatch(index + 1)
 
 			return await mw.channel(
 				channel_id=channel_id,
@@ -449,8 +440,8 @@ class LatencyMiddleware(PulseMiddleware):
 		*,
 		data: ClientMessage,
 		session: dict[str, Any],
-		next: Callable[[], Awaitable[Ok[None]]],
-	) -> Ok[None] | Deny:
+		next: Callable[[], Awaitable[MessageDecision]],
+	) -> MessageDecision:
 		if self.message_ms > 0:
 			await asyncio.sleep(self.message_ms / 1000.0)
 		return await next()
@@ -464,8 +455,8 @@ class LatencyMiddleware(PulseMiddleware):
 		payload: Any,
 		request_id: str | None,
 		session: dict[str, Any],
-		next: Callable[[], Awaitable[Ok[None]]],
-	) -> Ok[None] | Deny:
+		next: Callable[[], Awaitable[MessageDecision]],
+	) -> MessageDecision:
 		if self.channel_ms > 0:
 			await asyncio.sleep(self.channel_ms / 1000.0)
 		return await next()

--- a/packages/pulse/python/src/pulse/refs.py
+++ b/packages/pulse/python/src/pulse/refs.py
@@ -119,7 +119,6 @@ class RefHandle(Disposable, Generic[T]):
 		"_mount_waiters",
 		"_mount_handlers",
 		"_unmount_handlers",
-		"_owns_channel",
 		"_remove_mount",
 		"_remove_unmount",
 	)
@@ -130,7 +129,6 @@ class RefHandle(Disposable, Generic[T]):
 	_mount_waiters: list[asyncio.Future[None]]
 	_mount_handlers: list[Callable[[], Any]]
 	_unmount_handlers: list[Callable[[], Any]]
-	_owns_channel: bool
 	_remove_mount: Callable[[], None] | None
 	_remove_unmount: Callable[[], None] | None
 
@@ -139,7 +137,6 @@ class RefHandle(Disposable, Generic[T]):
 		channel: Channel,
 		*,
 		ref_id: str | None = None,
-		owns_channel: bool = True,
 	) -> None:
 		self._channel = channel
 		self.id = ref_id or uuid.uuid4().hex
@@ -147,7 +144,6 @@ class RefHandle(Disposable, Generic[T]):
 		self._mount_waiters = []
 		self._mount_handlers = []
 		self._unmount_handlers = []
-		self._owns_channel = owns_channel
 		self._remove_mount = self._channel.on("ref:mounted", self._on_mounted)
 		self._remove_unmount = self._channel.on("ref:unmounted", self._on_unmounted)
 
@@ -758,8 +754,6 @@ class RefHandle(Disposable, Generic[T]):
 		self._mount_waiters.clear()
 		self._mount_handlers.clear()
 		self._unmount_handlers.clear()
-		if self._owns_channel:
-			self._channel.close()
 
 	@override
 	def __repr__(self) -> str:
@@ -818,12 +812,12 @@ class RefHookState(HookState):
 				)
 			return existing, False
 
-		if self._channel is None or self._channel.closed:
+		if self._channel is None or self._channel.is_detached():
 			ctx = PulseContext.get()
 			if ctx.render is None:
 				raise RuntimeError("ref() requires an active render session")
 			self._channel = ctx.render.get_ref_channel()
-		handle = RefHandle(self._channel, owns_channel=False)
+		handle = RefHandle(self._channel)
 		self.instances[full_identity] = handle
 		return handle, True
 

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -277,8 +277,6 @@ class RenderSession:
 	_send_message: Callable[[ServerMessage], Any] | None
 	_pending_api: dict[str, asyncio.Future[dict[str, Any]]]
 	_pending_js_results: dict[str, asyncio.Future[Any]]
-	_ref_channel: Channel | None
-	_ref_channels_by_route: dict[str, Channel]
 	_global_states: dict[str, State]
 	_global_queue: list[ServerMessage]
 	_tasks: TaskRegistry
@@ -320,8 +318,6 @@ class RenderSession:
 		self.forms = FormRegistry(self)
 		self._pending_api = {}
 		self._pending_js_results = {}
-		self._ref_channel = None
-		self._ref_channels_by_route = {}
 		self._tasks = TaskRegistry(name=f"render:{id}")
 		self._timers = TimerRegistry(tasks=self._tasks, name=f"render:{id}")
 		self.query_store = QueryStore()
@@ -383,6 +379,7 @@ class RenderSession:
 		"""WebSocket disconnected. Queue briefly, then suspend mounts on timeout."""
 		self._send_message = None
 		self.connected = False
+		self.channels.fail_pending()
 		# Pause query interval refetching while nobody is watching
 		self.query_store.suspend_all()
 
@@ -592,7 +589,7 @@ class RenderSession:
 			return
 		try:
 			self.route_mounts.pop(path, None)
-			self._ref_channels_by_route.pop(path, None)
+			self.channels.detach_route(path)
 			mount.dispose()
 		except Exception as e:
 			self.report_error(path, "unmount", e)
@@ -600,7 +597,7 @@ class RenderSession:
 	def detach(self, path: str):
 		"""Client route unmounted. Dispose immediately outside dev StrictMode replay."""
 		path = ensure_absolute_path(path)
-		self._ref_channels_by_route.pop(path, None)
+		self.channels.detach_route(path)
 		mount = self.route_mounts.get(path)
 		if not mount:
 			return
@@ -714,11 +711,7 @@ class RenderSession:
 		for value in self._global_states.values():
 			value.dispose()
 		self._global_states.clear()
-		for channel_id in list(self.channels._channels.keys()):  # pyright: ignore[reportPrivateUsage]
-			channel = self.channels._channels.get(channel_id)  # pyright: ignore[reportPrivateUsage]
-			if channel:
-				channel.closed = True
-				self.channels.dispose_channel(channel, reason="render.close")
+		self.channels.reset()
 		for fut in self._pending_api.values():
 			if not fut.done():
 				fut.cancel()
@@ -727,8 +720,6 @@ class RenderSession:
 			if not fut.done():
 				fut.cancel()
 		self._pending_js_results.clear()
-		self._ref_channel = None
-		self._ref_channels_by_route.clear()
 		# Close any timer that may have been scheduled during cleanup (ex: query GC)
 		self._timers.cancel_all()
 		self._global_queue = []
@@ -767,20 +758,10 @@ class RenderSession:
 	def get_ref_channel(self) -> Channel:
 		ctx = PulseContext.get()
 		if ctx.route is None:
-			if self._ref_channel is not None and not self._ref_channel.closed:
-				return self._ref_channel
-			self._ref_channel = self.channels.create(bind_route=False)
-			return self._ref_channel
-
-		route_path = ctx.route.route_path
-		channel = self._ref_channels_by_route.get(route_path)
-		if channel is not None and channel.closed:
-			self._ref_channels_by_route.pop(route_path, None)
-			channel = None
-		if channel is None:
-			channel = self.channels.create(bind_route=True)
-			self._ref_channels_by_route[route_path] = channel
-		return channel
+			return self.channels.acquire("__pulse_ref__", lifetime="tab")
+		return self.channels.acquire(
+			f"__pulse_ref__:{ctx.route.route_path}", lifetime="route"
+		)
 
 	def flush(self):
 		with PulseContext.update(render=self):

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -47,6 +47,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__file__)
 
+# Cap on messages buffered while the socket is down (drop-oldest past this).
+MAX_DISCONNECT_QUEUE = 1000
+
 
 class JsExecError(Exception):
 	"""Raised when client-side JS execution fails."""
@@ -279,6 +282,7 @@ class RenderSession:
 	_pending_js_results: dict[str, asyncio.Future[Any]]
 	_global_states: dict[str, State]
 	_global_queue: list[ServerMessage]
+	_global_queue_overflowed: bool
 	_tasks: TaskRegistry
 	_timers: TimerRegistry
 
@@ -313,6 +317,7 @@ class RenderSession:
 		self._send_message = None
 		self._global_states = {}
 		self._global_queue = []
+		self._global_queue_overflowed = False
 		self.connected = False
 		self.channels = ChannelsManager(self)
 		self.forms = FormRegistry(self)
@@ -349,11 +354,20 @@ class RenderSession:
 		"""WebSocket connected. Set sender, don't auto-flush (attach does that)."""
 		self._send_message = send_message
 		self.connected = True
-		if self._global_queue:
-			queued = self._global_queue
-			self._global_queue = []
-			for msg in queued:
+		queued = self._global_queue
+		self._global_queue = []
+		self._global_queue_overflowed = False
+		for msg in queued:
+			# One undeliverable message must not abort the drain: the rest of the
+			# queue would be lost and the session left connected without a socket.
+			try:
 				self.send(msg)
+			except Exception as exc:
+				logger.error(
+					"Dropping queued %s message on reconnect",
+					msg.get("type"),
+					exc_info=exc,
+				)
 		# Restart query intervals and refetch stale data (no-op on first connect).
 		# Establishes render context here (so resume fetch-tasks register on this
 		# render); the session is inherited from the caller's context, which must
@@ -430,7 +444,7 @@ class RenderSession:
 			if self._send_message:
 				self._send_message(message)
 			else:
-				self._global_queue.append(message)
+				self._queue_global(message)
 			return
 		# Global messages (not path-specific) go directly if connected
 		path = message.get("path")
@@ -438,7 +452,7 @@ class RenderSession:
 			if self._send_message:
 				self._send_message(message)
 			else:
-				self._global_queue.append(message)
+				self._queue_global(message)
 			return
 
 		# Normalize path for lookup
@@ -455,6 +469,21 @@ class RenderSession:
 			return
 		if mount.state == "pending":
 			mount.deliver(message, lambda _: None)
+
+	def _queue_global(self, message: ServerMessage) -> None:
+		"""Buffer a message for the disconnect grace period, dropping oldest on overflow."""
+		self._global_queue.append(message)
+		overflow = len(self._global_queue) - MAX_DISCONNECT_QUEUE
+		if overflow <= 0:
+			return
+		del self._global_queue[:overflow]
+		if not self._global_queue_overflowed:
+			self._global_queue_overflowed = True
+			logger.warning(
+				"Render session %s disconnect queue hit %d messages; dropping oldest",
+				self.id,
+				MAX_DISCONNECT_QUEUE,
+			)
 
 	def _error_report_paths(self, path: str | None) -> list[str]:
 		# Wire `path` must match a live client view. Tab / connect / middleware

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -526,8 +526,7 @@ class RenderSession:
 
 			results[path] = message
 			if message["type"] == "navigate_to":
-				mount.dispose()
-				del self.route_mounts[path]
+				self.dispose_mount(path, mount)
 				continue
 
 		return results

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -47,8 +47,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__file__)
 
-# Cap on messages buffered while the socket is down (drop-oldest past this).
+# Caps on messages buffered while the socket is down (drop-oldest past these).
+# Channel events get their own budget so a chatty channel cannot evict
+# control-plane messages (reload, navigate_to, server_error).
 MAX_DISCONNECT_QUEUE = 1000
+MAX_QUEUED_CHANNEL_MESSAGES = 500
 
 
 class JsExecError(Exception):
@@ -282,7 +285,7 @@ class RenderSession:
 	_pending_js_results: dict[str, asyncio.Future[Any]]
 	_global_states: dict[str, State]
 	_global_queue: list[ServerMessage]
-	_global_queue_overflowed: bool
+	_queue_trim_warned: set[str]
 	_tasks: TaskRegistry
 	_timers: TimerRegistry
 
@@ -317,7 +320,7 @@ class RenderSession:
 		self._send_message = None
 		self._global_states = {}
 		self._global_queue = []
-		self._global_queue_overflowed = False
+		self._queue_trim_warned = set()
 		self.connected = False
 		self.channels = ChannelsManager(self)
 		self.forms = FormRegistry(self)
@@ -356,7 +359,7 @@ class RenderSession:
 		self.connected = True
 		queued = self._global_queue
 		self._global_queue = []
-		self._global_queue_overflowed = False
+		self._queue_trim_warned.clear()
 		for msg in queued:
 			# One undeliverable message must not abort the drain: the rest of the
 			# queue would be lost and the session left connected without a socket.
@@ -471,19 +474,39 @@ class RenderSession:
 			mount.deliver(message, lambda _: None)
 
 	def _queue_global(self, message: ServerMessage) -> None:
-		"""Buffer a message for the disconnect grace period, dropping oldest on overflow."""
+		"""Buffer a message for the disconnect grace period, dropping oldest on overflow.
+
+		Channel messages overflow against their own budget: they are the chatty ones,
+		and losing a reload / navigate_to / server_error to them would be far worse.
+		"""
 		self._global_queue.append(message)
-		overflow = len(self._global_queue) - MAX_DISCONNECT_QUEUE
-		if overflow <= 0:
+		if len(self._global_queue) <= MAX_QUEUED_CHANNEL_MESSAGES:
 			return
-		del self._global_queue[:overflow]
-		if not self._global_queue_overflowed:
-			self._global_queue_overflowed = True
-			logger.warning(
-				"Render session %s disconnect queue hit %d messages; dropping oldest",
-				self.id,
-				MAX_DISCONNECT_QUEUE,
-			)
+		channel_positions = [
+			i for i, msg in enumerate(self._global_queue) if msg["type"] == "channel"
+		]
+		drop = len(channel_positions) - MAX_QUEUED_CHANNEL_MESSAGES
+		if drop > 0:
+			dropped = set(channel_positions[:drop])
+			self._global_queue = [
+				msg for i, msg in enumerate(self._global_queue) if i not in dropped
+			]
+			self._warn_queue_trim("channel", MAX_QUEUED_CHANNEL_MESSAGES)
+		overflow = len(self._global_queue) - MAX_DISCONNECT_QUEUE
+		if overflow > 0:
+			del self._global_queue[:overflow]
+			self._warn_queue_trim("total", MAX_DISCONNECT_QUEUE)
+
+	def _warn_queue_trim(self, kind: str, cap: int) -> None:
+		if kind in self._queue_trim_warned:
+			return
+		self._queue_trim_warned.add(kind)
+		logger.warning(
+			"Render session %s disconnect queue hit its %s cap (%d); dropping oldest",
+			self.id,
+			kind,
+			cap,
+		)
 
 	def _error_report_paths(self, path: str | None) -> list[str]:
 		# Wire `path` must match a live client view. Tab / connect / middleware

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -456,9 +456,19 @@ class RenderSession:
 		if mount.state == "pending":
 			mount.deliver(message, lambda _: None)
 
+	def _error_report_paths(self, path: str | None) -> list[str]:
+		# Wire `path` must match a live client view. Tab / connect / middleware
+		# errors have no route (or a stale "/") — fan out to current mounts.
+		if path is not None:
+			path = ensure_absolute_path(path)
+			if path in self.route_mounts:
+				return [path]
+		mounts = list(self.route_mounts)
+		return mounts if mounts else ["/"]
+
 	def report_error(
 		self,
-		path: str,
+		path: str | None,
 		phase: ServerErrorPhase,
 		exc: BaseException,
 		details: dict[str, Any] | None = None,
@@ -467,18 +477,19 @@ class RenderSession:
 		# is also called outside an `except` block (e.g. a deferred connect error),
 		# where traceback.format_exc() would yield "NoneType: None".
 		stack = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
-		self.send(
-			{
-				"type": "server_error",
-				"path": path,
-				"error": {
-					"message": str(exc),
-					"stack": stack,
-					"phase": phase,
-					"details": details or {},
-				},
-			}
-		)
+		for target in self._error_report_paths(path):
+			self.send(
+				{
+					"type": "server_error",
+					"path": target,
+					"error": {
+						"message": str(exc),
+						"stack": stack,
+						"phase": phase,
+						"details": details or {},
+					},
+				}
+			)
 		logger.error(
 			"Error reported for path %r during %s: %s\n%s",
 			path,

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -391,6 +391,15 @@ class RenderSession:
 
 	def send(self, message: ServerMessage):
 		"""Route message based on mount state."""
+		# Channel RPC is fail-fast. Never park request/response on the
+		# disconnect queue — the pending future is already rejected.
+		if message.get("type") == "channel" and message.get("action") in (
+			"request",
+			"response",
+		):
+			if self._send_message:
+				self._send_message(message)
+			return
 		# Forced navigation is global. Route-bound navigation is dropped once
 		# its source route has unmounted.
 		if message.get("type") == "navigate_to":
@@ -597,7 +606,6 @@ class RenderSession:
 	def detach(self, path: str):
 		"""Client route unmounted. Dispose immediately outside dev StrictMode replay."""
 		path = ensure_absolute_path(path)
-		self.channels.detach_route(path)
 		mount = self.route_mounts.get(path)
 		if not mount:
 			return

--- a/packages/pulse/python/tests/test_channels.py
+++ b/packages/pulse/python/tests/test_channels.py
@@ -515,7 +515,7 @@ async def test_rpc_is_not_queued_while_disconnected():
 async def test_event_handler_error_is_reported():
 	app, dummy, session, render, _route = build_session()
 	del render.send  # pyright: ignore[reportAttributeAccessIssue]
-	render.connect(dummy.sent.append)
+	render.connect(dummy.send)  # pyright: ignore[reportArgumentType]
 
 	def boom(_: Any) -> None:
 		raise RuntimeError("handler exploded")

--- a/packages/pulse/python/tests/test_channels.py
+++ b/packages/pulse/python/tests/test_channels.py
@@ -513,13 +513,15 @@ async def test_rpc_is_not_queued_while_disconnected():
 
 @pytest.mark.asyncio
 async def test_event_handler_error_is_reported():
-	app, dummy, session, render, route = build_session(with_route=True)
+	app, dummy, session, render, _route = build_session()
+	del render.send  # pyright: ignore[reportAttributeAccessIssue]
+	render.connect(dummy.sent.append)
 
 	def boom(_: Any) -> None:
 		raise RuntimeError("handler exploded")
 
-	with ctx(app, session, render, route):
-		channel = ps.channel("boom")
+	with ctx(app, session, render):
+		channel = ps.channel("boom", lifetime="tab")
 		channel.on("ping", boom)
 	render.channels.handle_event(
 		as_event(
@@ -531,8 +533,12 @@ async def test_event_handler_error_is_reported():
 			},
 		)
 	)
-	await asyncio.sleep(0)
-	errors = [msg for msg in dummy.sent if msg.get("type") == "server_error"]
+	errors: list[dict[str, Any]] = []
+	for _ in range(20):
+		await asyncio.sleep(0)
+		errors = [msg for msg in dummy.sent if msg.get("type") == "server_error"]
+		if errors:
+			break
 	assert errors
 	assert errors[-1]["path"] == "/"
 	assert errors[-1]["error"]["phase"] == "channel"
@@ -586,10 +592,10 @@ async def test_middleware_exception_nacks_request():
 			},
 		),
 	)
-	assert dummy.sent[-1]["type"] == "channel"
-	assert dummy.sent[-1]["error"]["code"] == "handler_error"
-	assert dummy.sent[-2]["type"] == "server_error"
-	assert dummy.sent[-2]["error"]["phase"] == "channel"
+	nacks = [msg for msg in dummy.sent if msg.get("type") == "channel"]
+	errors = [msg for msg in dummy.sent if msg.get("type") == "server_error"]
+	assert nacks[-1]["error"]["code"] == "handler_error"
+	assert errors[-1]["error"]["phase"] == "channel"
 
 
 @pytest.mark.asyncio

--- a/packages/pulse/python/tests/test_channels.py
+++ b/packages/pulse/python/tests/test_channels.py
@@ -15,9 +15,10 @@ from pulse.messages import (
 	ClientChannelRequestMessage,
 	ClientChannelResponseMessage,
 )
-from pulse.middleware import Deny, PulseMiddleware
+from pulse.middleware import Deny, PulseMiddleware, stack
 from pulse.render_session import RenderSession
 from pulse.routing import Route, RouteContext, RouteInfo, RouteTree
+from pulse.serializer import serialize
 from pulse.user_session import UserSession
 
 
@@ -110,10 +111,21 @@ async def test_empty_identifier_raises():
 
 @pytest.mark.asyncio
 async def test_none_identifier_generates_uuid():
-	app, _dummy, session, render, _route = build_session()
-	with ctx(app, session, render):
+	app, _dummy, session, render, route = build_session(with_route=True)
+	with ctx(app, session, render, route):
 		channel = ps.channel()
 	assert len(channel.id) == 36
+
+
+@pytest.mark.asyncio
+async def test_route_lifetime_requires_route_context():
+	app, _dummy, session, render, _route = build_session()
+	with ctx(app, session, render):
+		with pytest.raises(RuntimeError, match="route context"):
+			ps.channel("x")
+		handle = ps.channel("x", lifetime="tab")
+	assert handle.lifetime == "tab"
+	assert handle is not None
 
 
 @pytest.mark.asyncio
@@ -172,7 +184,7 @@ async def test_tab_handle_survives_route_unmount():
 async def test_emit_sends_channel_event():
 	app, dummy, session, render, _route = build_session()
 	with ctx(app, session, render):
-		channel = ps.channel("form-channel")
+		channel = ps.channel("form-channel", lifetime="tab")
 		channel.emit("setValues", {"values": {"a": 1}})
 	assert dummy.sent == [
 		{
@@ -189,7 +201,7 @@ async def test_emit_sends_channel_event():
 async def test_request_resolves_on_response():
 	app, dummy, session, render, _route = build_session(connected=True)
 	with ctx(app, session, render):
-		channel = ps.channel("req-channel")
+		channel = ps.channel("req-channel", lifetime="tab")
 		pending = asyncio.create_task(channel.request("get", {"x": 1}))
 	await asyncio.sleep(0)
 	assert dummy.sent[0]["type"] == "channel"
@@ -213,7 +225,7 @@ async def test_request_resolves_on_response():
 async def test_request_maps_remote_error():
 	app, dummy, session, render, _route = build_session(connected=True)
 	with ctx(app, session, render):
-		channel = ps.channel("err-channel")
+		channel = ps.channel("err-channel", lifetime="tab")
 		pending = asyncio.create_task(channel.request("get"))
 	await asyncio.sleep(0)
 	render.channels.handle_response(
@@ -236,7 +248,7 @@ async def test_request_maps_remote_error():
 async def test_request_fail_fast_when_disconnected():
 	app, dummy, session, render, _route = build_session(connected=False)
 	with ctx(app, session, render):
-		channel = ps.channel("down")
+		channel = ps.channel("down", lifetime="tab")
 		with pytest.raises(ChannelDisconnected):
 			await channel.request("get")
 	assert dummy.sent == []
@@ -246,7 +258,7 @@ async def test_request_fail_fast_when_disconnected():
 async def test_request_nacks_without_handler():
 	app, dummy, session, render, _route = build_session()
 	with ctx(app, session, render):
-		ps.channel("empty")
+		ps.channel("empty", lifetime="tab")
 	await render.channels.handle_request(
 		as_request(
 			{
@@ -274,7 +286,7 @@ async def test_request_nacks_without_handler():
 async def test_event_without_listener_is_dropped():
 	app, dummy, session, render, _route = build_session()
 	with ctx(app, session, render):
-		ps.channel("quiet")
+		ps.channel("quiet", lifetime="tab")
 	render.channels.handle_event(
 		as_event(
 			{
@@ -291,11 +303,11 @@ async def test_event_without_listener_is_dropped():
 
 @pytest.mark.asyncio
 async def test_event_fans_out_to_two_handles():
-	app, _dummy, session, render, _route = build_session()
+	app, _dummy, session, render, route = build_session(with_route=True)
 	seen: list[str] = []
-	with ctx(app, session, render):
-		a = render.channels.open_handle("shared")
-		b = render.channels.open_handle("shared")
+	with ctx(app, session, render, route):
+		a = ps.channel("shared")
+		b = ps.channel("shared", lifetime="tab")
 		a.on("ping", lambda _: seen.append("a"))
 		b.on("ping", lambda _: seen.append("b"))
 	render.channels.handle_event(
@@ -317,7 +329,7 @@ async def test_transport_drop_rejects_rpc_and_keeps_listeners():
 	app, dummy, session, render, _route = build_session(connected=True)
 	received: list[Any] = []
 	with ctx(app, session, render):
-		channel = ps.channel("keep")
+		channel = ps.channel("keep", lifetime="tab")
 		channel.on("ping", lambda payload: received.append(payload))
 		pending = asyncio.create_task(channel.request("get"))
 	await asyncio.sleep(0)
@@ -344,7 +356,7 @@ async def test_transport_drop_rejects_rpc_and_keeps_listeners():
 async def test_session_end_rejects_rpc():
 	app, _dummy, session, render, _route = build_session(connected=True)
 	with ctx(app, session, render):
-		channel = ps.channel("end")
+		channel = ps.channel("end", lifetime="tab")
 		pending = asyncio.create_task(channel.request("get"))
 	await asyncio.sleep(0)
 	render.close()
@@ -360,7 +372,7 @@ async def test_emit_while_disconnected_uses_global_queue():
 	session = SimpleNamespace(sid="session-1", data={})
 	render = ps.RenderSession("render-q", app.routes)
 	with ctx(app, session, render):
-		channel = ps.channel("queued")
+		channel = ps.channel("queued", lifetime="tab")
 		channel.emit("ping", {"n": 1})
 	assert render._global_queue == [  # pyright: ignore[reportPrivateUsage]
 		{
@@ -441,7 +453,7 @@ async def test_middleware_skips_responses():
 	app.user_sessions[session.sid] = session  # pyright: ignore[reportArgumentType]
 	user = cast(UserSession, cast(object, session))
 	with ctx(app, session, render):
-		channel = ps.channel("mid")
+		channel = ps.channel("mid", lifetime="tab")
 		pending = asyncio.create_task(channel.request("echo"))
 	await asyncio.sleep(0)
 	await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
@@ -459,3 +471,228 @@ async def test_middleware_skips_responses():
 	)
 	assert await pending == "ok"
 	assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_on_same_handler_is_idempotent():
+	app, _dummy, session, render, route = build_session(with_route=True)
+	calls: list[int] = []
+
+	def handler(_: Any) -> None:
+		calls.append(1)
+
+	with ctx(app, session, render, route):
+		channel = ps.channel("once")
+		channel.on("ping", handler)
+		channel.on("ping", handler)
+	render.channels.handle_event(
+		as_event(
+			{
+				"type": "channel",
+				"action": "event",
+				"channel": "once",
+				"event": "ping",
+			},
+		)
+	)
+	await asyncio.sleep(0)
+	assert calls == [1]
+
+
+@pytest.mark.asyncio
+async def test_rpc_is_not_queued_while_disconnected():
+	app = ps.App()
+	session = SimpleNamespace(sid="session-1", data={})
+	render = ps.RenderSession("render-rpc", app.routes)
+	with ctx(app, session, render):
+		ps.channel("rpc", lifetime="tab")
+	render.channels.send_request("rpc", "echo", None, "req-1")
+	render.channels.send_response("rpc", "req-1", "ok")
+	assert render._global_queue == []  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.asyncio
+async def test_event_handler_error_is_reported():
+	app, dummy, session, render, route = build_session(with_route=True)
+
+	def boom(_: Any) -> None:
+		raise RuntimeError("handler exploded")
+
+	with ctx(app, session, render, route):
+		channel = ps.channel("boom")
+		channel.on("ping", boom)
+	render.channels.handle_event(
+		as_event(
+			{
+				"type": "channel",
+				"action": "event",
+				"channel": "boom",
+				"event": "ping",
+			},
+		)
+	)
+	await asyncio.sleep(0)
+	errors = [msg for msg in dummy.sent if msg.get("type") == "server_error"]
+	assert errors
+	assert errors[-1]["path"] == "/"
+	assert errors[-1]["error"]["phase"] == "channel"
+	assert "handler exploded" in errors[-1]["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_strict_mode_detach_keeps_route_handle():
+	app, _dummy, session, render, route = build_session(with_route=True)
+	render.dev_strict_mode_detach_timeout = 10.0
+	with ctx(app, session, render, route):
+		channel = ps.channel("form")
+		channel.on("sync", lambda _: None)
+	render.detach("/")
+	assert not channel.is_detached()
+	with ctx(app, session, render, route):
+		again = ps.channel("form")
+	assert again is channel
+	mount = render.route_mounts["/"]
+	render.dispose_mount("/", mount)
+	assert channel.is_detached()
+
+
+@pytest.mark.asyncio
+async def test_middleware_exception_nacks_request():
+	class Boom(PulseMiddleware):
+		@override
+		async def channel(self, **kwargs: Any):
+			raise RuntimeError("middleware down")
+
+	app = ps.App(middleware=Boom())
+	dummy = DummyRender()
+	session = SimpleNamespace(sid="session-1", data={})
+	render = ps.RenderSession(dummy.id, app.routes)
+	render.send = dummy.send  # pyright: ignore[reportAttributeAccessIssue]
+	app.render_sessions[render.id] = render
+	app._render_to_user[render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
+	app.user_sessions[session.sid] = session  # pyright: ignore[reportArgumentType]
+	user = cast(UserSession, cast(object, session))
+
+	await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
+		render,
+		user,
+		as_request(
+			{
+				"type": "channel",
+				"action": "request",
+				"channel": "gated",
+				"event": "ping",
+				"requestId": "req-boom",
+			},
+		),
+	)
+	assert dummy.sent[-1]["type"] == "channel"
+	assert dummy.sent[-1]["error"]["code"] == "handler_error"
+	assert dummy.sent[-2]["type"] == "server_error"
+	assert dummy.sent[-2]["error"]["phase"] == "channel"
+
+
+@pytest.mark.asyncio
+async def test_stacked_inner_deny_nacks_request():
+	class Outer(PulseMiddleware):
+		@override
+		async def channel(self, **kwargs: Any):
+			return await kwargs["next"]()
+
+	class Inner(PulseMiddleware):
+		@override
+		async def channel(self, **kwargs: Any):
+			return Deny()
+
+	app = ps.App(middleware=stack(Outer(), Inner()))
+	dummy = DummyRender()
+	session = SimpleNamespace(sid="session-1", data={})
+	render = ps.RenderSession(dummy.id, app.routes)
+	render.send = dummy.send  # pyright: ignore[reportAttributeAccessIssue]
+	app.render_sessions[render.id] = render
+	app._render_to_user[render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
+	app.user_sessions[session.sid] = session  # pyright: ignore[reportArgumentType]
+	user = cast(UserSession, cast(object, session))
+
+	await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
+		render,
+		user,
+		as_request(
+			{
+				"type": "channel",
+				"action": "request",
+				"channel": "gated",
+				"event": "ping",
+				"requestId": "req-inner",
+			},
+		),
+	)
+	assert dummy.sent[-1]["error"] == {"code": "denied", "message": "Denied"}
+
+
+@pytest.mark.asyncio
+async def test_inbound_request_does_not_hold_session_lock():
+	app, dummy, session, render, route = build_session(connected=True, with_route=True)
+	app._socket_to_render["socket-1"] = render.id  # pyright: ignore[reportPrivateUsage]
+
+	with ctx(app, session, render, route):
+		channel = ps.channel("rpc")
+
+		async def do(_: Any) -> Any:
+			return await channel.request("client-echo")
+
+		channel.on("do", do)
+
+	inbound_task = asyncio.create_task(
+		app._process_socket_message(  # pyright: ignore[reportPrivateUsage]
+			"socket-1",
+			serialize(
+				{
+					"type": "channel",
+					"action": "request",
+					"channel": "rpc",
+					"event": "do",
+					"requestId": "from-client",
+				}
+			),
+		)
+	)
+
+	echo_id: str | None = None
+	for _ in range(50):
+		await asyncio.sleep(0)
+		for msg in dummy.sent:
+			if msg.get("action") == "request" and msg.get("event") == "client-echo":
+				echo_id = msg["requestId"]
+				break
+		if echo_id is not None:
+			break
+	assert echo_id is not None
+
+	await asyncio.wait_for(
+		app._process_socket_message(  # pyright: ignore[reportPrivateUsage]
+			"socket-1",
+			serialize(
+				{
+					"type": "channel",
+					"action": "response",
+					"channel": "rpc",
+					"responseTo": echo_id,
+					"payload": "pong",
+				}
+			),
+		),
+		timeout=1,
+	)
+	await asyncio.wait_for(inbound_task, timeout=1)
+	for _ in range(50):
+		await asyncio.sleep(0)
+		if dummy.sent and dummy.sent[-1].get("responseTo") == "from-client":
+			break
+	assert dummy.sent[-1] == {
+		"type": "channel",
+		"action": "response",
+		"channel": "rpc",
+		"responseTo": "from-client",
+		"payload": "pong",
+	}

--- a/packages/pulse/python/tests/test_channels.py
+++ b/packages/pulse/python/tests/test_channels.py
@@ -565,6 +565,75 @@ async def test_event_handler_error_is_reported():
 	assert "handler exploded" in errors[-1]["error"]["message"]
 
 
+def _dash_route_info() -> RouteInfo:
+	return cast(
+		RouteInfo,
+		cast(
+			object,
+			{
+				"pathname": "/dash",
+				"hash": "",
+				"query": "",
+				"queryParams": {},
+				"pathParams": {},
+				"catchall": [],
+			},
+		),
+	)
+
+
+def build_dash_session():
+	def page():
+		return ps.div()
+
+	route = Route("/dash", ps.component(page))
+	app = ps.App(routes=[route])
+	dummy = DummyRender()
+	session = SimpleNamespace(sid="session-1", data={})
+	render = ps.RenderSession(dummy.id, app.routes, server_address="http://localhost")
+	render.connect(dummy.send)  # pyright: ignore[reportArgumentType]
+	app.render_sessions[render.id] = render
+	app._render_to_user[render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
+	app.user_sessions[session.sid] = session  # pyright: ignore[reportArgumentType]
+	info = _dash_route_info()
+	with ctx(app, session, render):
+		render.prerender(["/dash"], info)
+		render.attach("/dash", info)
+	return app, dummy, session, render
+
+
+@pytest.mark.asyncio
+async def test_tab_handler_error_reports_on_live_mount():
+	app, dummy, session, render = build_dash_session()
+
+	def boom(_: Any) -> None:
+		raise RuntimeError("tab exploded")
+
+	with ctx(app, session, render):
+		channel = ps.channel("tab-boom", lifetime="tab")
+		channel.on("ping", boom)
+	render.channels.handle_event(
+		as_event(
+			{
+				"type": "channel",
+				"action": "event",
+				"channel": "tab-boom",
+				"event": "ping",
+			},
+		)
+	)
+	errors: list[dict[str, Any]] = []
+	for _ in range(20):
+		await asyncio.sleep(0)
+		errors = [msg for msg in dummy.sent if msg.get("type") == "server_error"]
+		if errors:
+			break
+	assert errors
+	assert errors[-1]["path"] == "/dash"
+	assert errors[-1]["error"]["phase"] == "channel"
+	assert "tab exploded" in errors[-1]["error"]["message"]
+
+
 @pytest.mark.asyncio
 async def test_strict_mode_detach_keeps_route_handle():
 	app, _dummy, session, render, route = build_session(with_route=True)
@@ -615,6 +684,50 @@ async def test_middleware_exception_nacks_request():
 	nacks = [msg for msg in dummy.sent if msg.get("type") == "channel"]
 	errors = [msg for msg in dummy.sent if msg.get("type") == "server_error"]
 	assert nacks[-1]["error"]["code"] == "handler_error"
+	assert errors[-1]["error"]["phase"] == "channel"
+	assert errors[-1]["path"] == "/"
+
+
+@pytest.mark.asyncio
+async def test_middleware_exception_reports_on_live_mount():
+	class Boom(PulseMiddleware):
+		@override
+		async def channel(self, **kwargs: Any):
+			raise RuntimeError("middleware down")
+
+	def page():
+		return ps.div()
+
+	route = Route("/dash", ps.component(page))
+	app = ps.App(routes=[route], middleware=Boom())
+	dummy = DummyRender()
+	session = SimpleNamespace(sid="session-1", data={})
+	render = ps.RenderSession(dummy.id, app.routes, server_address="http://localhost")
+	render.connect(dummy.send)  # pyright: ignore[reportArgumentType]
+	app.render_sessions[render.id] = render
+	app._render_to_user[render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
+	app.user_sessions[session.sid] = session  # pyright: ignore[reportArgumentType]
+	info = _dash_route_info()
+	with ctx(app, session, render):
+		render.prerender(["/dash"], info)
+		render.attach("/dash", info)
+	user = cast(UserSession, cast(object, session))
+
+	await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
+		render,
+		user,
+		as_request(
+			{
+				"type": "channel",
+				"action": "request",
+				"channel": "gated",
+				"event": "ping",
+				"requestId": "req-dash",
+			},
+		),
+	)
+	errors = [msg for msg in dummy.sent if msg.get("type") == "server_error"]
+	assert errors[-1]["path"] == "/dash"
 	assert errors[-1]["error"]["phase"] == "channel"
 
 

--- a/packages/pulse/python/tests/test_channels.py
+++ b/packages/pulse/python/tests/test_channels.py
@@ -186,17 +186,18 @@ async def test_tab_handle_survives_route_unmount():
 		handle.on("ping", lambda payload: received.append(payload))
 	render.channels.detach_route("/")
 	handle.on("still-ok", lambda _: None)
-	render.channels.handle_event(
-		as_event(
-			{
-				"type": "channel",
-				"action": "event",
-				"channel": "tab-box",
-				"event": "ping",
-				"payload": 1,
-			},
+	with ctx(app, session, render, route):
+		render.channels.handle_event(
+			as_event(
+				{
+					"type": "channel",
+					"action": "event",
+					"channel": "tab-box",
+					"event": "ping",
+					"payload": 1,
+				},
+			)
 		)
-	)
 	await asyncio.sleep(0)
 	assert received == [1]
 
@@ -280,17 +281,18 @@ async def test_request_nacks_without_handler():
 	app, dummy, session, render, _route = build_session()
 	with ctx(app, session, render):
 		ps.channel("empty", lifetime="tab")
-	await render.channels.handle_request(
-		as_request(
-			{
-				"type": "channel",
-				"action": "request",
-				"channel": "empty",
-				"event": "missing",
-				"requestId": "req-1",
-			},
+	with ctx(app, session, render):
+		await render.channels.handle_request(
+			as_request(
+				{
+					"type": "channel",
+					"action": "request",
+					"channel": "empty",
+					"event": "missing",
+					"requestId": "req-1",
+				},
+			)
 		)
-	)
 	assert dummy.sent[-1] == {
 		"type": "channel",
 		"action": "response",
@@ -308,17 +310,18 @@ async def test_event_without_listener_is_dropped():
 	app, dummy, session, render, _route = build_session()
 	with ctx(app, session, render):
 		ps.channel("quiet", lifetime="tab")
-	render.channels.handle_event(
-		as_event(
-			{
-				"type": "channel",
-				"action": "event",
-				"channel": "quiet",
-				"event": "ping",
-				"payload": 1,
-			},
+	with ctx(app, session, render):
+		render.channels.handle_event(
+			as_event(
+				{
+					"type": "channel",
+					"action": "event",
+					"channel": "quiet",
+					"event": "ping",
+					"payload": 1,
+				},
+			)
 		)
-	)
 	assert dummy.sent == []
 
 
@@ -331,16 +334,17 @@ async def test_event_fans_out_to_two_handles():
 		b = ps.channel("shared", lifetime="tab")
 		a.on("ping", lambda _: seen.append("a"))
 		b.on("ping", lambda _: seen.append("b"))
-	render.channels.handle_event(
-		as_event(
-			{
-				"type": "channel",
-				"action": "event",
-				"channel": "shared",
-				"event": "ping",
-			},
+	with ctx(app, session, render, route):
+		render.channels.handle_event(
+			as_event(
+				{
+					"type": "channel",
+					"action": "event",
+					"channel": "shared",
+					"event": "ping",
+				},
+			)
 		)
-	)
 	await asyncio.sleep(0)
 	assert seen == ["a", "b"]
 
@@ -358,17 +362,18 @@ async def test_transport_drop_rejects_rpc_and_keeps_listeners():
 	with pytest.raises(ChannelDisconnected):
 		await pending
 	assert dummy.sent[0]["action"] == "request"
-	render.channels.handle_event(
-		as_event(
-			{
-				"type": "channel",
-				"action": "event",
-				"channel": "keep",
-				"event": "ping",
-				"payload": "still-here",
-			},
+	with ctx(app, session, render):
+		render.channels.handle_event(
+			as_event(
+				{
+					"type": "channel",
+					"action": "event",
+					"channel": "keep",
+					"event": "ping",
+					"payload": "still-here",
+				},
+			)
 		)
-	)
 	await asyncio.sleep(0)
 	assert received == ["still-here"]
 
@@ -506,16 +511,17 @@ async def test_on_same_handler_is_idempotent():
 		channel = ps.channel("once")
 		channel.on("ping", handler)
 		channel.on("ping", handler)
-	render.channels.handle_event(
-		as_event(
-			{
-				"type": "channel",
-				"action": "event",
-				"channel": "once",
-				"event": "ping",
-			},
+	with ctx(app, session, render, route):
+		render.channels.handle_event(
+			as_event(
+				{
+					"type": "channel",
+					"action": "event",
+					"channel": "once",
+					"event": "ping",
+				},
+			)
 		)
-	)
 	await asyncio.sleep(0)
 	assert calls == [1]
 
@@ -544,16 +550,17 @@ async def test_event_handler_error_is_reported():
 	with ctx(app, session, render):
 		channel = ps.channel("boom", lifetime="tab")
 		channel.on("ping", boom)
-	render.channels.handle_event(
-		as_event(
-			{
-				"type": "channel",
-				"action": "event",
-				"channel": "boom",
-				"event": "ping",
-			},
+	with ctx(app, session, render):
+		render.channels.handle_event(
+			as_event(
+				{
+					"type": "channel",
+					"action": "event",
+					"channel": "boom",
+					"event": "ping",
+				},
+			)
 		)
-	)
 	errors: list[dict[str, Any]] = []
 	for _ in range(20):
 		await asyncio.sleep(0)
@@ -613,16 +620,17 @@ async def test_tab_handler_error_reports_on_live_mount():
 	with ctx(app, session, render):
 		channel = ps.channel("tab-boom", lifetime="tab")
 		channel.on("ping", boom)
-	render.channels.handle_event(
-		as_event(
-			{
-				"type": "channel",
-				"action": "event",
-				"channel": "tab-boom",
-				"event": "ping",
-			},
+	with ctx(app, session, render):
+		render.channels.handle_event(
+			as_event(
+				{
+					"type": "channel",
+					"action": "event",
+					"channel": "tab-boom",
+					"event": "ping",
+				},
+			)
 		)
-	)
 	errors: list[dict[str, Any]] = []
 	for _ in range(20):
 		await asyncio.sleep(0)
@@ -848,16 +856,17 @@ async def test_stale_on_remover_does_not_drop_new_handler():
 		remove_first()
 		channel.on("ping", lambda _: seen.append("second"))
 		remove_first()
-	render.channels.handle_event(
-		as_event(
-			{
-				"type": "channel",
-				"action": "event",
-				"channel": "once",
-				"event": "ping",
-			},
+	with ctx(app, session, render, route):
+		render.channels.handle_event(
+			as_event(
+				{
+					"type": "channel",
+					"action": "event",
+					"channel": "once",
+					"event": "ping",
+				},
+			)
 		)
-	)
 	await asyncio.sleep(0)
 	assert seen == ["second"]
 
@@ -890,17 +899,18 @@ async def test_unserializable_request_result_nacks():
 	with ctx(app, session, render, route):
 		channel = ps.channel("bad")
 		channel.on("get", lambda _: object)
-	await render.channels.handle_request(
-		as_request(
-			{
-				"type": "channel",
-				"action": "request",
-				"channel": "bad",
-				"event": "get",
-				"requestId": "req-bad",
-			},
+	with ctx(app, session, render, route):
+		await render.channels.handle_request(
+			as_request(
+				{
+					"type": "channel",
+					"action": "request",
+					"channel": "bad",
+					"event": "get",
+					"requestId": "req-bad",
+				},
+			)
 		)
-	)
 	nacks = [msg for msg in dummy.sent if msg.get("type") == "channel"]
 	assert nacks[-1]["error"]["code"] == "handler_error"
 
@@ -1012,6 +1022,89 @@ async def test_request_without_request_id_is_dropped():
 
 
 @pytest.mark.asyncio
+async def test_inbound_handlers_receive_session_render_and_route_context():
+	app, dummy, session, render, route = build_session(connected=True, with_route=True)
+	assert route is not None
+	observed: dict[str, Any] = {}
+
+	with ctx(app, session, render, route):
+		request_channel = ps.channel("context-request")
+		event_channel = ps.channel("context-event")
+		tab_channel = ps.channel("context-tab", lifetime="tab")
+
+		def request_handler(_: Any) -> str:
+			observed["request_session"] = ps.session()
+			observed["request_render"] = ps.websocket_id()
+			observed["request_route"] = ps.route()
+			return "request-ok"
+
+		def event_handler(_: Any) -> None:
+			observed["event_session"] = ps.session()
+			observed["event_render"] = ps.websocket_id()
+			observed["event_route"] = ps.route()
+
+		def tab_handler(_: Any) -> None:
+			observed["tab_session"] = ps.session()
+			observed["tab_render"] = ps.websocket_id()
+			observed["tab_route"] = ps.PulseContext.get().route
+
+		request_channel.on("read", request_handler)
+		event_channel.on("changed", event_handler)
+		tab_channel.on("changed", tab_handler)
+
+	user = cast(UserSession, cast(object, session))
+	await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
+		render,
+		user,
+		as_request(
+			{
+				"type": "channel",
+				"action": "request",
+				"channel": "context-request",
+				"event": "read",
+				"requestId": "req-context",
+			},
+		),
+	)
+	await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
+		render,
+		user,
+		as_event(
+			{
+				"type": "channel",
+				"action": "event",
+				"channel": "context-event",
+				"event": "changed",
+			},
+		),
+	)
+	await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
+		render,
+		user,
+		as_event(
+			{
+				"type": "channel",
+				"action": "event",
+				"channel": "context-tab",
+				"event": "changed",
+			},
+		),
+	)
+
+	await wait_for(lambda: "tab_route" in observed)
+	assert dummy.sent[-1]["payload"] == "request-ok"
+	assert observed["request_session"] is session.data
+	assert observed["request_render"] == render.id
+	assert observed["request_route"] == route.info
+	assert observed["event_session"] is session.data
+	assert observed["event_render"] == render.id
+	assert observed["event_route"] == route.info
+	assert observed["tab_session"] is session.data
+	assert observed["tab_render"] == render.id
+	assert observed["tab_route"] is None
+
+
+@pytest.mark.asyncio
 async def test_cancelled_request_clears_pending():
 	app, _dummy, session, render, _route = build_session(connected=True)
 	with ctx(app, session, render):
@@ -1108,16 +1201,17 @@ async def test_events_run_in_arrival_order():
 		channel.on("first", slow)
 		channel.on("second", fast)
 	for event in ("first", "second"):
-		render.channels.handle_event(
-			as_event(
-				{
-					"type": "channel",
-					"action": "event",
-					"channel": "ordered",
-					"event": event,
-				},
+		with ctx(app, session, render):
+			render.channels.handle_event(
+				as_event(
+					{
+						"type": "channel",
+						"action": "event",
+						"channel": "ordered",
+						"event": event,
+					},
+				)
 			)
-		)
 	await wait_for(lambda: len(seen) == 2)
 	assert seen == ["first", "second"]
 
@@ -1135,16 +1229,17 @@ async def test_detach_skips_pending_handlers():
 		channel = ps.channel("detaching", lifetime="tab")
 		channel.on("ping", first)
 		channel.on("ping", lambda _: seen.append("second"))
-	render.channels.handle_event(
-		as_event(
-			{
-				"type": "channel",
-				"action": "event",
-				"channel": "detaching",
-				"event": "ping",
-			},
+	with ctx(app, session, render):
+		render.channels.handle_event(
+			as_event(
+				{
+					"type": "channel",
+					"action": "event",
+					"channel": "detaching",
+					"event": "ping",
+				},
+			)
 		)
-	)
 	await asyncio.sleep(0)
 	channel.detach()
 	for _ in range(10):
@@ -1194,17 +1289,18 @@ async def test_event_backlog_drops_oldest_with_one_warning(
 
 	with caplog.at_level(logging.WARNING):
 		for i in range(MAX_QUEUED_EVENTS + 5):
-			render.channels.handle_event(
-				as_event(
-					{
-						"type": "channel",
-						"action": "event",
-						"channel": "backlog",
-						"event": "ping",
-						"payload": i,
-					},
+			with ctx(app, session, render):
+				render.channels.handle_event(
+					as_event(
+						{
+							"type": "channel",
+							"action": "event",
+							"channel": "backlog",
+							"event": "ping",
+							"payload": i,
+						},
+					)
 				)
-			)
 		await asyncio.sleep(0)
 		# One event is in flight on the blocked handler, the rest wait in the queue.
 		assert len(channel._events) == MAX_QUEUED_EVENTS - 1  # pyright: ignore[reportPrivateUsage]
@@ -1230,17 +1326,18 @@ async def test_detach_cancels_event_pump():
 		channel = ps.channel("cancel-pump", lifetime="tab")
 		channel.on("ping", blocked)
 	for i in range(2):
-		render.channels.handle_event(
-			as_event(
-				{
-					"type": "channel",
-					"action": "event",
-					"channel": "cancel-pump",
-					"event": "ping",
-					"payload": i,
-				},
+		with ctx(app, session, render):
+			render.channels.handle_event(
+				as_event(
+					{
+						"type": "channel",
+						"action": "event",
+						"channel": "cancel-pump",
+						"event": "ping",
+						"payload": i,
+					},
+				)
 			)
-		)
 	await asyncio.sleep(0)
 	pump = channel._pump  # pyright: ignore[reportPrivateUsage]
 	assert pump is not None and not pump.done()

--- a/packages/pulse/python/tests/test_channels.py
+++ b/packages/pulse/python/tests/test_channels.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from types import SimpleNamespace
 from typing import Any, cast, override
 
@@ -6,6 +7,7 @@ import pulse as ps
 import pytest
 from pulse.app import App
 from pulse.channel import (
+	MAX_QUEUED_EVENTS,
 	ChannelDetached,
 	ChannelDisconnected,
 	ChannelRemoteError,
@@ -1147,4 +1149,114 @@ async def test_detach_skips_pending_handlers():
 	channel.detach()
 	for _ in range(10):
 		await asyncio.sleep(0)
-	assert seen == ["first"]
+	# detach cancels the pump mid-await, so neither the suspended handler nor the
+	# ones queued behind it resume.
+	assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_malformed_response_is_dropped():
+	app, dummy, _session, render, user = build_middleware_session(PulseMiddleware())
+	errors: list[Any] = []
+
+	def report_error(*args: Any, **kwargs: Any) -> None:
+		errors.append(args)
+
+	render.report_error = report_error  # pyright: ignore[reportAttributeAccessIssue]
+
+	for message in (
+		{"type": "channel", "action": "response", "channel": "c"},
+		{"type": "channel", "action": "response", "responseTo": "req-1"},
+		{"type": "channel", "action": "response", "channel": "c", "responseTo": 3},
+	):
+		await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
+			render, user, as_response(message)
+		)
+	assert dummy.sent == []
+	assert errors == []
+
+
+@pytest.mark.asyncio
+async def test_event_backlog_drops_oldest_with_one_warning(
+	caplog: pytest.LogCaptureFixture,
+):
+	app, _dummy, session, render, _route = build_session()
+	release = asyncio.Event()
+	seen: list[Any] = []
+
+	async def blocked(payload: Any) -> None:
+		seen.append(payload)
+		await release.wait()
+
+	with ctx(app, session, render):
+		channel = ps.channel("backlog", lifetime="tab")
+		channel.on("ping", blocked)
+
+	with caplog.at_level(logging.WARNING):
+		for i in range(MAX_QUEUED_EVENTS + 5):
+			render.channels.handle_event(
+				as_event(
+					{
+						"type": "channel",
+						"action": "event",
+						"channel": "backlog",
+						"event": "ping",
+						"payload": i,
+					},
+				)
+			)
+		await asyncio.sleep(0)
+		# One event is in flight on the blocked handler, the rest wait in the queue.
+		assert len(channel._events) == MAX_QUEUED_EVENTS - 1  # pyright: ignore[reportPrivateUsage]
+	warnings = [r for r in caplog.records if "event backlog" in r.getMessage()]
+	assert len(warnings) == 1
+	release.set()
+	await wait_for(lambda: len(seen) == MAX_QUEUED_EVENTS)
+	# The 5 oldest events were shed; the newest survive, in order.
+	assert seen == list(range(5, MAX_QUEUED_EVENTS + 5))
+
+
+@pytest.mark.asyncio
+async def test_detach_cancels_event_pump():
+	app, _dummy, session, render, _route = build_session()
+	release = asyncio.Event()
+	seen: list[Any] = []
+
+	async def blocked(payload: Any) -> None:
+		seen.append(payload)
+		await release.wait()
+
+	with ctx(app, session, render):
+		channel = ps.channel("cancel-pump", lifetime="tab")
+		channel.on("ping", blocked)
+	for i in range(2):
+		render.channels.handle_event(
+			as_event(
+				{
+					"type": "channel",
+					"action": "event",
+					"channel": "cancel-pump",
+					"event": "ping",
+					"payload": i,
+				},
+			)
+		)
+	await asyncio.sleep(0)
+	pump = channel._pump  # pyright: ignore[reportPrivateUsage]
+	assert pump is not None and not pump.done()
+	channel.detach()
+	release.set()
+	await wait_for(lambda: pump.cancelled())
+	assert pump.cancelled()
+	assert seen == [0]
+
+
+@pytest.mark.asyncio
+async def test_connected_emit_still_fails_on_unserializable_payload():
+	app, _dummy, session, render, _route = build_session(connected=True)
+	# The live socket serializes in the emitter's frame; nothing to validate twice.
+	render.send = lambda message: serialize(message)  # pyright: ignore[reportAttributeAccessIssue]
+	with ctx(app, session, render):
+		channel = ps.channel("live-bad", lifetime="tab")
+		with pytest.raises(TypeError):
+			channel.emit("ping", {"cls": object})

--- a/packages/pulse/python/tests/test_channels.py
+++ b/packages/pulse/python/tests/test_channels.py
@@ -19,6 +19,7 @@ from pulse.middleware import Deny, PulseMiddleware, stack
 from pulse.render_session import RenderSession
 from pulse.routing import Route, RouteContext, RouteInfo, RouteTree
 from pulse.serializer import serialize
+from pulse.test_helpers import wait_for
 from pulse.user_session import UserSession
 
 
@@ -166,10 +167,8 @@ async def test_new_handle_after_route_detach():
 	render.channels.detach_route("/")
 	with pytest.raises(ChannelDetached):
 		first.on("pong", lambda _: None)
-	first.emit("still-routes")
-	assert dummy.sent[-1]["type"] == "channel"
-	assert dummy.sent[-1]["action"] == "event"
-	assert dummy.sent[-1]["channel"] == "foo"
+	first.emit("dropped")
+	assert dummy.sent == []
 	with ctx(app, session, render, route):
 		second = ps.channel("foo")
 	assert second is not first
@@ -902,3 +901,250 @@ async def test_unserializable_request_result_nacks():
 	)
 	nacks = [msg for msg in dummy.sent if msg.get("type") == "channel"]
 	assert nacks[-1]["error"]["code"] == "handler_error"
+
+
+def build_middleware_session(middleware: PulseMiddleware):
+	app = ps.App(middleware=middleware)
+	dummy = DummyRender()
+	session = SimpleNamespace(sid="session-1", data={})
+	render = ps.RenderSession(dummy.id, app.routes)
+	render.send = dummy.send  # pyright: ignore[reportAttributeAccessIssue]
+	render.connected = True
+	app.render_sessions[render.id] = render
+	app._render_to_user[render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
+	app.user_sessions[session.sid] = session  # pyright: ignore[reportArgumentType]
+	return app, dummy, session, render, cast(UserSession, cast(object, session))
+
+
+@pytest.mark.asyncio
+async def test_deny_after_next_sends_single_nack():
+	class DenyAfterNext(PulseMiddleware):
+		@override
+		async def channel(self, **kwargs: Any):
+			await kwargs["next"]()
+			return Deny()
+
+	app, dummy, session, render, user = build_middleware_session(DenyAfterNext())
+	calls: list[Any] = []
+	with ctx(app, session, render):
+		channel = ps.channel("late-deny", lifetime="tab")
+		channel.on("ping", lambda payload: calls.append(payload))
+
+	await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
+		render,
+		user,
+		as_request(
+			{
+				"type": "channel",
+				"action": "request",
+				"channel": "late-deny",
+				"event": "ping",
+				"requestId": "req-late-deny",
+			},
+		),
+	)
+	for _ in range(10):
+		await asyncio.sleep(0)
+	responses = [msg for msg in dummy.sent if msg.get("action") == "response"]
+	assert len(responses) == 1
+	assert responses[0]["error"] == {"code": "denied", "message": "Denied"}
+	assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_raise_after_next_sends_single_nack():
+	class BoomAfterNext(PulseMiddleware):
+		@override
+		async def channel(self, **kwargs: Any):
+			await kwargs["next"]()
+			raise RuntimeError("middleware down")
+
+	app, dummy, session, render, user = build_middleware_session(BoomAfterNext())
+	calls: list[Any] = []
+	with ctx(app, session, render):
+		channel = ps.channel("late-boom", lifetime="tab")
+		channel.on("ping", lambda payload: calls.append(payload))
+
+	await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
+		render,
+		user,
+		as_request(
+			{
+				"type": "channel",
+				"action": "request",
+				"channel": "late-boom",
+				"event": "ping",
+				"requestId": "req-late-boom",
+			},
+		),
+	)
+	for _ in range(10):
+		await asyncio.sleep(0)
+	responses = [msg for msg in dummy.sent if msg.get("action") == "response"]
+	assert len(responses) == 1
+	assert responses[0]["error"]["code"] == "handler_error"
+	assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_request_without_request_id_is_dropped():
+	app, dummy, session, render, user = build_middleware_session(PulseMiddleware())
+	with ctx(app, session, render):
+		ps.channel("no-id", lifetime="tab")
+
+	await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
+		render,
+		user,
+		as_request(
+			{
+				"type": "channel",
+				"action": "request",
+				"channel": "no-id",
+				"event": "ping",
+			},
+		),
+	)
+	for _ in range(10):
+		await asyncio.sleep(0)
+	assert dummy.sent == []
+
+
+@pytest.mark.asyncio
+async def test_cancelled_request_clears_pending():
+	app, _dummy, session, render, _route = build_session(connected=True)
+	with ctx(app, session, render):
+		channel = ps.channel("cancelled", lifetime="tab")
+		pending = asyncio.create_task(channel.request("get"))
+	await asyncio.sleep(0)
+	assert render.channels._pending  # pyright: ignore[reportPrivateUsage]
+	pending.cancel()
+	with pytest.raises(asyncio.CancelledError):
+		await pending
+	assert render.channels._pending == {}  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.asyncio
+async def test_timed_out_request_clears_pending():
+	app, _dummy, session, render, _route = build_session(connected=True)
+	with ctx(app, session, render):
+		channel = ps.channel("slow", lifetime="tab")
+		with pytest.raises(ps.ChannelTimeout):
+			await channel.request("get", timeout=0.01)
+	assert render.channels._pending == {}  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.asyncio
+async def test_unserializable_emit_raises_at_emitter():
+	app, dummy, session, render, _route = build_session()
+	with ctx(app, session, render):
+		channel = ps.channel("bad-emit", lifetime="tab")
+		with pytest.raises(TypeError, match="not serializable"):
+			channel.emit("ping", {"cls": object})
+	assert dummy.sent == []
+	assert render._global_queue == []  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.asyncio
+async def test_response_channel_mismatch_is_ignored():
+	app, dummy, session, render, _route = build_session(connected=True)
+	with ctx(app, session, render):
+		channel = ps.channel("mine", lifetime="tab")
+		pending = asyncio.create_task(channel.request("get"))
+	await asyncio.sleep(0)
+	request_id = dummy.sent[0]["requestId"]
+	render.channels.handle_response(
+		as_response(
+			{
+				"type": "channel",
+				"action": "response",
+				"channel": "theirs",
+				"responseTo": request_id,
+				"payload": "stolen",
+			},
+		)
+	)
+	await asyncio.sleep(0)
+	assert not pending.done()
+	render.channels.handle_response(
+		as_response(
+			{
+				"type": "channel",
+				"action": "response",
+				"channel": "mine",
+				"responseTo": request_id,
+				"payload": "ok",
+			},
+		)
+	)
+	assert await pending == "ok"
+
+
+@pytest.mark.asyncio
+async def test_detached_handle_rejects_request():
+	app, _dummy, session, render, _route = build_session(connected=True)
+	with ctx(app, session, render):
+		channel = ps.channel("dead", lifetime="tab")
+	channel.detach()
+	with pytest.raises(ChannelDetached):
+		await channel.request("get")
+
+
+@pytest.mark.asyncio
+async def test_events_run_in_arrival_order():
+	app, _dummy, session, render, _route = build_session()
+	seen: list[str] = []
+
+	async def slow(_: Any) -> None:
+		await asyncio.sleep(0.02)
+		seen.append("first")
+
+	async def fast(_: Any) -> None:
+		seen.append("second")
+
+	with ctx(app, session, render):
+		channel = ps.channel("ordered", lifetime="tab")
+		channel.on("first", slow)
+		channel.on("second", fast)
+	for event in ("first", "second"):
+		render.channels.handle_event(
+			as_event(
+				{
+					"type": "channel",
+					"action": "event",
+					"channel": "ordered",
+					"event": event,
+				},
+			)
+		)
+	await wait_for(lambda: len(seen) == 2)
+	assert seen == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_detach_skips_pending_handlers():
+	app, _dummy, session, render, _route = build_session()
+	seen: list[str] = []
+
+	async def first(_: Any) -> None:
+		await asyncio.sleep(0)
+		seen.append("first")
+
+	with ctx(app, session, render):
+		channel = ps.channel("detaching", lifetime="tab")
+		channel.on("ping", first)
+		channel.on("ping", lambda _: seen.append("second"))
+	render.channels.handle_event(
+		as_event(
+			{
+				"type": "channel",
+				"action": "event",
+				"channel": "detaching",
+				"event": "ping",
+			},
+		)
+	)
+	await asyncio.sleep(0)
+	channel.detach()
+	for _ in range(10):
+		await asyncio.sleep(0)
+	assert seen == ["first"]

--- a/packages/pulse/python/tests/test_channels.py
+++ b/packages/pulse/python/tests/test_channels.py
@@ -1,11 +1,23 @@
 import asyncio
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any, cast, override
 
 import pulse as ps
 import pytest
-from pulse.channel import ChannelClosed
-from pulse.messages import ClientChannelResponseMessage
+from pulse.app import App
+from pulse.channel import (
+	ChannelDetached,
+	ChannelDisconnected,
+	ChannelRemoteError,
+)
+from pulse.messages import (
+	ClientChannelEventMessage,
+	ClientChannelRequestMessage,
+	ClientChannelResponseMessage,
+)
+from pulse.middleware import Deny, PulseMiddleware
+from pulse.render_session import RenderSession
+from pulse.routing import Route, RouteContext, RouteInfo, RouteTree
 from pulse.user_session import UserSession
 
 
@@ -20,145 +32,430 @@ class DummyRender:
 		self.sent.append(message)
 
 
-@pytest.mark.asyncio
-async def test_channel_emit_sends_message():
-	app = ps.App()
-	render = DummyRender()
-	session = SimpleNamespace(sid="session-1")
-
-	real_render = ps.RenderSession(render.id, app.routes)
-	real_render.send = render.send  # pyright: ignore[reportAttributeAccessIssue]
-
-	app.render_sessions[render.id] = real_render
-	app._render_to_user[render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
-	app.user_sessions[session.sid] = session  # pyright: ignore[reportArgumentType]
-
-	with ps.PulseContext(
-		app=app,
-		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
-		render=real_render,
-	):
-		channel = real_render.channels.create("form-channel")
-		channel.emit("setValues", {"values": {"a": 1}})
-
-	assert len(render.sent) == 1
-	message = render.sent[0]
-	assert message["type"] == "channel_message"
-	assert message["channel"] == "form-channel"
-	assert message["event"] == "setValues"
-	assert message["payload"] == {"values": {"a": 1}}
-
-
-@pytest.mark.asyncio
-async def test_channel_request_resolves_on_response():
-	app = ps.App()
-	render = DummyRender()
-	session = SimpleNamespace(sid="session-2")
-
-	real_render = ps.RenderSession(render.id, app.routes)
-	real_render.send = render.send  # pyright: ignore[reportAttributeAccessIssue]
-
-	app.render_sessions[render.id] = real_render
-	app._render_to_user[render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
-	app.user_sessions[session.sid] = session  # pyright: ignore[reportArgumentType]
-
-	with ps.PulseContext(
-		app=app,
-		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
-		render=real_render,
-	):
-		channel = real_render.channels.create("req-channel")
-		pending = asyncio.create_task(channel.request("get", {"x": 1}))
-
-	await asyncio.sleep(0)
-	assert len(render.sent) == 1
-	request_message = render.sent[0]
-	request_id = request_message.get("requestId")
-	assert request_id
-
-	real_render.channels.handle_client_response(
-		message=cast(
-			ClientChannelResponseMessage,
-			cast(
-				object,
-				{
-					"type": "channel_message",
-					"channel": "req-channel",
-					"responseTo": request_id,
-					"payload": {"x": 2},
-				},
-			),
-		)
+def _route_info() -> RouteInfo:
+	return cast(
+		RouteInfo,
+		cast(
+			object,
+			{
+				"pathname": "/",
+				"hash": "",
+				"query": "",
+				"queryParams": {},
+				"pathParams": {},
+				"catchall": [],
+			},
+		),
 	)
 
-	result = await pending
-	assert result == {"x": 2}
+
+def as_event(message: object) -> ClientChannelEventMessage:
+	return cast(ClientChannelEventMessage, message)
+
+
+def as_request(message: object) -> ClientChannelRequestMessage:
+	return cast(ClientChannelRequestMessage, message)
+
+
+def as_response(message: object) -> ClientChannelResponseMessage:
+	return cast(ClientChannelResponseMessage, message)
+
+
+def build_session(*, connected: bool = False, with_route: bool = False):
+	def page():
+		return ps.div()
+
+	route = Route("/", ps.component(page))
+	routes = RouteTree([route]) if with_route else None
+	app = ps.App(routes=[route] if with_route else None)
+	dummy = DummyRender()
+	session = SimpleNamespace(sid="session-1", data={})
+	real_render = ps.RenderSession(
+		dummy.id, routes or app.routes, server_address="http://localhost"
+	)
+	real_render.send = dummy.send  # pyright: ignore[reportAttributeAccessIssue]
+	real_render.connected = connected
+	app.render_sessions[real_render.id] = real_render
+	app._render_to_user[real_render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
+	app.user_sessions[session.sid] = session  # pyright: ignore[reportArgumentType]
+	route_ctx = None
+	if with_route:
+		with ps.PulseContext(app=app):
+			real_render.prerender(["/"], _route_info())
+		route_ctx = real_render.route_mounts["/"].route
+	return app, dummy, session, real_render, route_ctx
+
+
+def ctx(
+	app: App,
+	session: Any,
+	render: RenderSession,
+	route: RouteContext | None = None,
+):
+	return ps.PulseContext(
+		app=app,
+		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
+		render=render,
+		route=route,
+	)
 
 
 @pytest.mark.asyncio
-async def test_channel_event_dispatch():
-	app = ps.App()
-	render = DummyRender()
-	session = SimpleNamespace(sid="session-3")
+async def test_empty_identifier_raises():
+	app, _dummy, session, render, _route = build_session()
+	with ctx(app, session, render):
+		with pytest.raises(ValueError, match="empty"):
+			ps.channel("")
 
-	real_render = ps.RenderSession(render.id, app.routes)
-	real_render.send = render.send  # pyright: ignore[reportAttributeAccessIssue]
 
-	app.render_sessions[render.id] = real_render
-	app._render_to_user[render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
-	app.user_sessions[session.sid] = session  # pyright: ignore[reportArgumentType]
+@pytest.mark.asyncio
+async def test_none_identifier_generates_uuid():
+	app, _dummy, session, render, _route = build_session()
+	with ctx(app, session, render):
+		channel = ps.channel()
+	assert len(channel.id) == 36
 
+
+@pytest.mark.asyncio
+async def test_intern_same_handle_during_route_mount():
+	app, _dummy, session, render, route = build_session(with_route=True)
+	with ctx(app, session, render, route):
+		first = ps.channel("foo")
+		second = ps.channel("foo")
+	assert first is second
+
+
+@pytest.mark.asyncio
+async def test_new_handle_after_route_detach():
+	app, dummy, session, render, route = build_session(with_route=True)
+	with ctx(app, session, render, route):
+		first = ps.channel("foo")
+		first.on("ping", lambda _: None)
+	render.channels.detach_route("/")
+	with pytest.raises(ChannelDetached):
+		first.on("pong", lambda _: None)
+	first.emit("still-routes")
+	assert dummy.sent[-1]["type"] == "channel"
+	assert dummy.sent[-1]["action"] == "event"
+	assert dummy.sent[-1]["channel"] == "foo"
+	with ctx(app, session, render, route):
+		second = ps.channel("foo")
+	assert second is not first
+	second.on("ping", lambda _: None)
+
+
+@pytest.mark.asyncio
+async def test_tab_handle_survives_route_unmount():
+	app, _dummy, session, render, route = build_session(with_route=True)
 	received: list[Any] = []
-
-	with ps.PulseContext(
-		app=app,
-		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
-		render=real_render,
-	):
-		channel = real_render.channels.create("event-channel")
-		channel.on("ping", lambda payload: received.append(payload))
-
-	with ps.PulseContext(
-		app=app,
-		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
-		render=real_render,
-	):
-		real_render.channels.handle_client_event(
-			render=real_render,
-			session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
-			message={
-				"type": "channel_message",
-				"channel": "event-channel",
+	with ctx(app, session, render, route):
+		handle = ps.channel("tab-box", lifetime="tab")
+		handle.on("ping", lambda payload: received.append(payload))
+	render.channels.detach_route("/")
+	handle.on("still-ok", lambda _: None)
+	render.channels.handle_event(
+		as_event(
+			{
+				"type": "channel",
+				"action": "event",
+				"channel": "tab-box",
 				"event": "ping",
-				"payload": {"value": 42},
+				"payload": 1,
 			},
 		)
-
+	)
 	await asyncio.sleep(0)
-	assert received == [{"value": 42}]
+	assert received == [1]
 
 
 @pytest.mark.asyncio
-async def test_channel_pending_cancelled_on_render_close():
+async def test_emit_sends_channel_event():
+	app, dummy, session, render, _route = build_session()
+	with ctx(app, session, render):
+		channel = ps.channel("form-channel")
+		channel.emit("setValues", {"values": {"a": 1}})
+	assert dummy.sent == [
+		{
+			"type": "channel",
+			"action": "event",
+			"channel": "form-channel",
+			"event": "setValues",
+			"payload": {"values": {"a": 1}},
+		}
+	]
+
+
+@pytest.mark.asyncio
+async def test_request_resolves_on_response():
+	app, dummy, session, render, _route = build_session(connected=True)
+	with ctx(app, session, render):
+		channel = ps.channel("req-channel")
+		pending = asyncio.create_task(channel.request("get", {"x": 1}))
+	await asyncio.sleep(0)
+	assert dummy.sent[0]["type"] == "channel"
+	assert dummy.sent[0]["action"] == "request"
+	request_id = dummy.sent[0]["requestId"]
+	render.channels.handle_response(
+		as_response(
+			{
+				"type": "channel",
+				"action": "response",
+				"channel": "req-channel",
+				"responseTo": request_id,
+				"payload": {"x": 2},
+			},
+		)
+	)
+	assert await pending == {"x": 2}
+
+
+@pytest.mark.asyncio
+async def test_request_maps_remote_error():
+	app, dummy, session, render, _route = build_session(connected=True)
+	with ctx(app, session, render):
+		channel = ps.channel("err-channel")
+		pending = asyncio.create_task(channel.request("get"))
+	await asyncio.sleep(0)
+	render.channels.handle_response(
+		as_response(
+			{
+				"type": "channel",
+				"action": "response",
+				"channel": "err-channel",
+				"responseTo": dummy.sent[0]["requestId"],
+				"error": {"code": "no_handler", "message": "missing"},
+			},
+		)
+	)
+	with pytest.raises(ChannelRemoteError, match="no_handler") as exc:
+		await pending
+	assert exc.value.code == "no_handler"
+
+
+@pytest.mark.asyncio
+async def test_request_fail_fast_when_disconnected():
+	app, dummy, session, render, _route = build_session(connected=False)
+	with ctx(app, session, render):
+		channel = ps.channel("down")
+		with pytest.raises(ChannelDisconnected):
+			await channel.request("get")
+	assert dummy.sent == []
+
+
+@pytest.mark.asyncio
+async def test_request_nacks_without_handler():
+	app, dummy, session, render, _route = build_session()
+	with ctx(app, session, render):
+		ps.channel("empty")
+	await render.channels.handle_request(
+		as_request(
+			{
+				"type": "channel",
+				"action": "request",
+				"channel": "empty",
+				"event": "missing",
+				"requestId": "req-1",
+			},
+		)
+	)
+	assert dummy.sent[-1] == {
+		"type": "channel",
+		"action": "response",
+		"channel": "empty",
+		"responseTo": "req-1",
+		"error": {
+			"code": "no_handler",
+			"message": "No handler for 'missing' on channel 'empty'",
+		},
+	}
+
+
+@pytest.mark.asyncio
+async def test_event_without_listener_is_dropped():
+	app, dummy, session, render, _route = build_session()
+	with ctx(app, session, render):
+		ps.channel("quiet")
+	render.channels.handle_event(
+		as_event(
+			{
+				"type": "channel",
+				"action": "event",
+				"channel": "quiet",
+				"event": "ping",
+				"payload": 1,
+			},
+		)
+	)
+	assert dummy.sent == []
+
+
+@pytest.mark.asyncio
+async def test_event_fans_out_to_two_handles():
+	app, _dummy, session, render, _route = build_session()
+	seen: list[str] = []
+	with ctx(app, session, render):
+		a = render.channels.open_handle("shared")
+		b = render.channels.open_handle("shared")
+		a.on("ping", lambda _: seen.append("a"))
+		b.on("ping", lambda _: seen.append("b"))
+	render.channels.handle_event(
+		as_event(
+			{
+				"type": "channel",
+				"action": "event",
+				"channel": "shared",
+				"event": "ping",
+			},
+		)
+	)
+	await asyncio.sleep(0)
+	assert seen == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_transport_drop_rejects_rpc_and_keeps_listeners():
+	app, dummy, session, render, _route = build_session(connected=True)
+	received: list[Any] = []
+	with ctx(app, session, render):
+		channel = ps.channel("keep")
+		channel.on("ping", lambda payload: received.append(payload))
+		pending = asyncio.create_task(channel.request("get"))
+	await asyncio.sleep(0)
+	render.disconnect()
+	with pytest.raises(ChannelDisconnected):
+		await pending
+	assert dummy.sent[0]["action"] == "request"
+	render.channels.handle_event(
+		as_event(
+			{
+				"type": "channel",
+				"action": "event",
+				"channel": "keep",
+				"event": "ping",
+				"payload": "still-here",
+			},
+		)
+	)
+	await asyncio.sleep(0)
+	assert received == ["still-here"]
+
+
+@pytest.mark.asyncio
+async def test_session_end_rejects_rpc():
+	app, _dummy, session, render, _route = build_session(connected=True)
+	with ctx(app, session, render):
+		channel = ps.channel("end")
+		pending = asyncio.create_task(channel.request("get"))
+	await asyncio.sleep(0)
+	render.close()
+	with pytest.raises(ChannelDisconnected):
+		await pending
+	with pytest.raises(ChannelDetached):
+		channel.on("x", lambda _: None)
+
+
+@pytest.mark.asyncio
+async def test_emit_while_disconnected_uses_global_queue():
 	app = ps.App()
-	render = DummyRender()
-	session = SimpleNamespace(sid="session-4")
+	session = SimpleNamespace(sid="session-1", data={})
+	render = ps.RenderSession("render-q", app.routes)
+	with ctx(app, session, render):
+		channel = ps.channel("queued")
+		channel.emit("ping", {"n": 1})
+	assert render._global_queue == [  # pyright: ignore[reportPrivateUsage]
+		{
+			"type": "channel",
+			"action": "event",
+			"channel": "queued",
+			"event": "ping",
+			"payload": {"n": 1},
+		}
+	]
 
-	real_render = ps.RenderSession(render.id, app.routes)
-	real_render.send = render.send  # pyright: ignore[reportAttributeAccessIssue]
 
-	app.render_sessions[render.id] = real_render
+@pytest.mark.asyncio
+async def test_middleware_deny_drops_event_and_nacks_request():
+	class DenyChannel(PulseMiddleware):
+		@override
+		async def channel(self, **kwargs: Any):
+			return Deny()
+
+	app = ps.App(middleware=DenyChannel())
+	dummy = DummyRender()
+	session = SimpleNamespace(sid="session-1", data={})
+	render = ps.RenderSession(dummy.id, app.routes)
+	render.send = dummy.send  # pyright: ignore[reportAttributeAccessIssue]
+	app.render_sessions[render.id] = render
 	app._render_to_user[render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
 	app.user_sessions[session.sid] = session  # pyright: ignore[reportArgumentType]
+	user = cast(UserSession, cast(object, session))
 
-	with ps.PulseContext(
-		app=app,
-		session=cast(UserSession, session),  # pyright: ignore[reportInvalidCast]
-		render=real_render,
-	):
-		channel = real_render.channels.create("close-channel")
-		pending = asyncio.create_task(channel.request("get", None))
+	await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
+		render,
+		user,
+		as_event(
+			{
+				"type": "channel",
+				"action": "event",
+				"channel": "gated",
+				"event": "ping",
+			},
+		),
+	)
+	assert dummy.sent == []
 
-	real_render.close()
-	with pytest.raises(ChannelClosed):
-		await pending
+	await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
+		render,
+		user,
+		as_request(
+			{
+				"type": "channel",
+				"action": "request",
+				"channel": "gated",
+				"event": "ping",
+				"requestId": "req-deny",
+			},
+		),
+	)
+	assert dummy.sent[-1]["error"] == {"code": "denied", "message": "Denied"}
+
+
+@pytest.mark.asyncio
+async def test_middleware_skips_responses():
+	seen: list[str] = []
+
+	class Spy(PulseMiddleware):
+		@override
+		async def channel(self, **kwargs: Any):
+			seen.append(kwargs["event"])
+			return await kwargs["next"]()
+
+	app = ps.App(middleware=Spy())
+	dummy = DummyRender()
+	session = SimpleNamespace(sid="session-1", data={})
+	render = ps.RenderSession(dummy.id, app.routes)
+	render.send = dummy.send  # pyright: ignore[reportAttributeAccessIssue]
+	render.connected = True
+	app.render_sessions[render.id] = render
+	app._render_to_user[render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
+	app.user_sessions[session.sid] = session  # pyright: ignore[reportArgumentType]
+	user = cast(UserSession, cast(object, session))
+	with ctx(app, session, render):
+		channel = ps.channel("mid")
+		pending = asyncio.create_task(channel.request("echo"))
+	await asyncio.sleep(0)
+	await app._handle_channel_message(  # pyright: ignore[reportPrivateUsage]
+		render,
+		user,
+		as_response(
+			{
+				"type": "channel",
+				"action": "response",
+				"channel": "mid",
+				"responseTo": dummy.sent[0]["requestId"],
+				"payload": "ok",
+			},
+		),
+	)
+	assert await pending == "ok"
+	assert seen == []

--- a/packages/pulse/python/tests/test_channels.py
+++ b/packages/pulse/python/tests/test_channels.py
@@ -62,6 +62,18 @@ def as_response(message: object) -> ClientChannelResponseMessage:
 	return cast(ClientChannelResponseMessage, message)
 
 
+@ps.component
+def _leaky_redirect_page():
+	channel = ps.channel("leaky")
+	channel.on("ping", lambda _: None)
+	raise ps.RedirectInterrupt("/other", replace=True)
+
+
+@ps.component
+def _other_page():
+	return ps.div()
+
+
 def build_session(*, connected: bool = False, with_route: bool = False):
 	def page():
 		return ps.div()
@@ -126,6 +138,14 @@ async def test_route_lifetime_requires_route_context():
 		handle = ps.channel("x", lifetime="tab")
 	assert handle.lifetime == "tab"
 	assert handle is not None
+
+
+@pytest.mark.asyncio
+async def test_invalid_lifetime_raises():
+	app, _dummy, session, render, route = build_session(with_route=True)
+	with ctx(app, session, render, route):
+		with pytest.raises(ValueError, match="lifetime"):
+			ps.channel("x", lifetime=cast(Any, "typo"))
 
 
 @pytest.mark.asyncio
@@ -702,3 +722,70 @@ async def test_inbound_request_does_not_hold_session_lock():
 		"responseTo": "from-client",
 		"payload": "pong",
 	}
+
+
+@pytest.mark.asyncio
+async def test_stale_on_remover_does_not_drop_new_handler():
+	app, _dummy, session, render, route = build_session(with_route=True)
+	seen: list[str] = []
+	with ctx(app, session, render, route):
+		channel = ps.channel("once")
+		remove_first = channel.on("ping", lambda _: seen.append("first"))
+		remove_first()
+		channel.on("ping", lambda _: seen.append("second"))
+		remove_first()
+	render.channels.handle_event(
+		as_event(
+			{
+				"type": "channel",
+				"action": "event",
+				"channel": "once",
+				"event": "ping",
+			},
+		)
+	)
+	await asyncio.sleep(0)
+	assert seen == ["second"]
+
+
+@pytest.mark.asyncio
+async def test_prerender_redirect_detaches_route_handles():
+	route = Route("/", _leaky_redirect_page)
+	app = ps.App(routes=[route, Route("/other", _other_page)])
+	session = SimpleNamespace(sid="session-1", data={})
+	render = ps.RenderSession("render-redirect", app.routes)
+	with ctx(app, session, render):
+		result = render.prerender(["/"], _route_info())["/"]
+	assert result["type"] == "navigate_to"
+	assert "/" not in render.route_mounts
+	assert render.channels._handles_for("leaky") == []  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.asyncio
+async def test_unserializable_request_result_nacks():
+	from pulse.serializer import serialize as wire_serialize
+
+	app, dummy, session, render, route = build_session(with_route=True)
+	del render.send  # pyright: ignore[reportAttributeAccessIssue]
+
+	def send(message: dict[str, Any]) -> None:
+		wire_serialize(message)
+		dummy.sent.append(message)
+
+	render.connect(send)  # pyright: ignore[reportArgumentType]
+	with ctx(app, session, render, route):
+		channel = ps.channel("bad")
+		channel.on("get", lambda _: object)
+	await render.channels.handle_request(
+		as_request(
+			{
+				"type": "channel",
+				"action": "request",
+				"channel": "bad",
+				"event": "get",
+				"requestId": "req-bad",
+			},
+		)
+	)
+	nacks = [msg for msg in dummy.sent if msg.get("type") == "channel"]
+	assert nacks[-1]["error"]["code"] == "handler_error"

--- a/packages/pulse/python/tests/test_refs.py
+++ b/packages/pulse/python/tests/test_refs.py
@@ -33,7 +33,7 @@ class DummyChannel:
 			return self.responses.pop(0)
 		return None
 
-	def close(self) -> None:
+	def detach(self) -> None:
 		return None
 
 

--- a/packages/pulse/python/tests/test_render_session.py
+++ b/packages/pulse/python/tests/test_render_session.py
@@ -8,6 +8,7 @@ that updates from one session do not leak into the other.
 
 import asyncio
 import gc
+import logging
 from collections.abc import Callable, Iterator
 from typing import Any, cast, override
 
@@ -18,7 +19,7 @@ from pulse.hooks.core import HookContext
 from pulse.hooks.runtime import NotFoundInterrupt, RedirectInterrupt
 from pulse.messages import ServerMessage
 from pulse.reactive import Effect
-from pulse.render_session import RenderSession
+from pulse.render_session import MAX_DISCONNECT_QUEUE, RenderSession
 from pulse.routing import Route, RouteInfo, RouteTree
 from pulse.test_helpers import wait_for
 from pulse.transpiler.nodes import Element, PulseNode
@@ -2220,3 +2221,38 @@ def test_report_error_fans_out_when_path_is_unmounted():
 	assert scoped[0]["path"] == "/dash"
 
 	session.close()
+
+
+def test_disconnect_queue_drops_oldest_with_one_warning(
+	caplog: pytest.LogCaptureFixture,
+):
+	app = ps.App()
+	session = ps.RenderSession("render-cap", app.routes)
+	with caplog.at_level(logging.WARNING):
+		for i in range(MAX_DISCONNECT_QUEUE + 5):
+			session.channels.send_event("cap", f"e{i}", None)
+	queue = session._global_queue  # pyright: ignore[reportPrivateUsage]
+	assert len(queue) == MAX_DISCONNECT_QUEUE
+	assert cast(Any, queue[0])["event"] == "e5"
+	warnings = [r for r in caplog.records if "disconnect queue" in r.getMessage()]
+	assert len(warnings) == 1
+
+
+def test_connect_drain_survives_undeliverable_message():
+	app = ps.App()
+	session = ps.RenderSession("render-drain", app.routes)
+	session.channels.send_event("drain", "bad", None)
+	session.channels.send_event("drain", "good", None)
+	delivered: list[ServerMessage] = []
+
+	def send(message: ServerMessage) -> None:
+		if cast(Any, message).get("event") == "bad":
+			raise RuntimeError("transport blew up")
+		delivered.append(message)
+
+	session.connect(send)
+	assert [cast(Any, m)["event"] for m in delivered] == ["good"]
+	assert session.connected
+	session.channels.send_event("drain", "after", None)
+	assert [cast(Any, m)["event"] for m in delivered] == ["good", "after"]
+	assert session._global_queue == []  # pyright: ignore[reportPrivateUsage]

--- a/packages/pulse/python/tests/test_render_session.py
+++ b/packages/pulse/python/tests/test_render_session.py
@@ -19,7 +19,7 @@ from pulse.hooks.core import HookContext
 from pulse.hooks.runtime import NotFoundInterrupt, RedirectInterrupt
 from pulse.messages import ServerMessage
 from pulse.reactive import Effect
-from pulse.render_session import MAX_DISCONNECT_QUEUE, RenderSession
+from pulse.render_session import MAX_QUEUED_CHANNEL_MESSAGES, RenderSession
 from pulse.routing import Route, RouteInfo, RouteTree
 from pulse.test_helpers import wait_for
 from pulse.transpiler.nodes import Element, PulseNode
@@ -2223,19 +2223,31 @@ def test_report_error_fans_out_when_path_is_unmounted():
 	session.close()
 
 
-def test_disconnect_queue_drops_oldest_with_one_warning(
+def test_disconnect_queue_drops_oldest_channel_events_with_one_warning(
 	caplog: pytest.LogCaptureFixture,
 ):
 	app = ps.App()
 	session = ps.RenderSession("render-cap", app.routes)
 	with caplog.at_level(logging.WARNING):
-		for i in range(MAX_DISCONNECT_QUEUE + 5):
+		for i in range(MAX_QUEUED_CHANNEL_MESSAGES + 5):
 			session.channels.send_event("cap", f"e{i}", None)
 	queue = session._global_queue  # pyright: ignore[reportPrivateUsage]
-	assert len(queue) == MAX_DISCONNECT_QUEUE
+	assert len(queue) == MAX_QUEUED_CHANNEL_MESSAGES
 	assert cast(Any, queue[0])["event"] == "e5"
 	warnings = [r for r in caplog.records if "disconnect queue" in r.getMessage()]
 	assert len(warnings) == 1
+
+
+def test_channel_overflow_keeps_control_plane_messages():
+	app = ps.App()
+	session = ps.RenderSession("render-control", app.routes)
+	session.send({"type": "reload"})
+	for i in range(MAX_QUEUED_CHANNEL_MESSAGES + 50):
+		session.channels.send_event("cap", f"e{i}", None)
+	queue = session._global_queue  # pyright: ignore[reportPrivateUsage]
+	assert [m["type"] for m in queue].count("reload") == 1
+	assert len(queue) == MAX_QUEUED_CHANNEL_MESSAGES + 1
+	assert cast(Any, queue[1])["event"] == "e50"
 
 
 def test_connect_drain_survives_undeliverable_message():

--- a/packages/pulse/python/tests/test_render_session.py
+++ b/packages/pulse/python/tests/test_render_session.py
@@ -2178,3 +2178,45 @@ async def test_async_callback_error_reports_real_traceback():
 	assert "NoneType: None" not in err["stack"]
 
 	session.close()
+
+
+def test_report_error_fans_out_when_path_is_unmounted():
+	routes = RouteTree(
+		[Route("dash", simple_component), Route("other", simple_component)]
+	)
+	session = RenderSession("test-id", routes)
+	messages: list[ServerMessage] = []
+	session.connect(lambda msg: messages.append(msg))
+
+	with ps.PulseContext.update(render=session):
+		session.prerender(["/dash", "/other"])
+		session.attach("/dash", make_route_info("/dash"))
+		session.attach("/other", make_route_info("/other"))
+
+	session.report_error(None, "channel", RuntimeError("no path"))
+	session.report_error("/", "connect", RuntimeError("stale root"))
+	session.report_error("/dash", "callback", RuntimeError("route scoped"))
+
+	channel_paths = [
+		m["path"]
+		for m in messages
+		if m["type"] == "server_error" and cast(Any, m)["error"]["message"] == "no path"
+	]
+	connect_paths = [
+		m["path"]
+		for m in messages
+		if m["type"] == "server_error"
+		and cast(Any, m)["error"]["message"] == "stale root"
+	]
+	scoped = [
+		m
+		for m in messages
+		if m["type"] == "server_error"
+		and cast(Any, m)["error"]["message"] == "route scoped"
+	]
+	assert sorted(channel_paths) == ["/dash", "/other"]
+	assert sorted(connect_paths) == ["/dash", "/other"]
+	assert len(scoped) == 1
+	assert scoped[0]["path"] == "/dash"
+
+	session.close()

--- a/packages/pulse/python/tests/test_renderer.py
+++ b/packages/pulse/python/tests/test_renderer.py
@@ -1286,14 +1286,14 @@ async def test_ref_on_mount_uses_route_context():
 		render.prerender(["/"])
 
 	assert handle is not None
-	render.channels.handle_client_event(
-		render=render,
-		session=session,
-		message={
+	render.channels.handle_event(
+		{
+			"type": "channel",
+			"action": "event",
 			"channel": handle.channel_id,
 			"event": "ref:mounted",
 			"payload": {"refId": handle.id},
-		},
+		}
 	)
 	await asyncio.wait_for(mounted.wait(), timeout=1)
 	assert seen.get("path") == "/"

--- a/packages/pulse/python/tests/test_renderer.py
+++ b/packages/pulse/python/tests/test_renderer.py
@@ -1286,15 +1286,16 @@ async def test_ref_on_mount_uses_route_context():
 		render.prerender(["/"])
 
 	assert handle is not None
-	render.channels.handle_event(
-		{
-			"type": "channel",
-			"action": "event",
-			"channel": handle.channel_id,
-			"event": "ref:mounted",
-			"payload": {"refId": handle.id},
-		}
-	)
+	with ps.PulseContext(app=app, session=session, render=render):
+		render.channels.handle_event(
+			{
+				"type": "channel",
+				"action": "event",
+				"channel": handle.channel_id,
+				"event": "ref:mounted",
+				"payload": {"refId": handle.id},
+			}
+		)
 	await asyncio.wait_for(mounted.wait(), timeout=1)
 	assert seen.get("path") == "/"
 

--- a/skills/pulse/references/channels.md
+++ b/skills/pulse/references/channels.md
@@ -66,11 +66,11 @@ cleanup()
 ## Client-side
 
 ```python
-from pulse.js.pulse import usePulseChannel
+from pulse.js.pulse import useChannel
 
 @ps.javascript(jsx=True)
 def ChatClient(*, channel_id: str):
-    bridge = usePulseChannel(channel_id)
+    bridge = useChannel(channel_id)
 
     def sendMessage(text: str):
         bridge.emit("client:message", {"text": text})

--- a/skills/pulse/references/channels.md
+++ b/skills/pulse/references/channels.md
@@ -35,7 +35,7 @@ self.channel.emit("server:notify", {"type": "update", "data": {...}})
 
 If the WebSocket is down, emit uses the session global queue. No per-channel buffer.
 
-Do not emit during prerender / first server render and expect the client to hear it. `useChannel` registers during render, so an emit after the client has rendered the hook is delivered. Earlier events drop — no listener yet.
+Do not emit during prerender / first server render and expect the client to hear it. `useChannel` attaches in an effect, so events emitted before that effect runs can drop — no listener yet.
 
 ### Request (with response)
 
@@ -84,9 +84,9 @@ def ChatClient(*, channel_id: str):
     return ps.div(...)
 ```
 
-No `lifetime` argument. Place the hook in a layout to keep listeners across routes. The hook attaches during render (not only in `useEffect`).
+No `lifetime` argument. Place the hook in a layout to keep listeners across routes. The hook attaches in an effect.
 
-Two hooks → two handles, one name. Events fan out. RPC uses the first handler in attach order. Client `on()` is legal while detached (StrictMode). Optional `request(event, payload, { timeout })` is milliseconds.
+Two hooks → two handles, one name. Events fan out to all attached handles. Requests use the first attached handle in registration order that has a handler. Client `on()` is legal while detached (StrictMode). Optional `request(event, payload, { timeout })` is milliseconds; the default is 30 seconds. Detaching a handle rejects its in-flight requests with `PulseChannelDetachedError`; detached `emit()` warns once and still sends.
 
 ## Wire
 

--- a/skills/pulse/references/channels.md
+++ b/skills/pulse/references/channels.md
@@ -33,7 +33,7 @@ During a live route mount, `ps.channel("foo")` returns the same handle. `on(even
 self.channel.emit("server:notify", {"type": "update", "data": {...}})
 ```
 
-If the WebSocket is down, emit uses the session global queue (capped at 1000 messages, drop-oldest). No per-channel buffer. Payloads are serialized at emit time: unserializable payload → `TypeError` at the emitter.
+If the WebSocket is down, emit uses the session global queue: channel messages have their own 500-message drop-oldest budget (never evicting control-plane messages) inside an overall 1000-message bound. No per-channel buffer. Unserializable payload → `TypeError` at the emitter (validated before queueing; the live socket serializes in the emitter's frame anyway).
 
 Do not emit during prerender / first server render and expect the client to hear it. `useChannel` attaches in an effect, so events emitted before that effect runs can drop — no listener yet.
 
@@ -63,9 +63,9 @@ cleanup = self.channel.on("client:ping", self._on_ping)
 cleanup()
 ```
 
-After `detach()`: `on()` and `request()` raise `ChannelDetached`, `emit()` is a debug-logged no-op (emits race detach from background tasks). Queued handlers not yet run are skipped.
+After `detach()`: `on()` and `request()` raise `ChannelDetached`, `emit()` is a debug-logged no-op (emits race detach from background tasks). Queued and in-flight handlers are cancelled.
 
-Events on one handle are FIFO: each event's handlers are awaited before the next event runs. Inbound requests run as independent tasks (a request handler may `await` a client request, which must not block the session).
+Events on one handle are FIFO: each event's handlers are awaited before the next event runs, so an event handler must never block indefinitely (`await request(...)` with no `timeout` stalls the handle). Backlog capped at 500 events per handle, drop-oldest, warn once. FIFO covers events only: inbound requests run as independent tasks (a request handler may `await` a client request) and can overtake queued events.
 
 Several live handles can share a name, including a `"tab"` and a `"route"` handle. Events fan out to all. A request goes to the first attached handle with a handler for the event (registration order).
 

--- a/skills/pulse/references/channels.md
+++ b/skills/pulse/references/channels.md
@@ -1,6 +1,6 @@
 # Channels
 
-A channel id is a mailbox name scoped to a render session. Messages route by id. The only lifecycle is local listener attach/detach. The mailbox is not created or destroyed on the wire.
+A channel id is a session-scoped name. Messages route by id. The only lifecycle is local listener attach/detach. The name is not created or destroyed on the wire.
 
 ## Creating a handle
 
@@ -9,7 +9,7 @@ class ChatState(ps.State):
     messages: list[str] = []
 
     def __init__(self):
-        self.channel = ps.channel()
+        self.channel = ps.channel("chat")
         self._cleanup = self.channel.on("client:message", self._on_message)
 
     def _on_message(self, payload: dict):
@@ -21,9 +21,9 @@ class ChatState(ps.State):
 
 `ps.channel()` with `None` generates a UUID. Empty string raises `ValueError`. Pass `channel.id` to client components.
 
-`lifetime="route"` (default) auto-detaches this handle on route unmount. `lifetime="tab"` survives navigation until session end or `detach()`.
+`lifetime="route"` (default) auto-detaches this handle on real route unmount and requires a route context. `lifetime="tab"` survives navigation until session end or `detach()`.
 
-During a live route mount, `ps.channel("foo")` returns the same handle. After auto-detach, the next call is a new handle on the same mailbox.
+During a live route mount, `ps.channel("foo")` returns the same handle. `on(event, handler)` is idempotent for that triple. Use a stable method, not a new lambda each render. After auto-detach, the next call is a new handle on the same name.
 
 ## Server → Client
 
@@ -34,6 +34,8 @@ self.channel.emit("server:notify", {"type": "update", "data": {...}})
 ```
 
 If the WebSocket is down, emit uses the session global queue. No per-channel buffer.
+
+Do not emit during prerender / first server render and expect the client to hear it. `useChannel` registers during render, so an emit after the client has rendered the hook is delivered. Earlier events drop — no listener yet.
 
 ### Request (with response)
 
@@ -52,7 +54,7 @@ except ps.ChannelRemoteError as exc:
     print(exc.code, exc.message)
 ```
 
-No handler → immediate `no_handler` NACK. Never hangs when `timeout=None`. Requests are not queued while the socket is down.
+No handler → immediate `no_handler` NACK. Middleware `Deny` → `denied`. Middleware exception → `handler_error`. Requests are not queued while the socket is down.
 
 ## Client → Server
 
@@ -61,7 +63,7 @@ cleanup = self.channel.on("client:ping", self._on_ping)
 cleanup()
 ```
 
-`on()` after `detach()` raises `ChannelDetached`. `emit` / `request` still address the mailbox.
+`on()` after `detach()` raises `ChannelDetached`. `emit` / `request` still address the channel name.
 
 ## Client-side
 
@@ -82,9 +84,9 @@ def ChatClient(*, channel_id: str):
     return ps.div(...)
 ```
 
-No `lifetime` argument. Place the hook in a layout to keep listeners across routes.
+No `lifetime` argument. Place the hook in a layout to keep listeners across routes. The hook attaches during render (not only in `useEffect`).
 
-Two hooks → two handles, one mailbox. Events fan out. RPC uses the first handler in attach order.
+Two hooks → two handles, one name. Events fan out. RPC uses the first handler in attach order. Client `on()` is legal while detached (StrictMode). Optional `request(event, payload, { timeout })` is milliseconds.
 
 ## Wire
 
@@ -94,11 +96,11 @@ Two hooks → two handles, one mailbox. Events fan out. RPC uses the first handl
 {type:"channel", action:"response", channel, responseTo, payload?, error?}
 ```
 
-`error.code` is `no_handler` | `denied` | `handler_error`. No connect/disconnect/close/subscriptionId on the wire. Reconnect sends zero channel protocol traffic.
+`error.code` is `no_handler` | `denied` | `handler_error`. No connect/disconnect/close/subscriptionId on the wire. Reconnect sends zero channel protocol traffic. Events may flush from the global queue; request/response never do.
 
 ## Middleware
 
-`channel()` sees inbound events and requests only. `Deny` on event = drop. `Deny` on request = `denied` error response. Mailbox names are guessable; gate messages.
+`channel()` sees inbound events and requests only. `Deny` on event = drop. `Deny` on request = `denied` error response. Channel ids are guessable; gate messages.
 
 ## See Also
 

--- a/skills/pulse/references/channels.md
+++ b/skills/pulse/references/channels.md
@@ -1,8 +1,8 @@
 # Channels
 
-Bidirectional real-time communication between server (Python) and client (browser).
+A channel id is a mailbox name scoped to a render session. Messages route by id. The only lifecycle is local listener attach/detach. The mailbox is not created or destroyed on the wire.
 
-## Creating a Channel
+## Creating a handle
 
 ```python
 class ChatState(ps.State):
@@ -19,7 +19,11 @@ class ChatState(ps.State):
         self._cleanup()
 ```
 
-`ps.channel()` creates a unique channel ID. Pass `channel.id` to client components.
+`ps.channel()` with `None` generates a UUID. Empty string raises `ValueError`. Pass `channel.id` to client components.
+
+`lifetime="route"` (default) auto-detaches this handle on route unmount. `lifetime="tab"` survives navigation until session end or `detach()`.
+
+During a live route mount, `ps.channel("foo")` returns the same handle. After auto-detach, the next call is a new handle on the same mailbox.
 
 ## Server → Client
 
@@ -29,6 +33,8 @@ class ChatState(ps.State):
 self.channel.emit("server:notify", {"type": "update", "data": {...}})
 ```
 
+If the WebSocket is down, emit uses the session global queue. No per-channel buffer.
+
 ### Request (with response)
 
 ```python
@@ -36,224 +42,67 @@ try:
     response = await self.channel.request(
         "server:ask",
         {"question": "confirm?"},
-        timeout=5.0,  # Optional, default no timeout
+        timeout=5.0,
     )
-    print(f"Client responded: {response}")
 except ps.ChannelTimeout:
     print("Client didn't respond in time")
-except ps.ChannelClosed:
-    print("Channel was closed")
+except ps.ChannelDisconnected:
+    print("Socket is down")
+except ps.ChannelRemoteError as exc:
+    print(exc.code, exc.message)
 ```
+
+No handler → immediate `no_handler` NACK. Never hangs when `timeout=None`. Requests are not queued while the socket is down.
 
 ## Client → Server
 
-### Listen for events
-
 ```python
-def _on_ping(self, payload: dict):
-    print(f"Client pinged: {payload}")
-    # Optionally respond
-    self.channel.emit("server:pong", {"ack": True})
-
-# Register handler
-cleanup = self.channel.on("client:ping", _on_ping)
-
-# Unregister when done
+cleanup = self.channel.on("client:ping", self._on_ping)
 cleanup()
 ```
 
-### Handle requests (return response)
+`on()` after `detach()` raises `ChannelDetached`. `emit` / `request` still address the mailbox.
 
-```python
-async def _on_request(self, payload: dict) -> dict:
-    result = await process(payload)
-    return {"status": "ok", "result": result}
-
-self.channel.on("client:request", _on_request)
-```
-
-## Client-Side (JavaScript)
-
-Use `@ps.javascript` to write client code that uses channels:
+## Client-side
 
 ```python
 from pulse.js.pulse import usePulseChannel
 
 @ps.javascript(jsx=True)
-def ChatClient(*, channelId: str):
-    bridge = usePulseChannel(channelId)
+def ChatClient(*, channel_id: str):
+    bridge = usePulseChannel(channel_id)
 
-    # Send event to server
     def sendMessage(text: str):
         bridge.emit("client:message", {"text": text})
 
-    # Request with response
-    async def askServer():
-        response = await bridge.request("client:request", {"data": "..."})
-        print(response)
-
-    # Listen for server events
     def setupListeners():
-        def onNotify(payload):
-            print("Server notified:", payload)
-
-        off = bridge.on("server:notify", onNotify)
-        return off  # Cleanup
+        return bridge.on("server:notify", lambda payload: print(payload))
 
     useEffect(setupListeners, [bridge])
-
     return ps.div(...)
 ```
 
-### Client Bridge API
+No `lifetime` argument. Place the hook in a layout to keep listeners across routes.
 
-```typescript
-bridge.emit(event: string, payload?: any): void
-bridge.request(event: string, payload?: any): Promise<any>
-bridge.on(event: string, handler: (payload) => any): () => void
+Two hooks → two handles, one mailbox. Events fan out. RPC uses the first handler in attach order.
+
+## Wire
+
+```
+{type:"channel", action:"event", channel, event, payload?}
+{type:"channel", action:"request", channel, event, payload?, requestId}
+{type:"channel", action:"response", channel, responseTo, payload?, error?}
 ```
 
-## Full Example
+`error.code` is `no_handler` | `denied` | `handler_error`. No connect/disconnect/close/subscriptionId on the wire. Reconnect sends zero channel protocol traffic.
 
-```python
-import pulse as ps
-from pulse.js.pulse import usePulseChannel
+## Middleware
 
-useState = ps.Import("useState", "react")
-useEffect = ps.Import("useEffect", "react")
-
-
-class ChatRoom(ps.State):
-    messages: list[dict] = []
-
-    def __init__(self):
-        self.channel = ps.channel()
-        self._handlers = [
-            self.channel.on("client:send", self._on_send),
-        ]
-
-    def _on_send(self, payload: dict):
-        msg = {"user": "User", "text": payload["text"]}
-        self.messages.append(msg)
-        # Broadcast to client
-        self.channel.emit("server:message", msg)
-
-    def on_dispose(self):
-        for cleanup in self._handlers:
-            cleanup()
-
-
-@ps.javascript(jsx=True)
-def ChatWidget(*, channelId: str):
-    bridge = usePulseChannel(channelId)
-    messages, setMessages = useState([])
-    draft, setDraft = useState("")
-
-    def subscribe():
-        def onMessage(msg):
-            setMessages(lambda prev: [*prev, msg])
-
-        return bridge.on("server:message", onMessage)
-
-    useEffect(subscribe, [bridge])
-
-    def send():
-        if draft.strip():
-            bridge.emit("client:send", {"text": draft})
-            setDraft("")
-
-    return ps.div(className="chat")[
-        ps.div(className="messages")[
-            ps.For(
-                messages,
-                lambda m, i: ps.div(f"{m['user']}: {m['text']}", key=str(i)),
-            )
-        ],
-        ps.input(
-            value=draft,
-            onChange=lambda e: setDraft(e.target.value),
-            placeholder="Type message...",
-        ),
-        ps.button("Send", onClick=send),
-    ]
-
-
-@ps.component
-def ChatApp():
-    with ps.init():
-        room = ChatRoom()
-
-    return ps.div(
-        ps.h1("Chat"),
-        # Server-rendered message list
-        ps.ul(
-            ps.For(
-                room.messages,
-                lambda m, _: ps.li(f"{m['user']}: {m['text']}"),
-            )
-        ),
-        # Client widget with channel
-        ChatWidget(channelId=room.channel.id),
-    )
-```
-
-## Error Handling
-
-```python
-# Timeout on request
-try:
-    response = await channel.request("event", data, timeout=5.0)
-except ps.ChannelTimeout:
-    # Handle timeout
-    pass
-
-# Channel closed (user navigated away)
-try:
-    channel.emit("event", data)
-except ps.ChannelClosed:
-    # Handle closed channel
-    pass
-```
-
-## Channel Lifecycle
-
-1. **Created** — `ps.channel()` in State `__init__`
-2. **Active** — While component is mounted
-3. **Closed** — When component unmounts or user disconnects
-
-Always clean up handlers in `on_dispose()`:
-
-```python
-class MyState(ps.State):
-    def __init__(self):
-        self.channel = ps.channel()
-        self._cleanup = []
-        self._cleanup.append(self.channel.on("event1", self._h1))
-        self._cleanup.append(self.channel.on("event2", self._h2))
-
-    def on_dispose(self):
-        for cleanup in self._cleanup:
-            cleanup()
-```
-
-## Channel Properties
-
-```python
-channel.id      # str — unique channel identifier
-channel.closed  # bool — True if channel is closed
-```
-
-## Use Cases
-
-- **Chat/messaging** — Real-time message sync
-- **Live updates** — Push data changes to client
-- **Collaborative editing** — Multi-user sync
-- **Notifications** — Server-initiated alerts
-- **Gaming** — Low-latency state sync
-- **Progress tracking** — Long-running task updates
+`channel()` sees inbound events and requests only. `Deny` on event = drop. `Deny` on request = `denied` error response. Mailbox names are guessable; gate messages.
 
 ## See Also
 
 - `js-interop.md` - React integration for channel UI
 - `reactive.md` - Effect for cleanup patterns
-- `middleware.md` - Channel authorization with channel hook
+- `middleware.md` - Channel authorization
+- `errors.md` - Channel exceptions

--- a/skills/pulse/references/channels.md
+++ b/skills/pulse/references/channels.md
@@ -33,7 +33,7 @@ During a live route mount, `ps.channel("foo")` returns the same handle. `on(even
 self.channel.emit("server:notify", {"type": "update", "data": {...}})
 ```
 
-If the WebSocket is down, emit uses the session global queue. No per-channel buffer.
+If the WebSocket is down, emit uses the session global queue (capped at 1000 messages, drop-oldest). No per-channel buffer. Payloads are serialized at emit time: unserializable payload → `TypeError` at the emitter.
 
 Do not emit during prerender / first server render and expect the client to hear it. `useChannel` registers during render, so an emit after the client has rendered the hook is delivered. Earlier events drop — no listener yet.
 
@@ -63,7 +63,11 @@ cleanup = self.channel.on("client:ping", self._on_ping)
 cleanup()
 ```
 
-`on()` after `detach()` raises `ChannelDetached`. `emit` / `request` still address the channel name.
+After `detach()`: `on()` and `request()` raise `ChannelDetached`, `emit()` is a debug-logged no-op (emits race detach from background tasks). Queued handlers not yet run are skipped.
+
+Events on one handle are FIFO: each event's handlers are awaited before the next event runs. Inbound requests run as independent tasks (a request handler may `await` a client request, which must not block the session).
+
+Several live handles can share a name, including a `"tab"` and a `"route"` handle. Events fan out to all. A request goes to the first attached handle with a handler for the event (registration order).
 
 ## Client-side
 

--- a/skills/pulse/references/errors.md
+++ b/skills/pulse/references/errors.md
@@ -7,27 +7,30 @@ Exception classes, error propagation, and debugging in Pulse.
 ### Channel Errors
 
 ```python
-from pulse import ChannelClosed, ChannelTimeout
+from pulse import ChannelDetached, ChannelDisconnected, ChannelRemoteError, ChannelTimeout
 
 try:
-    channel.emit("event", data)
-except ChannelClosed:
-    print("Channel was closed")
+    channel.on("event", handler)
+except ChannelDetached:
+    print("This handle's listeners were detached")
 
 try:
     result = await channel.request("get_data", timeout=5.0)
 except ChannelTimeout:
     print("Request timed out")
+except ChannelDisconnected:
+    print("Socket is down")
+except ChannelRemoteError as exc:
+    print(exc.code, exc.message)
 ```
 
-**ChannelClosed** - Raised when:
-- Calling `emit()`, `request()`, or `on()` on a closed channel
-- User navigates away or disconnects
-- Component unmounts
+**ChannelDetached** - `on()` on a detached handle. `emit` / `request` still work.
 
-**ChannelTimeout** - Raised when:
-- `channel.request()` exceeds timeout waiting for client response
-- Subclass of `asyncio.TimeoutError`
+**ChannelDisconnected** - No socket, socket died mid-flight, or the session ended.
+
+**ChannelRemoteError** - Peer responded with `no_handler`, `denied`, or `handler_error`.
+
+**ChannelTimeout** - `channel.request()` exceeded `timeout`.
 
 ### JavaScript Execution Errors
 

--- a/skills/pulse/references/examples.md
+++ b/skills/pulse/references/examples.md
@@ -199,7 +199,7 @@ Bidirectional communication using channels.
 
 ```python
 import pulse as ps
-from pulse.js.pulse import usePulseChannel
+from pulse.js.pulse import useChannel
 
 useState = ps.Import("useState", "react")
 useEffect = ps.Import("useEffect", "react")
@@ -220,7 +220,7 @@ class ChatRoom(ps.State):
 
 @ps.javascript(jsx=True)
 def ChatWidget(*, channelId: str):
-    bridge = usePulseChannel(channelId)
+    bridge = useChannel(channelId)
     messages, setMessages = useState([])
     draft, setDraft = useState("")
 

--- a/skills/pulse/references/js-interop.md
+++ b/skills/pulse/references/js-interop.md
@@ -173,7 +173,7 @@ The emitted JavaScript symbol uses the callable name captured by `@ps.javascript
 ### React Hooks in Transpiled Code
 
 ```python
-from pulse.js.pulse import usePulseChannel
+from pulse.js.pulse import useChannel
 
 useState = ps.Import("useState", "react")
 useEffect = ps.Import("useEffect", "react")

--- a/skills/pulse/references/middleware.md
+++ b/skills/pulse/references/middleware.md
@@ -193,7 +193,7 @@ async def message(
 
 ### `channel`
 
-Called when channel messages are received. Authorize by channel, event, or payload.
+Called for inbound channel events and requests only — never responses. Mailbox names are guessable; gate messages. `Deny` on an event drops it. `Deny` on a request sends a `denied` error response.
 
 ```python
 from typing import Any

--- a/specs/combobox-channelid-required.md
+++ b/specs/combobox-channelid-required.md
@@ -12,7 +12,7 @@ Scope
 Plan
 1. JS combobox
    - Make `channelId: string` required in `PulseComboboxProps`.
-   - Call `usePulseChannel(channelId)` unconditionally; remove conditional hook.
+   - Call `useChannel(channelId)` unconditionally; remove conditional hook.
    - Make channel handlers require payload shapes (no `?` types, no guards).
 2. Python combobox API
    - Make `Combobox` require `store: ComboboxStore` (no `store=None` path).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Channel ids are session-scoped names. Listener attach/detach is the only lifecycle. Hard cutoff, off `main`, not stacked on #129.

## Review fixes

- Inbound `request` handlers run as tasks so they cannot deadlock the session message lock.
- Inbound handlers run in a full `PulseContext`. `_handle_channel_message` wraps both event dispatch and the request `create_task` in `PulseContext(app, session, render)` (the task copies the context at creation time), and `_invoke_handler` layers route/source metadata for `lifetime="route"` handles. The old `if PULSE_CONTEXT.get() is None: handler(payload)` fallback is gone — missing context fails loudly instead of running handlers without `ps.session()` / `ps.route()` / `ps.channel()`.
- Middleware `Deny` / exceptions NACK inbound RPC. Stack no longer rewrites inner `Deny` to `Ok`.
- Route handles detach only in `dispose_mount`. Prerender `navigate_to` now uses that path (no leaked interned handles).
- `request`/`response` never enter the reconnect queue. Disconnect queue budgets are split so channel traffic can't evict control messages, the event pump is bounded (drop-oldest past `MAX_QUEUED_EVENTS`), and malformed responses are dropped.
- Event handler exceptions surface via `report_error(phase="channel")`.
- `on(event, handler)` is idempotent; removers only pop their own bucket.
- `handle_request` wraps dispatch + send in one try/except so unserializable results NACK `handler_error`.
- `useChannel` attaches in an effect, not during render, so abandoned concurrent renders can't leak handles. Detach sweeps on a microtask so a StrictMode detach/reattach doesn't reject in-flight requests. Invalid `lifetime` raises; `lifetime="route"` without a route context raises.
- Unrouted `server_error` (tab / connect / middleware) fans out to live mounts instead of hardcoding `"/"`. Client also delivers unmatched `server_error` to every active view. JS `ServerError.phase` now includes `channel` | `connect` | `effect`.

## Wire

```
{type:"channel", action:"event", channel, event, payload?}
{type:"channel", action:"request", channel, event, payload?, requestId}
{type:"channel", action:"response", channel, responseTo, payload?, error?}
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffcff-5d5e-7f12-ad15-4d5230afff14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffcff-5d5e-7f12-ad15-4d5230afff14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

Link to Devin session: https://app.devin.ai/sessions/0bdc9b41689945469c0e337d6ccf3613
Requested by: @erwinkn