### PR TITLE
Drop the render-wide inbound lock

### DIFF
--- a/docs/content/docs/(core)/advanced/js-interop.mdx
+++ b/docs/content/docs/(core)/advanced/js-interop.mdx
@@ -189,12 +189,10 @@ def debounced_log(message: str):
 JavaScript errors propagate to Python when awaiting results:
 
 ```python
-from pulse.render_session import JsExecError
-
 async def on_click():
     try:
         result = await ps.run_js(might_fail(), result=True)
-    except JsExecError as e:
+    except RuntimeError as e:
         print(f"JS error: {e}")
 ```
 

--- a/docs/content/docs/(core)/cookbook/js-from-python/run-js-imperative.mdx
+++ b/docs/content/docs/(core)/cookbook/js-from-python/run-js-imperative.mdx
@@ -151,13 +151,10 @@ class PreferencesState(ps.State):
 Catch JavaScript errors in Python when awaiting results:
 
 ```python
-from pulse.render_session import JsExecError
-
-
 async def safe_js_call():
     try:
         result = await ps.run_js(some_js_function(), result=True)
-    except JsExecError as e:
+    except RuntimeError as e:
         print(f"JavaScript error: {e}")
 ```
 

--- a/docs/content/docs/(core)/glossary.mdx
+++ b/docs/content/docs/(core)/glossary.mdx
@@ -272,3 +272,6 @@ An architecture where the server controls what the UI shows. The client is a thi
 
 **Serialization**
 Converting data structures to a format that can be transmitted (like JSON). Pulse serializes VDOM on the server and deserializes it in the browser.
+
+**Reply**
+A `{type: "reply", id}` packet that completes a pending request (`call_api`, `run_js`, `Channel.request`). Same shape in both directions: `payload` on success, `error` on failure.

--- a/docs/content/docs/reference/pulse-client/types.mdx
+++ b/docs/content/docs/reference/pulse-client/types.mdx
@@ -359,9 +359,8 @@ type ClientMessage =
   | ClientCallbackMessage
   | ClientUpdateMessage
   | ClientDetachMessage
-  | ClientApiResultMessage
   | ClientChannelRequestMessage
-  | ClientChannelResponseMessage;
+  | ReplyMessage;
 ```
 
 #### ClientAttachMessage
@@ -412,18 +411,16 @@ interface ClientDetachMessage {
 }
 ```
 
-#### ClientApiResultMessage
+#### ReplyMessage
 
-Result of an API call requested by the server.
+Completes a pending server request (`call_api`, `run_js`, `Channel.request`). Same shape in both directions.
 
 ```ts
-interface ClientApiResultMessage {
-  type: "api_result";
+interface ReplyMessage {
+  type: "reply";
   id: string;
-  ok: boolean;
-  status: number;
-  headers: Record<string, string>;
-  body: any | null;
+  payload?: any;
+  error?: any;
 }
 ```
 
@@ -441,20 +438,6 @@ interface ClientChannelRequestMessage {
 }
 ```
 
-#### ClientChannelResponseMessage
-
-Response to a server channel request.
-
-```ts
-interface ClientChannelResponseMessage {
-  type: "channel_message";
-  channel: string;
-  responseTo: string;
-  payload?: any;
-  error?: any;
-}
-```
-
 ### Server Messages
 
 ```ts
@@ -465,7 +448,7 @@ type ServerMessage =
   | ServerApiCallMessage
   | ServerNavigateToMessage
   | ServerChannelRequestMessage
-  | ServerChannelResponseMessage;
+  | ReplyMessage;
 ```
 
 #### ServerInitMessage
@@ -553,20 +536,6 @@ interface ServerChannelRequestMessage {
   event: string;
   payload?: any;
   requestId?: string;
-}
-```
-
-#### ServerChannelResponseMessage
-
-Response to a client channel request.
-
-```ts
-interface ServerChannelResponseMessage {
-  type: "channel_message";
-  channel: string;
-  responseTo: string;
-  payload?: any;
-  error?: any;
 }
 ```
 

--- a/docs/content/docs/reference/pulse/js-interop.mdx
+++ b/docs/content/docs/reference/pulse/js-interop.mdx
@@ -314,17 +314,16 @@ async def on_check():
 
 ---
 
-## JsExecError
+## Reply errors
 
-Exception raised when client-side JS execution fails.
-
-```python
-from pulse import JsExecError
-```
+A failed `run_js(..., result=True)` arrives as `{type: "reply", error}` and rejects the future with `RuntimeError`.
 
 ```python
-class JsExecError(Exception):
-    pass
+async def on_check():
+    try:
+        await run_js(might_fail(), result=True)
+    except RuntimeError as e:
+        print(e)
 ```
 
 ---

--- a/docs/content/docs/reference/pulse/middleware.mdx
+++ b/docs/content/docs/reference/pulse/middleware.mdx
@@ -125,7 +125,7 @@ async def message(
     *,
     data: ClientMessage,
     session: dict[str, Any],
-    next: Callable[[], Awaitable[Ok[None]]],
+    next: Callable[[], Awaitable[Ok[None] | Deny]],
 ) -> Ok[None] | Deny
 ```
 
@@ -134,7 +134,7 @@ Handle per-message authorization.
 **Parameters:**
 - `data` - Client message data.
 - `session` - Session data dictionary.
-- `next` - Callable to continue the middleware chain.
+- `next` - Callable to continue the middleware chain. Returns the downstream decision; return it as-is or override it.
 
 **Returns:** `Ok[None]` to allow, `Deny` to block.
 
@@ -149,7 +149,7 @@ async def channel(
     payload: Any,
     request_id: str | None,
     session: dict[str, Any],
-    next: Callable[[], Awaitable[Ok[None]]],
+    next: Callable[[], Awaitable[Ok[None] | Deny]],
 ) -> Ok[None] | Deny
 ```
 
@@ -161,7 +161,7 @@ Handle channel message authorization.
 - `payload` - Event payload.
 - `request_id` - Request ID if awaiting response.
 - `session` - Session data dictionary.
-- `next` - Callable to continue the middleware chain.
+- `next` - Callable to continue the middleware chain. Returns the downstream decision; return it as-is or override it.
 
 **Returns:** `Ok[None]` to allow, `Deny` to block.
 

--- a/examples/js_exec_demo.py
+++ b/examples/js_exec_demo.py
@@ -14,7 +14,6 @@ from typing import Any, cast
 import pulse as ps
 from pulse import App, Route, component, javascript, run_js
 from pulse.js import Error, console, document, navigator, window
-from pulse.render_session import JsExecError
 
 
 class DemoState(ps.State):
@@ -114,7 +113,7 @@ def JsExecDemo():
 		state.add_log("Triggering JS error...")
 		try:
 			await run_js(cause_error(), result=True)  # pyright: ignore[reportArgumentType]
-		except JsExecError as e:
+		except RuntimeError as e:
 			state.error = str(e)
 			state.add_log(f"Caught error: {e}")
 

--- a/packages/pulse-mantine/python/tests/test_combobox_store.py
+++ b/packages/pulse-mantine/python/tests/test_combobox_store.py
@@ -4,7 +4,7 @@ from typing import Any, cast
 
 import pulse as ps
 import pytest
-from pulse.messages import ClientChannelResponseMessage
+from pulse.messages import ReplyMessage
 from pulse.user_session import UserSession
 from pulse_mantine.core.combobox.combobox import Combobox, ComboboxStore
 
@@ -98,19 +98,8 @@ async def test_combobox_store_request_roundtrip():
 	request_id = request_message.get("requestId")
 	assert request_id
 
-	real_render.channels.handle_client_response(
-		message=cast(
-			ClientChannelResponseMessage,
-			cast(
-				object,
-				{
-					"type": "channel_message",
-					"channel": request_message["channel"],
-					"responseTo": request_id,
-					"payload": True,
-				},
-			),
-		)
+	real_render.replies.apply(
+		cast(ReplyMessage, {"type": "reply", "id": request_id, "payload": True})
 	)
 
 	result = await pending

--- a/packages/pulse/js/src/channel.test.ts
+++ b/packages/pulse/js/src/channel.test.ts
@@ -1,28 +1,56 @@
 import { describe, expect, it, vi } from "bun:test";
 import { ChannelBridge, PulseChannelResetError } from "./channel";
 import { PulseSocketIOClient } from "./client";
-import type { ClientChannelMessage } from "./messages";
+import type { ClientMessage, ReplyMessage } from "./messages";
 
 function makeClient() {
-	const sent: ClientChannelMessage[] = [];
-	const sendMessage = vi.fn(async (message: ClientChannelMessage) => {
+	const sent: ClientMessage[] = [];
+	const pending = new Map<string, { resolve: (value: any) => void; reject: (error: any) => void }>();
+	const sendMessage = vi.fn(async (message: ClientMessage) => {
 		sent.push(message);
 	});
-	const client = { sendMessage } as any;
+	const client = {
+		sendMessage,
+		replies: {
+			register(id: string) {
+				return new Promise((resolve, reject) => {
+					pending.set(id, { resolve, reject });
+				});
+			},
+			reject(id: string, error: unknown) {
+				const entry = pending.get(id);
+				if (!entry) return;
+				pending.delete(id);
+				entry.reject(error);
+			},
+			apply(message: ReplyMessage) {
+				const entry = pending.get(message.id);
+				if (!entry) return;
+				pending.delete(message.id);
+				if (message.error != null) {
+					entry.reject(new PulseChannelResetError(String(message.error)));
+				} else {
+					entry.resolve(message.payload);
+				}
+			},
+		},
+	};
 	const bridge = new ChannelBridge(client, "chan-1");
-	return { bridge, sent, sendMessage };
+	return { bridge, sent, sendMessage, client };
 }
 
 describe("ChannelBridge", () => {
-	it("queues request and resolves on response", async () => {
-		const { bridge, sent } = makeClient();
+	it("queues request and resolves on reply", async () => {
+		const { bridge, sent, client } = makeClient();
 		const pending = bridge.request("echo", { foo: 1 });
 		expect(sent).toHaveLength(1);
-		const requestId = sent[0]!.requestId!;
-		bridge.handleServerMessage({
-			type: "channel_message",
-			channel: "chan-1",
-			responseTo: requestId,
+		const request = sent[0];
+		expect(request).toMatchObject({ type: "channel_message", event: "echo" });
+		const requestId = request && "requestId" in request ? request.requestId : undefined;
+		expect(requestId).toBeDefined();
+		client.replies.apply({
+			type: "reply",
+			id: requestId!,
 			payload: { foo: 2 },
 		});
 		await expect(pending).resolves.toEqual({ foo: 2 });
@@ -41,7 +69,7 @@ describe("ChannelBridge", () => {
 		expect(handler).toHaveBeenCalledWith({ value: 42 });
 	});
 
-	it("responds to server requests", async () => {
+	it("responds to server requests with a reply", async () => {
 		const { bridge, sendMessage } = makeClient();
 		bridge.on("compute", () => 99);
 		bridge.handleServerMessage({
@@ -52,13 +80,11 @@ describe("ChannelBridge", () => {
 			payload: {},
 		});
 		await new Promise((resolve) => setTimeout(resolve, 0));
-		expect(sendMessage).toHaveBeenCalledWith(
-			expect.objectContaining({
-				responseTo: "req-1",
-				payload: 99,
-				event: undefined,
-			}),
-		);
+		expect(sendMessage).toHaveBeenCalledWith({
+			type: "reply",
+			id: "req-1",
+			payload: 99,
+		});
 	});
 
 	it("rejects pending requests when closed", async () => {

--- a/packages/pulse/js/src/channel.ts
+++ b/packages/pulse/js/src/channel.ts
@@ -1,10 +1,6 @@
 import { useEffect, useState } from "react";
 import type { PulseSocketIOClient } from "./client";
-import type {
-	ServerChannelMessage,
-	ServerChannelRequestMessage,
-	ServerChannelResponseMessage,
-} from "./messages";
+import type { ClientMessage, ReplyMessage, ServerChannelRequestMessage } from "./messages";
 import { usePulseClient } from "./pulse";
 
 export class PulseChannelResetError extends Error {
@@ -16,9 +12,12 @@ export class PulseChannelResetError extends Error {
 
 export type ChannelEventHandler = (payload: any) => any | Promise<any>;
 
-interface PendingRequest {
-	resolve: (value: any) => void;
-	reject: (error: any) => void;
+export interface ChannelHost {
+	sendMessage(message: ClientMessage): void | Promise<void>;
+	replies: {
+		register(id: string): Promise<any>;
+		reject(id: string, error: unknown): void;
+	};
 }
 
 export function createRandomId(): string {
@@ -38,26 +37,14 @@ function formatError(error: unknown): string {
 	}
 }
 
-function isServerResponseMessage(
-	message: ServerChannelMessage,
-): message is ServerChannelResponseMessage {
-	return typeof (message as ServerChannelResponseMessage).responseTo === "string";
-}
-
-function isServerRequestMessage(
-	message: ServerChannelMessage,
-): message is ServerChannelRequestMessage {
-	return typeof (message as ServerChannelRequestMessage).event === "string";
-}
-
 export class ChannelBridge {
 	private handlers = new Map<string, Set<ChannelEventHandler>>();
-	private pending = new Map<string, PendingRequest>();
+	private pendingIds = new Set<string>();
 	private backlog: ServerChannelRequestMessage[] = [];
 	private closed = false;
 
 	constructor(
-		private client: PulseSocketIOClient,
+		private client: ChannelHost,
 		public readonly id: string,
 	) {}
 
@@ -74,15 +61,17 @@ export class ChannelBridge {
 	request(event: string, payload?: any): Promise<any> {
 		this.ensureOpen();
 		const requestId = createRandomId();
-		return new Promise((resolve, reject) => {
-			this.pending.set(requestId, { resolve, reject });
-			this.client.sendMessage({
-				type: "channel_message",
-				channel: this.id,
-				event,
-				payload,
-				requestId,
-			});
+		this.pendingIds.add(requestId);
+		const pending = this.client.replies.register(requestId);
+		this.client.sendMessage({
+			type: "channel_message",
+			channel: this.id,
+			event,
+			payload,
+			requestId,
+		});
+		return pending.finally(() => {
+			this.pendingIds.delete(requestId);
 		});
 	}
 
@@ -105,16 +94,9 @@ export class ChannelBridge {
 		};
 	}
 
-	handleServerMessage(message: ServerChannelMessage): boolean {
-		if (isServerResponseMessage(message)) {
-			this.resolvePending(message);
-			return this.closed;
-		}
+	handleServerMessage(message: ServerChannelRequestMessage): boolean {
 		if (this.closed) {
 			return true;
-		}
-		if (!isServerRequestMessage(message)) {
-			return this.closed;
 		}
 
 		if (message.event === "__close__") {
@@ -200,36 +182,11 @@ export class ChannelBridge {
 				}
 			}
 		}
-		if (error) {
-			this.client.sendMessage({
-				type: "channel_message",
-				channel: this.id,
-				event: undefined,
-				responseTo: message.requestId,
-				error: formatError(error),
-			});
-			return;
-		}
-		this.client.sendMessage({
-			type: "channel_message",
-			channel: this.id,
-			event: undefined,
-			responseTo: message.requestId,
-			payload: response,
-		});
-	}
-
-	private resolvePending(message: ServerChannelResponseMessage): void {
-		const entry = message.responseTo ? this.pending.get(message.responseTo) : undefined;
-		if (!entry) {
-			return;
-		}
-		this.pending.delete(message.responseTo!);
-		if (message.error !== undefined && message.error !== null) {
-			entry.reject(new PulseChannelResetError(String(message.error)));
-		} else {
-			entry.resolve(message.payload);
-		}
+		const reply: ReplyMessage =
+			error !== undefined
+				? { type: "reply", id: message.requestId, error: formatError(error) }
+				: { type: "reply", id: message.requestId, payload: response };
+		this.client.sendMessage(reply);
 	}
 
 	private close(reason: PulseChannelResetError): void {
@@ -237,13 +194,12 @@ export class ChannelBridge {
 			return;
 		}
 		this.closed = true;
-		for (const request of this.pending.values()) {
-			request.reject(reason);
+		for (const id of this.pendingIds) {
+			this.client.replies.reject(id, reason);
 		}
-		this.pending.clear();
+		this.pendingIds.clear();
 		this.handlers.clear();
 		this.backlog = [];
-		// No-op: owning client manages registry lifecycle.
 	}
 }
 

--- a/packages/pulse/js/src/client.test.ts
+++ b/packages/pulse/js/src/client.test.ts
@@ -396,14 +396,16 @@ describe("PulseSocketIOClient attach ack", () => {
 		expect(init.credentials).toBe("omit");
 
 		expect(sentMessages().at(-1)).toEqual({
-			type: "api_result",
+			type: "reply",
 			id: "call-1",
-			ok: true,
-			status: 200,
-			headers: {
-				"content-type": "application/json",
+			payload: {
+				ok: true,
+				status: 200,
+				headers: {
+					"content-type": "application/json",
+				},
+				body: { ok: true },
 			},
-			body: { ok: true },
 		});
 	});
 });

--- a/packages/pulse/js/src/client.tsx
+++ b/packages/pulse/js/src/client.tsx
@@ -4,10 +4,9 @@ import { ChannelBridge, createRandomId, PulseChannelResetError } from "./channel
 import type { RouteInfo } from "./helpers";
 import { pulseFetch } from "./http";
 import type {
-	ClientApiResultMessage,
 	ClientCallbackMessage,
-	ClientJsResultMessage,
 	ClientMessage,
+	ReplyMessage,
 	ServerApiCallMessage,
 	ServerChannelMessage,
 	ServerError,
@@ -82,6 +81,29 @@ export class PulseSocketIOClient {
 	#messageQueue: ClientMessage[];
 	#connectionListeners: Set<ConnectionStatusListener> = new Set();
 	#channels: Map<string, { bridge: ChannelBridge; refCount: number }> = new Map();
+	#pendingReplies = new Map<string, { resolve: (value: any) => void; reject: (error: any) => void }>();
+	readonly replies = {
+		register: (id: string) =>
+			new Promise<any>((resolve, reject) => {
+				this.#pendingReplies.set(id, { resolve, reject });
+			}),
+		apply: (message: ReplyMessage) => {
+			const entry = this.#pendingReplies.get(message.id);
+			if (!entry) return;
+			this.#pendingReplies.delete(message.id);
+			if (message.error != null) {
+				entry.reject(new PulseChannelResetError(String(message.error)));
+			} else {
+				entry.resolve(message.payload);
+			}
+		},
+		reject: (id: string, error: unknown) => {
+			const entry = this.#pendingReplies.get(id);
+			if (!entry) return;
+			this.#pendingReplies.delete(id);
+			entry.reject(error);
+		},
+	};
 	#url: string;
 	#frameworkNavigate: NavigateFunction;
 	#directives: Directives;
@@ -443,6 +465,10 @@ export class PulseSocketIOClient {
 				this.#handleAttachAck(message.path, message.attachId);
 				break;
 			}
+			case "reply": {
+				this.replies.apply(message);
+				break;
+			}
 			case "channel_message": {
 				this.#routeChannelMessage(message);
 				break;
@@ -477,25 +503,19 @@ export class PulseSocketIOClient {
 			} else {
 				body = await res.text().catch(() => null);
 			}
-			const reply: ClientApiResultMessage = {
-				type: "api_result",
-				id: msg.id,
+			this.sendReply(msg.id, {
 				ok: res.ok,
 				status: res.status,
 				headers: headersObj,
 				body,
-			};
-			this.sendMessage(reply);
+			});
 		} catch (err) {
-			const reply: ClientApiResultMessage = {
-				type: "api_result",
-				id: msg.id,
+			this.sendReply(msg.id, {
 				ok: false,
 				status: 0,
 				headers: {},
 				body: { error: String(err) },
-			};
-			this.sendMessage(reply);
+			});
 		}
 	}
 
@@ -519,24 +539,18 @@ export class PulseSocketIOClient {
 		if (!view) {
 			// View unmounted before the message arrived - send result back to unblock
 			// the server-side future (which is likely already cancelled anyway).
-			this.#sendJsResult(message.id, undefined, null);
+			this.sendReply(message.id, undefined, null);
 			return;
 		}
 		view.onJsExec(message);
 	}
 
-	public sendJsResult(id: string, result: any, error: string | null) {
-		this.#sendJsResult(id, result, error);
-	}
-
-	#sendJsResult(id: string, result: any, error: string | null) {
-		const msg: ClientJsResultMessage = {
-			type: "js_result",
-			id,
-			result,
-			error,
-		};
-		this.sendMessage(msg);
+	public sendReply(id: string, payload?: any, error?: string | null) {
+		const message: ReplyMessage =
+			error != null
+				? { type: "reply", id, error }
+				: { type: "reply", id, payload };
+		this.sendMessage(message);
 	}
 
 	public acquireChannel(id: string): ChannelBridge {

--- a/packages/pulse/js/src/index.ts
+++ b/packages/pulse/js/src/index.ts
@@ -16,19 +16,17 @@ export type { RouteInfo } from "./helpers";
 export { extractServerRouteInfo } from "./helpers";
 // Messages (types only)
 export type {
-	ClientApiResultMessage,
 	ClientAttachMessage,
 	ClientCallbackMessage,
 	ClientChannelMessage,
 	ClientChannelRequestMessage,
-	ClientChannelResponseMessage,
 	ClientDetachMessage,
 	ClientMessage,
 	ClientUpdateMessage,
+	ReplyMessage,
 	ServerApiCallMessage,
 	ServerChannelMessage,
 	ServerChannelRequestMessage,
-	ServerChannelResponseMessage,
 	ServerError,
 	ServerErrorMessage,
 	ServerInitMessage,

--- a/packages/pulse/js/src/messages.ts
+++ b/packages/pulse/js/src/messages.ts
@@ -47,21 +47,17 @@ export interface ServerChannelRequestMessage {
 	event: string;
 	payload?: any;
 	requestId?: string;
-	responseTo?: never;
 	error?: any;
 }
 
-export interface ServerChannelResponseMessage {
-	type: "channel_message";
-	channel: string;
-	event?: undefined;
-	responseTo: string;
+export interface ReplyMessage {
+	type: "reply";
+	id: string;
 	payload?: any;
 	error?: any;
-	requestId?: never;
 }
 
-export type ServerChannelMessage = ServerChannelRequestMessage | ServerChannelResponseMessage;
+export type ServerChannelMessage = ServerChannelRequestMessage;
 
 export interface ServerNavigateToMessage {
 	type: "navigate_to";
@@ -99,8 +95,8 @@ export type ServerMessage =
 	| ServerReloadMessage
 	| ServerAttachAckMessage
 	| ServerChannelRequestMessage
-	| ServerChannelResponseMessage
-	| ServerJsExecMessage;
+	| ServerJsExecMessage
+	| ReplyMessage;
 
 export interface ClientCallbackMessage {
 	type: "callback";
@@ -125,50 +121,21 @@ export interface ClientDetachMessage {
 	path: string;
 }
 
-export interface ClientApiResultMessage {
-	type: "api_result";
-	id: string;
-	ok: boolean;
-	status: number;
-	headers: Record<string, string>;
-	body: any | null;
-}
-
 export interface ClientChannelRequestMessage {
 	type: "channel_message";
 	channel: string;
 	event: string;
 	payload?: any;
 	requestId?: string;
-	responseTo?: never;
 	error?: any;
 }
 
-export interface ClientChannelResponseMessage {
-	type: "channel_message";
-	channel: string;
-	event?: undefined;
-	responseTo: string;
-	payload?: any;
-	error?: any;
-	requestId?: never;
-}
-
-export type ClientChannelMessage = ClientChannelRequestMessage | ClientChannelResponseMessage;
-
-export interface ClientJsResultMessage {
-	type: "js_result";
-	id: string;
-	result: any;
-	error: string | null;
-}
+export type ClientChannelMessage = ClientChannelRequestMessage;
 
 export type ClientMessage =
 	| ClientAttachMessage
 	| ClientCallbackMessage
 	| ClientUpdateMessage
 	| ClientDetachMessage
-	| ClientApiResultMessage
 	| ClientChannelRequestMessage
-	| ClientChannelResponseMessage
-	| ClientJsResultMessage;
+	| ReplyMessage;

--- a/packages/pulse/js/src/pulse.tsx
+++ b/packages/pulse/js/src/pulse.tsx
@@ -251,7 +251,7 @@ export function PulseView({ path, registry }: PulseViewProps) {
 					} catch (e) {
 						error = e instanceof Error ? e.message : String(e);
 					}
-					client.sendJsResult(msg.id, result, error);
+					client.sendReply(msg.id, result, error);
 				},
 				onServerError: setServerError,
 			});

--- a/packages/pulse/python/src/pulse/__init__.py
+++ b/packages/pulse/python/src/pulse/__init__.py
@@ -1424,7 +1424,6 @@ from pulse.refs import (
 )
 
 # JavaScript execution
-from pulse.render_session import JsExecError as JsExecError
 from pulse.render_session import (
 	RenderSession as RenderSession,
 )

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -1105,10 +1105,8 @@ class App:
 	) -> None:
 		try:
 			if msg["type"] == "channel_message":
-				await self._handle_channel_command(
-					render, session, cast(ClientChannelRequestMessage, msg)
-				)
-			else:
+				await self._handle_channel_command(render, session, msg)
+			elif msg["type"] != "reply":
 				await self._handle_pulse_command(render, session, msg)
 		except Exception as e:
 			path = msg.get("path", "")

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -1055,7 +1055,19 @@ class App:
 		if sid in self._connecting_sockets:
 			self._queue_pending_socket_message(sid, data)
 			return
-		await self._process_socket_message(sid, data)
+		inbound = self._resolve_socket_inbound(sid, data)
+		if inbound is None:
+			return
+		render, session, msg = inbound
+		if self._is_inbound_reply(msg):
+			self._apply_inbound_reply(render, msg)
+			return
+		# Command handling is async (middleware). Detach it so this Socket.IO
+		# handler can return — replies on this socket must not sit behind Decide.
+		self._tasks.create_task(
+			self._dispatch_inbound_command(render, session, msg),
+			name=f"inbound:{render.id}:{msg['type']}",
+		)
 
 	def _queue_pending_socket_message(self, sid: str, data: Serialized) -> None:
 		queue = self._pending_socket_messages.setdefault(sid, [])
@@ -1071,48 +1083,80 @@ class App:
 		try:
 			while pending := self._pending_socket_messages.pop(sid, []):
 				for data in pending:
+					# Connect replay stays ordered: await each command. Replies
+					# still resolve inline when we reach them.
 					await self._process_socket_message(sid, data)
 		finally:
 			self._connecting_sockets.discard(sid)
 
-	async def _process_socket_message(self, sid: str, data: Serialized) -> None:
+	def _resolve_socket_inbound(
+		self, sid: str, data: Serialized
+	) -> tuple[RenderSession, UserSession, ClientMessage] | None:
 		rid = self._socket_to_render.get(sid)
 		if not rid:
-			return
+			return None
 		msg = cast(ClientMessage, deserialize(data))
 		render = self.render_sessions.get(rid)
 		if render is None:
-			return
+			return None
 		owner_sid = self._render_to_user.get(rid)
 		if owner_sid is None:
-			return
+			return None
 		session = self.user_sessions.get(owner_sid)
 		if session is None:
-			return
+			return None
 		# Cancel any leftover cleanup for connected sessions. Never cancel
 		# for disconnected renders: nothing would reschedule it and the
 		# session would survive past its timeout.
 		if render.connected:
 			self._cancel_render_cleanup(rid)
-		try:
-			if msg["type"] == "channel_message":
-				await self._handle_channel_message(render, session, msg)
-			else:
-				await self._handle_pulse_message(render, session, msg)
-		except Exception as e:
-			path = msg.get("path", "")
-			render.report_error(path, "server", e)
+		return render, session, msg
 
-	async def _handle_pulse_message(
-		self, render: RenderSession, session: UserSession, msg: ClientPulseMessage
-	) -> None:
-		# Completions Apply immediately. They are not policy-gated — a
-		# pending call_api / run_js future must not sit behind unrelated Decide.
+	def _is_inbound_reply(self, msg: ClientMessage) -> bool:
+		if msg["type"] == "api_result" or msg["type"] == "js_result":
+			return True
+		return msg["type"] == "channel_message" and bool(msg.get("responseTo"))
+
+	def _apply_inbound_reply(self, render: RenderSession, msg: ClientMessage) -> None:
 		if msg["type"] == "api_result":
 			render.handle_api_result(dict(msg))
 			return
 		if msg["type"] == "js_result":
 			render.handle_js_result(dict(msg))
+			return
+		render.channels.handle_client_response(cast(ClientChannelResponseMessage, msg))
+
+	async def _dispatch_inbound_command(
+		self, render: RenderSession, session: UserSession, msg: ClientMessage
+	) -> None:
+		try:
+			if msg["type"] == "channel_message":
+				await self._handle_channel_message(
+					render, session, cast(ClientChannelMessage, msg)
+				)
+			else:
+				await self._handle_pulse_message(
+					render, session, cast(ClientPulseMessage, msg)
+				)
+		except Exception as e:
+			path = msg.get("path", "")
+			render.report_error(path, "server", e)
+
+	async def _process_socket_message(self, sid: str, data: Serialized) -> None:
+		inbound = self._resolve_socket_inbound(sid, data)
+		if inbound is None:
+			return
+		render, session, msg = inbound
+		if self._is_inbound_reply(msg):
+			self._apply_inbound_reply(render, msg)
+			return
+		await self._dispatch_inbound_command(render, session, msg)
+
+	async def _handle_pulse_message(
+		self, render: RenderSession, session: UserSession, msg: ClientPulseMessage
+	) -> None:
+		if self._is_inbound_reply(msg):
+			self._apply_inbound_reply(render, msg)
 			return
 
 		async def _next() -> Ok[None]:
@@ -1169,9 +1213,7 @@ class App:
 		self, render: RenderSession, session: UserSession, msg: ClientChannelMessage
 	) -> None:
 		if msg.get("responseTo"):
-			# Completions Apply immediately — never sit behind channel Decide.
-			msg = cast(ClientChannelResponseMessage, msg)
-			render.channels.handle_client_response(msg)
+			self._apply_inbound_reply(render, msg)
 		else:
 			channel_id = str(msg.get("channel", ""))
 			msg = cast(ClientChannelRequestMessage, msg)

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -300,7 +300,6 @@ class App:
 	_connecting_sockets: set[str]
 	_pending_socket_messages: dict[str, list[Serialized]]
 	_render_cleanups: dict[str, TimerHandleLike]
-	_render_message_locks: dict[str, asyncio.Lock]
 	_tasks: TaskRegistry
 	_timers: TimerRegistry
 	_proxy: ReactProxy | None
@@ -387,7 +386,6 @@ class App:
 		self._pending_socket_messages = {}
 		# Map render_id -> cleanup timer handle for timeout-based expiry
 		self._render_cleanups = {}
-		self._render_message_locks = {}
 		self._tasks = TaskRegistry(name="app")
 		self._timers = TimerRegistry(tasks=self._tasks, name="app")
 		self._proxy = None
@@ -1082,34 +1080,41 @@ class App:
 		if not rid:
 			return
 		msg = cast(ClientMessage, deserialize(data))
-		lock = self._render_message_locks.setdefault(rid, asyncio.Lock())
-		async with lock:
-			render = self.render_sessions.get(rid)
-			if render is None:
-				return
-			owner_sid = self._render_to_user.get(rid)
-			if owner_sid is None:
-				return
-			session = self.user_sessions.get(owner_sid)
-			if session is None:
-				return
-			# Cancel any leftover cleanup for connected sessions. Never cancel
-			# for disconnected renders: nothing would reschedule it and the
-			# session would survive past its timeout.
-			if render.connected:
-				self._cancel_render_cleanup(rid)
-			try:
-				if msg["type"] == "channel_message":
-					await self._handle_channel_message(render, session, msg)
-				else:
-					await self._handle_pulse_message(render, session, msg)
-			except Exception as e:
-				path = msg.get("path", "")
-				render.report_error(path, "server", e)
+		render = self.render_sessions.get(rid)
+		if render is None:
+			return
+		owner_sid = self._render_to_user.get(rid)
+		if owner_sid is None:
+			return
+		session = self.user_sessions.get(owner_sid)
+		if session is None:
+			return
+		# Cancel any leftover cleanup for connected sessions. Never cancel
+		# for disconnected renders: nothing would reschedule it and the
+		# session would survive past its timeout.
+		if render.connected:
+			self._cancel_render_cleanup(rid)
+		try:
+			if msg["type"] == "channel_message":
+				await self._handle_channel_message(render, session, msg)
+			else:
+				await self._handle_pulse_message(render, session, msg)
+		except Exception as e:
+			path = msg.get("path", "")
+			render.report_error(path, "server", e)
 
 	async def _handle_pulse_message(
 		self, render: RenderSession, session: UserSession, msg: ClientPulseMessage
 	) -> None:
+		# Completions Apply immediately. They are not policy-gated — a
+		# pending call_api / run_js future must not sit behind unrelated Decide.
+		if msg["type"] == "api_result":
+			render.handle_api_result(dict(msg))
+			return
+		if msg["type"] == "js_result":
+			render.handle_js_result(dict(msg))
+			return
+
 		async def _next() -> Ok[None]:
 			if msg["type"] == "attach":
 				attached = render.attach(msg["path"], msg["routeInfo"])
@@ -1129,10 +1134,6 @@ class App:
 			elif msg["type"] == "detach":
 				render.detach(msg["path"])
 				render.channels.remove_route(msg["path"])
-			elif msg["type"] == "api_result":
-				render.handle_api_result(dict(msg))
-			elif msg["type"] == "js_result":
-				render.handle_js_result(dict(msg))
 			else:
 				logger.warning("Unknown message type received: %s", msg)
 			return Ok()
@@ -1168,6 +1169,7 @@ class App:
 		self, render: RenderSession, session: UserSession, msg: ClientChannelMessage
 	) -> None:
 		if msg.get("responseTo"):
+			# Completions Apply immediately — never sit behind channel Decide.
 			msg = cast(ClientChannelResponseMessage, msg)
 			render.channels.handle_client_response(msg)
 		else:
@@ -1313,7 +1315,6 @@ class App:
 	def close_render(self, rid: str):
 		# Cancel any pending cleanup task
 		self._cancel_render_cleanup(rid)
-		self._render_message_locks.pop(rid, None)
 		self._render_to_page_instance.pop(rid, None)
 		self._render_connect_attempts.pop(rid, None)
 		socket_sid = self._render_to_socket.pop(rid, None)

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -51,7 +51,6 @@ from pulse.helpers import (
 from pulse.hooks.core import hooks
 from pulse.messages import (
 	ClientChannelRequestMessage,
-	ClientChannelResponseMessage,
 	ClientMessage,
 	ClientPulseMessage,
 	Prerender,
@@ -1102,9 +1101,7 @@ class App:
 		elif kind == "js_result":
 			render.handle_js_result(dict(msg))
 		elif kind == "channel_message" and "responseTo" in msg:
-			render.channels.handle_client_response(
-				cast(ClientChannelResponseMessage, msg)
-			)
+			render.channels.handle_client_response(msg)
 		else:
 			await self._run_command(render, session, msg)
 

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -1131,13 +1131,9 @@ class App:
 	) -> None:
 		try:
 			if msg["type"] == "channel_message":
-				await self._handle_channel_message(
-					render, session, cast(ClientChannelMessage, msg)
-				)
+				await self._handle_channel_message(render, session, msg)
 			else:
-				await self._handle_pulse_message(
-					render, session, cast(ClientPulseMessage, msg)
-				)
+				await self._handle_pulse_message(render, session, msg)
 		except Exception as e:
 			path = msg.get("path", "")
 			render.report_error(path, "server", e)

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -1157,7 +1157,7 @@ class App:
 				return
 
 			if isinstance(res, Deny):
-				path = cast(str, msg.get("path", "api_response"))
+				path = msg.get("path", "api_response")
 				render.report_error(
 					path,
 					"server",

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -183,6 +183,13 @@ class PulseFastAPI(FastAPI):
 		super().include_router(router, **kwargs)
 
 
+def _normalize_message_response(res: Any) -> Ok[None] | Deny:
+	"""Middleware may return anything; treat everything but Ok/Deny as allow."""
+	if isinstance(res, (Ok, Deny)):
+		return res  # type: ignore[return-value]
+	return Ok(None)
+
+
 def _wrap_router_endpoints(router: APIRouter) -> None:
 	for route in router.routes:
 		if isinstance(route, APIRoute):
@@ -1053,21 +1060,18 @@ class App:
 
 	async def _handle_socket_message(self, sid: str, data: Serialized) -> None:
 		if sid in self._connecting_sockets:
-			self._queue_pending_socket_message(sid, data)
+			# Connect middleware is still running; the render is not mapped
+			# yet. _drain_pending_socket_messages replays these in order.
+			queue = self._pending_socket_messages.setdefault(sid, [])
+			if len(queue) >= MAX_PENDING_SOCKET_MESSAGES:
+				logger.warning(
+					"Dropping socket message for %s while connect is pending; queue is full",
+					sid,
+				)
+			else:
+				queue.append(data)
 			return
-		# Live socket: detach commands so this handler returns. Replies
-		# resolve inline and must not wait on middleware.
 		await self._deliver_socket_message(sid, data, detach=True)
-
-	def _queue_pending_socket_message(self, sid: str, data: Serialized) -> None:
-		queue = self._pending_socket_messages.setdefault(sid, [])
-		if len(queue) >= MAX_PENDING_SOCKET_MESSAGES:
-			logger.warning(
-				"Dropping socket message for %s while connect is pending; queue is full",
-				sid,
-			)
-			return
-		queue.append(data)
 
 	async def _drain_pending_socket_messages(self, sid: str) -> None:
 		try:
@@ -1078,48 +1082,41 @@ class App:
 		finally:
 			self._connecting_sockets.discard(sid)
 
-	async def _process_socket_message(self, sid: str, data: Serialized) -> None:
-		await self._deliver_socket_message(sid, data, detach=False)
-
 	async def _deliver_socket_message(
 		self, sid: str, data: Serialized, *, detach: bool
 	) -> None:
-		inbound = self._resolve_socket_inbound(sid, data)
-		if inbound is None:
-			return
-		render, session, msg = inbound
-		if self._apply_reply(render, msg):
-			return
-		if detach:
-			self._tasks.create_task(
-				self._run_command(render, session, msg),
-				name=f"inbound:{render.id}:{msg['type']}",
-			)
-			return
-		await self._run_command(render, session, msg)
-
-	def _resolve_socket_inbound(
-		self, sid: str, data: Serialized
-	) -> tuple[RenderSession, UserSession, ClientMessage] | None:
+		"""Route a packet to its render, then dispatch: replies resolve
+		inline; commands may await middleware, so the live socket detaches
+		them (`detach=True`) to keep the Socket.IO handler prompt."""
+		# Route. The packet carries no render id; the socket does.
 		rid = self._socket_to_render.get(sid)
 		if not rid:
-			return None
-		msg = cast(ClientMessage, deserialize(data))
+			return
 		render = self.render_sessions.get(rid)
 		if render is None:
-			return None
+			return
 		owner_sid = self._render_to_user.get(rid)
 		if owner_sid is None:
-			return None
+			return
 		session = self.user_sessions.get(owner_sid)
 		if session is None:
-			return None
+			return
 		# Cancel leftover cleanup for connected sessions only. Never cancel
 		# for disconnected renders: nothing would reschedule it and the
 		# session would survive past its timeout.
 		if render.connected:
 			self._cancel_render_cleanup(rid)
-		return render, session, msg
+		# Dispatch.
+		msg = cast(ClientMessage, deserialize(data))
+		if self._apply_reply(render, msg):
+			return
+		if detach:
+			self._tasks.create_task(
+				self._run_command(render, session, msg),
+				name=f"inbound:{rid}:{msg['type']}",
+			)
+		else:
+			await self._run_command(render, session, msg)
 
 	def _apply_reply(self, render: RenderSession, msg: ClientMessage) -> bool:
 		"""Resolve a protocol reply. Returns False if `msg` is a command."""
@@ -1141,19 +1138,16 @@ class App:
 	) -> None:
 		try:
 			if msg["type"] == "channel_message":
-				await self._handle_channel_message(render, session, msg)
+				await self._handle_channel_command(render, session, msg)
 			else:
-				await self._handle_pulse_message(render, session, msg)
+				await self._handle_pulse_command(render, session, msg)
 		except Exception as e:
 			path = msg.get("path", "")
 			render.report_error(path, "server", e)
 
-	async def _handle_pulse_message(
+	async def _handle_pulse_command(
 		self, render: RenderSession, session: UserSession, msg: ClientPulseMessage
 	) -> None:
-		if self._apply_reply(render, msg):
-			return
-
 		async def _next() -> Ok[None]:
 			if msg["type"] == "attach":
 				attached = render.attach(msg["path"], msg["routeInfo"])
@@ -1177,12 +1171,6 @@ class App:
 				logger.warning("Unknown message type received: %s", msg)
 			return Ok()
 
-		def _normalize_message_response(res: Any) -> Ok[None] | Deny:
-			if isinstance(res, (Ok, Deny)):
-				return res  # type: ignore[return-value]
-			# Treat any other value as allow
-			return Ok(None)
-
 		with PulseContext.update(session=session, render=render):
 			try:
 				res = await self.middleware.message(
@@ -1204,12 +1192,9 @@ class App:
 					{"kind": "deny"},
 				)
 
-	async def _handle_channel_message(
+	async def _handle_channel_command(
 		self, render: RenderSession, session: UserSession, msg: ClientChannelMessage
 	) -> None:
-		if self._apply_reply(render, msg):
-			return
-
 		channel_id = str(msg.get("channel", ""))
 		msg = cast(ClientChannelRequestMessage, msg)
 
@@ -1217,12 +1202,6 @@ class App:
 			render.channels.handle_client_event(
 				render=render, session=session, message=msg
 			)
-			return Ok(None)
-
-		def _normalize_message_response(res: Any) -> Ok[None] | Deny:
-			if isinstance(res, (Ok, Deny)):
-				return res  # type: ignore[return-value]
-			# Treat any other value as allow
 			return Ok(None)
 
 		with PulseContext.update(session=session, render=render):

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -1055,19 +1055,9 @@ class App:
 		if sid in self._connecting_sockets:
 			self._queue_pending_socket_message(sid, data)
 			return
-		inbound = self._resolve_socket_inbound(sid, data)
-		if inbound is None:
-			return
-		render, session, msg = inbound
-		if self._is_inbound_reply(msg):
-			self._apply_inbound_reply(render, msg)
-			return
-		# Command handling is async (middleware). Detach it so this Socket.IO
-		# handler can return — replies on this socket must not sit behind Decide.
-		self._tasks.create_task(
-			self._dispatch_inbound_command(render, session, msg),
-			name=f"inbound:{render.id}:{msg['type']}",
-		)
+		# Live socket: detach commands so this handler returns. Replies
+		# resolve inline and must not wait on middleware.
+		await self._deliver_socket_message(sid, data, detach=True)
 
 	def _queue_pending_socket_message(self, sid: str, data: Serialized) -> None:
 		queue = self._pending_socket_messages.setdefault(sid, [])
@@ -1083,11 +1073,30 @@ class App:
 		try:
 			while pending := self._pending_socket_messages.pop(sid, []):
 				for data in pending:
-					# Connect replay stays ordered: await each command. Replies
-					# still resolve inline when we reach them.
-					await self._process_socket_message(sid, data)
+					# First-load replay stays ordered (attach then callback).
+					await self._deliver_socket_message(sid, data, detach=False)
 		finally:
 			self._connecting_sockets.discard(sid)
+
+	async def _process_socket_message(self, sid: str, data: Serialized) -> None:
+		await self._deliver_socket_message(sid, data, detach=False)
+
+	async def _deliver_socket_message(
+		self, sid: str, data: Serialized, *, detach: bool
+	) -> None:
+		inbound = self._resolve_socket_inbound(sid, data)
+		if inbound is None:
+			return
+		render, session, msg = inbound
+		if self._apply_reply(render, msg):
+			return
+		if detach:
+			self._tasks.create_task(
+				self._run_command(render, session, msg),
+				name=f"inbound:{render.id}:{msg['type']}",
+			)
+			return
+		await self._run_command(render, session, msg)
 
 	def _resolve_socket_inbound(
 		self, sid: str, data: Serialized
@@ -1105,28 +1114,29 @@ class App:
 		session = self.user_sessions.get(owner_sid)
 		if session is None:
 			return None
-		# Cancel any leftover cleanup for connected sessions. Never cancel
+		# Cancel leftover cleanup for connected sessions only. Never cancel
 		# for disconnected renders: nothing would reschedule it and the
 		# session would survive past its timeout.
 		if render.connected:
 			self._cancel_render_cleanup(rid)
 		return render, session, msg
 
-	def _is_inbound_reply(self, msg: ClientMessage) -> bool:
-		if msg["type"] == "api_result" or msg["type"] == "js_result":
-			return True
-		return msg["type"] == "channel_message" and bool(msg.get("responseTo"))
-
-	def _apply_inbound_reply(self, render: RenderSession, msg: ClientMessage) -> None:
+	def _apply_reply(self, render: RenderSession, msg: ClientMessage) -> bool:
+		"""Resolve a protocol reply. Returns False if `msg` is a command."""
 		if msg["type"] == "api_result":
 			render.handle_api_result(dict(msg))
-			return
+			return True
 		if msg["type"] == "js_result":
 			render.handle_js_result(dict(msg))
-			return
-		render.channels.handle_client_response(cast(ClientChannelResponseMessage, msg))
+			return True
+		if msg["type"] == "channel_message" and msg.get("responseTo"):
+			render.channels.handle_client_response(
+				cast(ClientChannelResponseMessage, msg)
+			)
+			return True
+		return False
 
-	async def _dispatch_inbound_command(
+	async def _run_command(
 		self, render: RenderSession, session: UserSession, msg: ClientMessage
 	) -> None:
 		try:
@@ -1138,21 +1148,10 @@ class App:
 			path = msg.get("path", "")
 			render.report_error(path, "server", e)
 
-	async def _process_socket_message(self, sid: str, data: Serialized) -> None:
-		inbound = self._resolve_socket_inbound(sid, data)
-		if inbound is None:
-			return
-		render, session, msg = inbound
-		if self._is_inbound_reply(msg):
-			self._apply_inbound_reply(render, msg)
-			return
-		await self._dispatch_inbound_command(render, session, msg)
-
 	async def _handle_pulse_message(
 		self, render: RenderSession, session: UserSession, msg: ClientPulseMessage
 	) -> None:
-		if self._is_inbound_reply(msg):
-			self._apply_inbound_reply(render, msg)
+		if self._apply_reply(render, msg):
 			return
 
 		async def _next() -> Ok[None]:
@@ -1208,38 +1207,38 @@ class App:
 	async def _handle_channel_message(
 		self, render: RenderSession, session: UserSession, msg: ClientChannelMessage
 	) -> None:
-		if msg.get("responseTo"):
-			self._apply_inbound_reply(render, msg)
-		else:
-			channel_id = str(msg.get("channel", ""))
-			msg = cast(ClientChannelRequestMessage, msg)
+		if self._apply_reply(render, msg):
+			return
 
-			async def _next() -> Ok[None]:
-				render.channels.handle_client_event(
-					render=render, session=session, message=msg
-				)
-				return Ok(None)
+		channel_id = str(msg.get("channel", ""))
+		msg = cast(ClientChannelRequestMessage, msg)
 
-			def _normalize_message_response(res: Any) -> Ok[None] | Deny:
-				if isinstance(res, (Ok, Deny)):
-					return res  # type: ignore[return-value]
-				# Treat any other value as allow
-				return Ok(None)
+		async def _next() -> Ok[None]:
+			render.channels.handle_client_event(
+				render=render, session=session, message=msg
+			)
+			return Ok(None)
 
-			with PulseContext.update(session=session, render=render):
-				res = await self.middleware.channel(
-					channel_id=channel_id,
-					event=msg.get("event", ""),
-					payload=msg.get("payload"),
-					request_id=msg.get("requestId"),
-					session=session.data,
-					next=_next,
-				)
-				res = _normalize_message_response(res)
+		def _normalize_message_response(res: Any) -> Ok[None] | Deny:
+			if isinstance(res, (Ok, Deny)):
+				return res  # type: ignore[return-value]
+			# Treat any other value as allow
+			return Ok(None)
 
-			if isinstance(res, Deny):
-				if req_id := msg.get("requestId"):
-					render.channels.send_error(channel_id, req_id, "Denied")
+		with PulseContext.update(session=session, render=render):
+			res = await self.middleware.channel(
+				channel_id=channel_id,
+				event=msg.get("event", ""),
+				payload=msg.get("payload"),
+				request_id=msg.get("requestId"),
+				session=session.data,
+				next=_next,
+			)
+			res = _normalize_message_response(res)
+
+		if isinstance(res, Deny):
+			if req_id := msg.get("requestId"):
+				render.channels.send_error(channel_id, req_id, "Denied")
 
 	def get_route(self, path: str):
 		return self.routes.find(path)

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -183,13 +183,6 @@ class PulseFastAPI(FastAPI):
 		super().include_router(router, **kwargs)
 
 
-def _normalize_message_response(res: Any) -> Ok[None] | Deny:
-	"""Middleware may return anything; treat everything but Ok/Deny as allow."""
-	if isinstance(res, (Ok, Deny)):
-		return res  # type: ignore[return-value]
-	return Ok(None)
-
-
 def _wrap_router_endpoints(router: APIRouter) -> None:
 	for route in router.routes:
 		if isinstance(route, APIRoute):
@@ -922,12 +915,7 @@ class App:
 			try:
 				with PulseContext.update(session=session, render=render):
 
-					async def _next():
-						return Ok(None)
-
-					def _normalize_connect_response(res: Any) -> ConnectResponse:
-						if isinstance(res, (Ok, Deny)):
-							return res  # type: ignore[return-value]
+					async def _next() -> ConnectResponse:
 						return Ok(None)
 
 					try:
@@ -936,7 +924,6 @@ class App:
 							session=session.data,
 							next=_next,
 						)
-						res = _normalize_connect_response(res)
 					except Exception as exc:
 						connect_error = exc
 						res = Ok(None)
@@ -1178,7 +1165,6 @@ class App:
 					session=session.data,
 					next=_next,
 				)
-				res = _normalize_message_response(res)
 			except Exception:
 				logger.exception("Error in message middleware")
 				return
@@ -1213,7 +1199,6 @@ class App:
 				session=session.data,
 				next=_next,
 			)
-			res = _normalize_message_response(res)
 
 		if isinstance(res, Deny):
 			if req_id := msg.get("requestId"):

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -427,8 +427,10 @@ class App:
 			lifespan=self.fastapi_lifespan,
 		)
 		self.fastapi.router.route_class = PulseAPIRoute
+		# EVENT handlers run as tasks so a parked command does not stall
+		# the receive loop. CONNECT is still awaited by python-socketio.
 		self.sio = socketio.AsyncServer(
-			async_mode="asgi", cors_allowed_origins="*", async_handlers=False
+			async_mode="asgi", cors_allowed_origins="*", async_handlers=True
 		)
 		self.asgi = socketio.ASGIApp(self.sio, self.fastapi)
 
@@ -1058,23 +1060,22 @@ class App:
 			else:
 				queue.append(data)
 			return
-		await self._deliver_socket_message(sid, data, detach=True)
+		await self._deliver_socket_message(sid, data)
 
 	async def _drain_pending_socket_messages(self, sid: str) -> None:
 		try:
 			while pending := self._pending_socket_messages.pop(sid, []):
 				for data in pending:
 					# First-load replay stays ordered (attach then callback).
-					await self._deliver_socket_message(sid, data, detach=False)
+					await self._deliver_socket_message(sid, data)
 		finally:
 			self._connecting_sockets.discard(sid)
 
-	async def _deliver_socket_message(
-		self, sid: str, data: Serialized, *, detach: bool
-	) -> None:
-		"""Route a packet to its render, then dispatch: replies resolve
-		inline; commands may await middleware, so the live socket detaches
-		them (`detach=True`) to keep the Socket.IO handler prompt."""
+	async def _deliver_socket_message(self, sid: str, data: Serialized) -> None:
+		"""Route a packet to its render. Replies resolve here; commands
+		await middleware. Live EVENTs are already tasks (async_handlers).
+		Connect drain awaits this so first-load attach then callback stays
+		ordered."""
 		# Route. The packet carries no render id; the socket does.
 		rid = self._socket_to_render.get(sid)
 		if not rid:
@@ -1097,13 +1098,7 @@ class App:
 		msg = cast(ClientMessage, deserialize(data))
 		if self._apply_reply(render, msg):
 			return
-		if detach:
-			self._tasks.create_task(
-				self._run_command(render, session, msg),
-				name=f"inbound:{rid}:{msg['type']}",
-			)
-		else:
-			await self._run_command(render, session, msg)
+		await self._run_command(render, session, msg)
 
 	def _apply_reply(self, render: RenderSession, msg: ClientMessage) -> bool:
 		"""Resolve a protocol reply. Returns False if `msg` is a command."""

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -1070,10 +1070,10 @@ class App:
 			self._connecting_sockets.discard(sid)
 
 	async def _deliver_socket_message(self, sid: str, data: Serialized) -> None:
-		"""Route a packet to its render. Replies resolve here; commands
-		await middleware. Live EVENTs are already tasks (async_handlers).
-		Connect drain awaits this so first-load attach then callback stays
-		ordered."""
+		"""Route a packet to its render. `reply` completes a pending
+		request; commands await middleware. Live EVENTs are already tasks
+		(async_handlers). Connect drain awaits this so first-load attach
+		then callback stays ordered."""
 		# Route. The packet carries no render id; the socket does.
 		rid = self._socket_to_render.get(sid)
 		if not rid:
@@ -1092,16 +1092,11 @@ class App:
 		# session would survive past its timeout.
 		if render.connected:
 			self._cancel_render_cleanup(rid)
-		# Dispatch. Replies and commands are disjoint types. channel_message
-		# is the one wire type that carries both; responseTo is the reply.
+		# Dispatch. `reply` completes a pending request; everything else
+		# is a command (middleware + mutation).
 		msg = cast(ClientMessage, deserialize(data))
-		kind = msg["type"]
-		if kind == "api_result":
-			render.handle_api_result(dict(msg))
-		elif kind == "js_result":
-			render.handle_js_result(dict(msg))
-		elif kind == "channel_message" and "responseTo" in msg:
-			render.channels.handle_client_response(msg)
+		if msg["type"] == "reply":
+			render.replies.apply(msg)
 		else:
 			await self._run_command(render, session, msg)
 

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -50,7 +50,6 @@ from pulse.helpers import (
 )
 from pulse.hooks.core import hooks
 from pulse.messages import (
-	ClientChannelMessage,
 	ClientChannelRequestMessage,
 	ClientChannelResponseMessage,
 	ClientMessage,
@@ -1094,33 +1093,29 @@ class App:
 		# session would survive past its timeout.
 		if render.connected:
 			self._cancel_render_cleanup(rid)
-		# Dispatch.
+		# Dispatch. Replies and commands are disjoint types. channel_message
+		# is the one wire type that carries both; responseTo is the reply.
 		msg = cast(ClientMessage, deserialize(data))
-		if self._apply_reply(render, msg):
-			return
-		await self._run_command(render, session, msg)
-
-	def _apply_reply(self, render: RenderSession, msg: ClientMessage) -> bool:
-		"""Resolve a protocol reply. Returns False if `msg` is a command."""
-		if msg["type"] == "api_result":
+		kind = msg["type"]
+		if kind == "api_result":
 			render.handle_api_result(dict(msg))
-			return True
-		if msg["type"] == "js_result":
+		elif kind == "js_result":
 			render.handle_js_result(dict(msg))
-			return True
-		if msg["type"] == "channel_message" and msg.get("responseTo"):
+		elif kind == "channel_message" and "responseTo" in msg:
 			render.channels.handle_client_response(
 				cast(ClientChannelResponseMessage, msg)
 			)
-			return True
-		return False
+		else:
+			await self._run_command(render, session, msg)
 
 	async def _run_command(
 		self, render: RenderSession, session: UserSession, msg: ClientMessage
 	) -> None:
 		try:
 			if msg["type"] == "channel_message":
-				await self._handle_channel_command(render, session, msg)
+				await self._handle_channel_command(
+					render, session, cast(ClientChannelRequestMessage, msg)
+				)
 			else:
 				await self._handle_pulse_command(render, session, msg)
 		except Exception as e:
@@ -1174,10 +1169,12 @@ class App:
 				)
 
 	async def _handle_channel_command(
-		self, render: RenderSession, session: UserSession, msg: ClientChannelMessage
+		self,
+		render: RenderSession,
+		session: UserSession,
+		msg: ClientChannelRequestMessage,
 	) -> None:
 		channel_id = str(msg.get("channel", ""))
-		msg = cast(ClientChannelRequestMessage, msg)
 
 		async def _next() -> Ok[None]:
 			render.channels.handle_client_event(

--- a/packages/pulse/python/src/pulse/channel.py
+++ b/packages/pulse/python/src/pulse/channel.py
@@ -3,7 +3,6 @@ import logging
 import uuid
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 from pulse.context import PulseContext
@@ -14,6 +13,7 @@ from pulse.messages import (
 	ServerChannelRequestMessage,
 	ServerChannelResponseMessage,
 )
+from pulse.replies import PendingReplies
 from pulse.scheduling import create_future
 
 if TYPE_CHECKING:
@@ -28,6 +28,12 @@ ChannelHandler = Callable[[Any], Any | Awaitable[Any]]
 
 Type alias for ``Callable[[Any], Any | Awaitable[Any]]``.
 """
+
+
+def _as_exception(error: Any) -> BaseException:
+	if isinstance(error, BaseException):
+		return error
+	return RuntimeError(str(error))
 
 
 class ChannelClosed(RuntimeError):
@@ -60,25 +66,21 @@ class ChannelTimeout(asyncio.TimeoutError):
 	"""
 
 
-@dataclass(slots=True)
-class PendingRequest:
-	future: asyncio.Future[Any]
-	channel_id: str
-
-
 class ChannelsManager:
 	"""Coordinates creation, routing, and cleanup of Pulse channels."""
 
 	_render_session: "RenderSession"
 	_channels: dict[str, "Channel"]
 	_channels_by_route: dict[str, set[str]]
-	pending_requests: dict[str, PendingRequest]
 
 	def __init__(self, render_session: "RenderSession") -> None:
 		self._render_session = render_session
 		self._channels = {}
 		self._channels_by_route = defaultdict(set)
-		self.pending_requests = {}
+
+	@property
+	def replies(self) -> PendingReplies:
+		return self._render_session.replies
 
 	# ------------------------------------------------------------------
 	def create(
@@ -132,9 +134,9 @@ class ChannelsManager:
 
 		error = message.get("error")
 		if error is not None:
-			self.resolve_pending_error(response_to, error)
+			self.replies.reject(response_to, _as_exception(error))
 		else:
-			self._resolve_pending_success(response_to, message.get("payload"))
+			self.replies.resolve(response_to, message.get("payload"))
 
 	def handle_client_event(
 		self,
@@ -216,42 +218,12 @@ class ChannelsManager:
 
 		render.create_task(_invoke(), name=f"channel:{channel_id}:{event}")
 
-	# ------------------------------------------------------------------
-	def register_pending(
-		self,
-		request_id: str,
-		future: asyncio.Future[Any],
-		channel_id: str,
-	) -> None:
-		self.pending_requests[request_id] = PendingRequest(
-			future=future, channel_id=channel_id
-		)
-
-	def _resolve_pending_success(self, request_id: str, payload: Any) -> None:
-		pending = self.pending_requests.pop(request_id, None)
-		if not pending:
-			return
-		if pending.future.done():
-			return
-		pending.future.set_result(payload)
-
-	def resolve_pending_error(self, request_id: str, error: Any) -> None:
-		pending = self.pending_requests.pop(request_id, None)
-		if not pending:
-			return
-		if pending.future.done():
-			return
-		if isinstance(error, Exception):
-			pending.future.set_exception(error)
-		else:
-			pending.future.set_exception(RuntimeError(str(error)))
-
 	def _send_error_response(
 		self, channel_id: str, request_id: str, message: str
 	) -> None:
 		channel = self._channels.get(channel_id)
 		if channel is None:
-			self.resolve_pending_error(request_id, ChannelClosed(message))
+			self.replies.reject(request_id, ChannelClosed(message))
 			return
 		try:
 			msg = ServerChannelResponseMessage(
@@ -267,18 +239,10 @@ class ChannelsManager:
 				msg=msg,
 			)
 		except ChannelClosed:
-			self.resolve_pending_error(request_id, ChannelClosed(message))
+			self.replies.reject(request_id, ChannelClosed(message))
 
 	def send_error(self, channel_id: str, request_id: str, message: str) -> None:
 		self._send_error_response(channel_id, request_id, message)
-
-	def _cancel_pending_for_channel(self, channel_id: str) -> None:
-		for key, pending in list(self.pending_requests.items()):
-			if pending.channel_id != channel_id:
-				continue
-			if not pending.future.done():
-				pending.future.set_exception(ChannelClosed("Channel closed"))
-			self.pending_requests.pop(key, None)
 
 	# ------------------------------------------------------------------
 	def release_channel(
@@ -314,14 +278,8 @@ class ChannelsManager:
 		*,
 		reason: str | None = None,
 	) -> None:
-		# pending = sum(
-		# 	1
-		# 	for pending in self.pending_requests.values()
-		# 	if pending.channel_id == channel.id
-		# )
-		# print(f"Disposing channel id={channel.id} render={channel.render_id} session={channel.session_id} route={channel.route_path} reason={reason or 'unspecified'} pending={pending}")
 		self._cleanup_channel_refs(channel)
-		self._cancel_pending_for_channel(channel.id)
+		self.replies.reject_where(channel.id, ChannelClosed("Channel closed"))
 		self._channels.pop(channel.id, None)
 		# Notify client that the channel has been closed
 		try:
@@ -506,7 +464,7 @@ class Channel:
 		self._ensure_open()
 		request_id = uuid.uuid4().hex
 		fut = create_future()
-		self._manager.register_pending(request_id, fut, self.id)
+		self._manager.replies.register(request_id, fut, cancel_key=self.id)
 		msg = ServerChannelRequestMessage(
 			type="channel_message",
 			channel=self.id,
@@ -523,13 +481,11 @@ class Channel:
 				return await fut
 			return await asyncio.wait_for(fut, timeout=timeout)
 		except TimeoutError as exc:
-			self._manager.resolve_pending_error(
-				request_id,
-				ChannelTimeout("Channel request timed out"),
-			)
 			raise ChannelTimeout("Channel request timed out") from exc
 		finally:
-			self._manager.pending_requests.pop(request_id, None)
+			# Success/close/timeout all pop the entry; this covers outer
+			# cancellation of the awaiting task, which would otherwise leak it.
+			self._manager.replies.discard(request_id)
 
 	# ---------------------------------------------------------------------
 	def close(self) -> None:

--- a/packages/pulse/python/src/pulse/channel.py
+++ b/packages/pulse/python/src/pulse/channel.py
@@ -8,10 +8,9 @@ from typing import TYPE_CHECKING, Any, cast
 from pulse.context import PulseContext
 from pulse.messages import (
 	ClientChannelRequestMessage,
-	ClientChannelResponseMessage,
+	ReplyMessage,
 	ServerChannelMessage,
 	ServerChannelRequestMessage,
-	ServerChannelResponseMessage,
 )
 from pulse.replies import PendingReplies
 from pulse.scheduling import create_future
@@ -28,12 +27,6 @@ ChannelHandler = Callable[[Any], Any | Awaitable[Any]]
 
 Type alias for ``Callable[[Any], Any | Awaitable[Any]]``.
 """
-
-
-def _as_exception(error: Any) -> BaseException:
-	if isinstance(error, BaseException):
-		return error
-	return RuntimeError(str(error))
 
 
 class ChannelClosed(RuntimeError):
@@ -126,18 +119,6 @@ class ChannelsManager:
 			self.dispose_channel(channel, reason="route.unmount")
 		self._channels_by_route.pop(path, None)
 
-	# ------------------------------------------------------------------
-	def handle_client_response(self, message: ClientChannelResponseMessage) -> None:
-		response_to = message.get("responseTo")
-		if not response_to:
-			return
-
-		error = message.get("error")
-		if error is not None:
-			self.replies.reject(response_to, _as_exception(error))
-		else:
-			self.replies.resolve(response_to, message.get("payload"))
-
 	def handle_client_event(
 		self,
 		*,
@@ -204,16 +185,8 @@ class ChannelsManager:
 				return
 
 			if request_id:
-				msg = ServerChannelResponseMessage(
-					type="channel_message",
-					channel=channel.id,
-					event=None,
-					responseTo=request_id,
-					payload=result,
-				)
-				self.send_to_client(
-					channel=channel,
-					msg=msg,
+				self._render_session.send(
+					ReplyMessage(type="reply", id=request_id, payload=result)
 				)
 
 		render.create_task(_invoke(), name=f"channel:{channel_id}:{event}")
@@ -226,17 +199,8 @@ class ChannelsManager:
 			self.replies.reject(request_id, ChannelClosed(message))
 			return
 		try:
-			msg = ServerChannelResponseMessage(
-				type="channel_message",
-				channel=channel.id,
-				event=None,
-				responseTo=request_id,
-				payload=None,
-				error=message,
-			)
-			self.send_to_client(
-				channel=channel,
-				msg=msg,
+			self._render_session.send(
+				ReplyMessage(type="reply", id=request_id, error=message)
 			)
 		except ChannelClosed:
 			self.replies.reject(request_id, ChannelClosed(message))

--- a/packages/pulse/python/src/pulse/messages.py
+++ b/packages/pulse/python/src/pulse/messages.py
@@ -83,12 +83,12 @@ class ServerChannelRequestMessage(TypedDict):
 	error: NotRequired[Any]
 
 
-class ServerChannelResponseMessage(TypedDict):
-	type: Literal["channel_message"]
-	channel: str
-	event: None
-	responseTo: str
-	payload: Any
+class ReplyMessage(TypedDict):
+	"""Client or server reply to a pending request (`PendingReplies`)."""
+
+	type: Literal["reply"]
+	id: str
+	payload: NotRequired[Any]
 	error: NotRequired[Any]
 
 
@@ -129,15 +129,6 @@ class ClientDetachMessage(TypedDict):
 	path: str
 
 
-class ClientApiResultMessage(TypedDict):
-	type: Literal["api_result"]
-	id: str
-	ok: bool
-	status: int
-	headers: dict[str, str]
-	body: Any | None
-
-
 class ClientChannelRequestMessage(TypedDict):
 	type: Literal["channel_message"]
 	channel: str
@@ -147,25 +138,7 @@ class ClientChannelRequestMessage(TypedDict):
 	error: NotRequired[Any]
 
 
-class ClientChannelResponseMessage(TypedDict):
-	type: Literal["channel_message"]
-	channel: str
-	event: None
-	responseTo: str
-	payload: Any
-	error: NotRequired[Any]
-
-
-class ClientJsResultMessage(TypedDict):
-	"""Result of client-side JS execution."""
-
-	type: Literal["js_result"]
-	id: str
-	result: Any
-	error: str | None
-
-
-ServerChannelMessage = ServerChannelRequestMessage | ServerChannelResponseMessage
+ServerChannelMessage = ServerChannelRequestMessage
 ServerMessage = (
 	ServerInitMessage
 	| ServerUpdateMessage
@@ -176,6 +149,7 @@ ServerMessage = (
 	| ServerAttachAckMessage
 	| ServerChannelMessage
 	| ServerJsExecMessage
+	| ReplyMessage
 )
 
 
@@ -184,11 +158,9 @@ ClientPulseMessage = (
 	| ClientAttachMessage
 	| ClientUpdateMessage
 	| ClientDetachMessage
-	| ClientApiResultMessage
-	| ClientJsResultMessage
 )
-ClientChannelMessage = ClientChannelRequestMessage | ClientChannelResponseMessage
-ClientMessage = ClientPulseMessage | ClientChannelMessage
+ClientChannelMessage = ClientChannelRequestMessage
+ClientMessage = ClientPulseMessage | ClientChannelMessage | ReplyMessage
 
 
 class PrerenderPayload(TypedDict):

--- a/packages/pulse/python/src/pulse/middleware.py
+++ b/packages/pulse/python/src/pulse/middleware.py
@@ -78,6 +78,17 @@ class Deny:
 	"""Denial response. Blocks the request."""
 
 
+def _coerce_decision(res: Any) -> "Ok[None] | Deny":
+	"""User hooks may return anything; only Ok/Deny are decisions.
+
+	Applied once, where each middleware returns — so `MiddlewareStack`
+	honors its declared return types and callers never re-normalize.
+	"""
+	if isinstance(res, (Ok, Deny)):
+		return res  # type: ignore[return-value]
+	return Ok(None)
+
+
 PrerenderResponse = Ok[Prerender] | Redirect | NotFound
 """Response type for batch prerender: ``Ok[Prerender] | Redirect | NotFound``."""
 
@@ -167,14 +178,15 @@ class PulseMiddleware:
 		*,
 		data: ClientMessage,
 		session: dict[str, Any],
-		next: Callable[[], Awaitable[Ok[None]]],
+		next: Callable[[], Awaitable["Ok[None] | Deny"]],
 	) -> Ok[None] | Deny:
 		"""Handle per-message authorization.
 
 		Args:
 			data: Client message data.
 			session: Session data dictionary.
-			next: Callable to continue the middleware chain.
+			next: Callable to continue the middleware chain. Returns the
+				downstream decision; return it as-is or override it.
 
 		Returns:
 			``Ok[None]`` to allow, ``Deny`` to block.
@@ -189,7 +201,7 @@ class PulseMiddleware:
 		payload: Any,
 		request_id: str | None,
 		session: dict[str, Any],
-		next: Callable[[], Awaitable[Ok[None]]],
+		next: Callable[[], Awaitable["Ok[None] | Deny"]],
 	) -> Ok[None] | Deny:
 		"""Handle channel message authorization.
 
@@ -199,7 +211,8 @@ class PulseMiddleware:
 			payload: Event payload.
 			request_id: Request ID if awaiting response.
 			session: Session data dictionary.
-			next: Callable to continue the middleware chain.
+			next: Callable to continue the middleware chain. Returns the
+				downstream decision; return it as-is or override it.
 
 		Returns:
 			``Ok[None]`` to allow, ``Deny`` to block.
@@ -282,7 +295,9 @@ class MiddlewareStack(PulseMiddleware):
 			async def _next() -> ConnectResponse:
 				return await dispatch(index + 1)
 
-			return await mw.connect(request=request, session=session, next=_next)
+			return _coerce_decision(
+				await mw.connect(request=request, session=session, next=_next)
+			)
 
 		return await dispatch(0)
 
@@ -292,23 +307,19 @@ class MiddlewareStack(PulseMiddleware):
 		*,
 		data: ClientMessage,
 		session: dict[str, Any],
-		next: Callable[[], Awaitable[Ok[None]]],
+		next: Callable[[], Awaitable["Ok[None] | Deny"]],
 	) -> Ok[None] | Deny:
 		async def dispatch(index: int) -> Ok[None] | Deny:
 			if index >= len(self._middlewares):
 				return await next()
 			mw = self._middlewares[index]
 
-			async def _next() -> Ok[None]:
-				result = await dispatch(index + 1)
-				# If dispatch returns Deny, the middleware should have short-circuited
-				# This should only be called when continuing the chain
-				if isinstance(result, Deny):
-					# This shouldn't happen, but handle it gracefully
-					return Ok(None)
-				return result
+			async def _next() -> Ok[None] | Deny:
+				return await dispatch(index + 1)
 
-			return await mw.message(session=session, data=data, next=_next)
+			return _coerce_decision(
+				await mw.message(session=session, data=data, next=_next)
+			)
 
 		return await dispatch(0)
 
@@ -321,29 +332,25 @@ class MiddlewareStack(PulseMiddleware):
 		payload: Any,
 		request_id: str | None,
 		session: dict[str, Any],
-		next: Callable[[], Awaitable[Ok[None]]],
+		next: Callable[[], Awaitable["Ok[None] | Deny"]],
 	) -> Ok[None] | Deny:
 		async def dispatch(index: int) -> Ok[None] | Deny:
 			if index >= len(self._middlewares):
 				return await next()
 			mw = self._middlewares[index]
 
-			async def _next() -> Ok[None]:
-				result = await dispatch(index + 1)
-				# If dispatch returns Deny, the middleware should have short-circuited
-				# This should only be called when continuing the chain
-				if isinstance(result, Deny):
-					# This shouldn't happen, but handle it gracefully
-					return Ok(None)
-				return result
+			async def _next() -> Ok[None] | Deny:
+				return await dispatch(index + 1)
 
-			return await mw.channel(
-				channel_id=channel_id,
-				event=event,
-				payload=payload,
-				request_id=request_id,
-				session=session,
-				next=_next,
+			return _coerce_decision(
+				await mw.channel(
+					channel_id=channel_id,
+					event=event,
+					payload=payload,
+					request_id=request_id,
+					session=session,
+					next=_next,
+				)
 			)
 
 		return await dispatch(0)
@@ -449,7 +456,7 @@ class LatencyMiddleware(PulseMiddleware):
 		*,
 		data: ClientMessage,
 		session: dict[str, Any],
-		next: Callable[[], Awaitable[Ok[None]]],
+		next: Callable[[], Awaitable["Ok[None] | Deny"]],
 	) -> Ok[None] | Deny:
 		if self.message_ms > 0:
 			await asyncio.sleep(self.message_ms / 1000.0)
@@ -464,7 +471,7 @@ class LatencyMiddleware(PulseMiddleware):
 		payload: Any,
 		request_id: str | None,
 		session: dict[str, Any],
-		next: Callable[[], Awaitable[Ok[None]]],
+		next: Callable[[], Awaitable["Ok[None] | Deny"]],
 	) -> Ok[None] | Deny:
 		if self.channel_ms > 0:
 			await asyncio.sleep(self.channel_ms / 1000.0)

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -22,6 +22,7 @@ from pulse.queries.store import QueryStore
 from pulse.reactive import REACTIVE_CONTEXT, Effect, Untrack, flush_effects
 from pulse.reactive_extensions import ReactiveDict
 from pulse.renderer import RenderTree
+from pulse.replies import PendingReplies
 from pulse.routing import (
 	Layout,
 	Route,
@@ -275,8 +276,7 @@ class RenderSession:
 	_server_address: str | None
 	_client_address: str | None
 	_send_message: Callable[[ServerMessage], Any] | None
-	_pending_api: dict[str, asyncio.Future[dict[str, Any]]]
-	_pending_js_results: dict[str, asyncio.Future[Any]]
+	replies: PendingReplies
 	_ref_channel: Channel | None
 	_ref_channels_by_route: dict[str, Channel]
 	_global_states: dict[str, State]
@@ -318,8 +318,7 @@ class RenderSession:
 		self.connected = False
 		self.channels = ChannelsManager(self)
 		self.forms = FormRegistry(self)
-		self._pending_api = {}
-		self._pending_js_results = {}
+		self.replies = PendingReplies()
 		self._ref_channel = None
 		self._ref_channels_by_route = {}
 		self._tasks = TaskRegistry(name=f"render:{id}")
@@ -719,14 +718,7 @@ class RenderSession:
 			if channel:
 				channel.closed = True
 				self.channels.dispose_channel(channel, reason="render.close")
-		for fut in self._pending_api.values():
-			if not fut.done():
-				fut.cancel()
-		self._pending_api.clear()
-		for fut in self._pending_js_results.values():
-			if not fut.done():
-				fut.cancel()
-		self._pending_js_results.clear()
+		self.replies.cancel_all()
 		self._ref_channel = None
 		self._ref_channels_by_route.clear()
 		# Close any timer that may have been scheduled during cleanup (ex: query GC)
@@ -876,7 +868,7 @@ class RenderSession:
 			url = f"{base}{api_path}"
 		corr_id = uuid.uuid4().hex
 		fut = create_future()
-		self._pending_api[corr_id] = fut
+		self.replies.register(corr_id, fut)
 		headers = headers or {}
 		headers["x-pulse-render-id"] = self.id
 		self.send(
@@ -893,7 +885,7 @@ class RenderSession:
 		try:
 			result = await asyncio.wait_for(fut, timeout=timeout)
 		except asyncio.TimeoutError:
-			self._pending_api.pop(corr_id, None)
+			self.replies.discard(corr_id)
 			raise
 		return result
 
@@ -901,17 +893,15 @@ class RenderSession:
 		id_ = data.get("id")
 		if id_ is None:
 			return
-		id_ = str(id_)
-		fut = self._pending_api.pop(id_, None)
-		if fut and not fut.done():
-			fut.set_result(
-				{
-					"ok": data.get("ok", False),
-					"status": data.get("status", 0),
-					"headers": data.get("headers", {}),
-					"body": data.get("body"),
-				}
-			)
+		self.replies.resolve(
+			str(id_),
+			{
+				"ok": data.get("ok", False),
+				"status": data.get("status", 0),
+				"headers": data.get("headers", {}),
+				"body": data.get("body"),
+			},
+		)
 
 	# ---- JS Execution ----
 
@@ -986,12 +976,10 @@ class RenderSession:
 		if result:
 			loop = asyncio.get_running_loop()
 			future: asyncio.Future[object] = loop.create_future()
-			self._pending_js_results[exec_id] = future
+			self.replies.register(exec_id, future)
 
 			def _on_timeout() -> None:
-				self._pending_js_results.pop(exec_id, None)
-				if not future.done():
-					future.set_exception(asyncio.TimeoutError())
+				self.replies.reject(exec_id, asyncio.TimeoutError())
 
 			self._timers.later(timeout, _on_timeout)
 
@@ -1005,11 +993,8 @@ class RenderSession:
 		if exec_id is None:
 			return
 		exec_id = str(exec_id)
-		fut = self._pending_js_results.pop(exec_id, None)
-		if fut is None or fut.done():
-			return
 		error = data.get("error")
 		if error is not None:
-			fut.set_exception(JsExecError(error))
+			self.replies.reject(exec_id, JsExecError(error))
 		else:
-			fut.set_result(data.get("result"))
+			self.replies.resolve(exec_id, data.get("result"))

--- a/packages/pulse/python/src/pulse/render_session.py
+++ b/packages/pulse/python/src/pulse/render_session.py
@@ -49,10 +49,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__file__)
 
 
-class JsExecError(Exception):
-	"""Raised when client-side JS execution fails."""
-
-
 class RenderLoopError(RuntimeError):
 	path: str
 	renders: int
@@ -889,20 +885,6 @@ class RenderSession:
 			raise
 		return result
 
-	def handle_api_result(self, data: dict[str, Any]):
-		id_ = data.get("id")
-		if id_ is None:
-			return
-		self.replies.resolve(
-			str(id_),
-			{
-				"ok": data.get("ok", False),
-				"status": data.get("status", 0),
-				"headers": data.get("headers", {}),
-				"body": data.get("body"),
-			},
-		)
-
 	# ---- JS Execution ----
 
 	@overload
@@ -986,15 +968,3 @@ class RenderSession:
 			return future
 
 		return None
-
-	def handle_js_result(self, data: dict[str, Any]) -> None:
-		"""Handle js_result message from client."""
-		exec_id = data.get("id")
-		if exec_id is None:
-			return
-		exec_id = str(exec_id)
-		error = data.get("error")
-		if error is not None:
-			self.replies.reject(exec_id, JsExecError(error))
-		else:
-			self.replies.resolve(exec_id, data.get("result"))

--- a/packages/pulse/python/src/pulse/replies.py
+++ b/packages/pulse/python/src/pulse/replies.py
@@ -1,18 +1,20 @@
 """Single request/reply primitive for server-initiated exchanges.
 
 `call_api`, `run_js`, and `Channel.request` all follow the same protocol:
-mint a correlation id, park a future here, send a typed message to the
-client, and await the future. The matching client reply (`api_result`,
-`js_result`, channel `responseTo`) resolves it synchronously — no
-middleware, no awaits between packet and `set_result`.
+mint a correlation id, park a future here, send a typed command to the
+client, and await the future. The matching `{type: "reply", id}` packet
+resolves it synchronously — no middleware, no awaits between packet and
+`set_result`.
 
-Only the wire shapes and payload codecs differ; they stay at the call
-sites. Unknown or already-resolved ids are ignored: a reply can race a
-timeout or a channel close, and the loser must be a no-op.
+Command payloads stay at the call sites (`api_call`, `js_exec`,
+`channel_message`). Unknown or already-resolved ids are ignored: a reply
+can race a timeout or a channel close, and the loser must be a no-op.
 """
 
 import asyncio
 from typing import Any
+
+from pulse.messages import ReplyMessage
 
 
 class PendingReplies:
@@ -49,6 +51,15 @@ class PendingReplies:
 		if cancel_key is not None:
 			self._cancel_keys[reply_id] = cancel_key
 
+	def apply(self, message: ReplyMessage) -> None:
+		"""Resolve or reject from a `reply` packet. Missing ids are no-ops."""
+		reply_id = message["id"]
+		error = message.get("error")
+		if error is not None:
+			self.reject(reply_id, as_exception(error))
+		else:
+			self.resolve(reply_id, message.get("payload"))
+
 	def resolve(self, reply_id: str, value: Any) -> None:
 		future = self._pop(reply_id)
 		if future is not None and not future.done():
@@ -80,3 +91,9 @@ class PendingReplies:
 	def _pop(self, reply_id: str) -> asyncio.Future[Any] | None:
 		self._cancel_keys.pop(reply_id, None)
 		return self._futures.pop(reply_id, None)
+
+
+def as_exception(error: Any) -> BaseException:
+	if isinstance(error, BaseException):
+		return error
+	return RuntimeError(str(error))

--- a/packages/pulse/python/src/pulse/replies.py
+++ b/packages/pulse/python/src/pulse/replies.py
@@ -1,0 +1,82 @@
+"""Single request/reply primitive for server-initiated exchanges.
+
+`call_api`, `run_js`, and `Channel.request` all follow the same protocol:
+mint a correlation id, park a future here, send a typed message to the
+client, and await the future. The matching client reply (`api_result`,
+`js_result`, channel `responseTo`) resolves it synchronously — no
+middleware, no awaits between packet and `set_result`.
+
+Only the wire shapes and payload codecs differ; they stay at the call
+sites. Unknown or already-resolved ids are ignored: a reply can race a
+timeout or a channel close, and the loser must be a no-op.
+"""
+
+import asyncio
+from typing import Any
+
+
+class PendingReplies:
+	"""Correlation id -> future. Resolution never awaits."""
+
+	_futures: dict[str, asyncio.Future[Any]]
+	_cancel_keys: dict[str, str]
+
+	def __init__(self) -> None:
+		self._futures = {}
+		self._cancel_keys = {}
+
+	def __len__(self) -> int:
+		return len(self._futures)
+
+	def __contains__(self, reply_id: str) -> bool:
+		return reply_id in self._futures
+
+	def register(
+		self,
+		reply_id: str,
+		future: asyncio.Future[Any],
+		*,
+		cancel_key: str | None = None,
+	) -> None:
+		"""Park `future` until the client reply for `reply_id` arrives.
+
+		`cancel_key` groups requests that die together (e.g. all inflight
+		requests of one channel), failed via `reject_where`.
+		"""
+		if reply_id in self._futures:
+			raise ValueError(f"Duplicate pending reply id {reply_id!r}")
+		self._futures[reply_id] = future
+		if cancel_key is not None:
+			self._cancel_keys[reply_id] = cancel_key
+
+	def resolve(self, reply_id: str, value: Any) -> None:
+		future = self._pop(reply_id)
+		if future is not None and not future.done():
+			future.set_result(value)
+
+	def reject(self, reply_id: str, error: BaseException) -> None:
+		future = self._pop(reply_id)
+		if future is not None and not future.done():
+			future.set_exception(error)
+
+	def discard(self, reply_id: str) -> None:
+		"""Forget a pending reply without touching its future (timeouts)."""
+		self._pop(reply_id)
+
+	def reject_where(self, cancel_key: str, error: BaseException) -> None:
+		reply_ids = [
+			reply_id for reply_id, key in self._cancel_keys.items() if key == cancel_key
+		]
+		for reply_id in reply_ids:
+			self.reject(reply_id, error)
+
+	def cancel_all(self) -> None:
+		for future in self._futures.values():
+			if not future.done():
+				future.cancel()
+		self._futures.clear()
+		self._cancel_keys.clear()
+
+	def _pop(self, reply_id: str) -> asyncio.Future[Any] | None:
+		self._cancel_keys.pop(reply_id, None)
+		return self._futures.pop(reply_id, None)

--- a/packages/pulse/python/tests/test_app_message_order.py
+++ b/packages/pulse/python/tests/test_app_message_order.py
@@ -35,9 +35,7 @@ def _bind_render(
 	app._socket_to_render[socket_sid] = render.id  # pyright: ignore[reportPrivateUsage]
 
 
-async def _send(
-	app: ps.App, socket_sid: str, message: dict[str, object]
-) -> None:
+async def _send(app: ps.App, socket_sid: str, message: dict[str, object]) -> None:
 	await app._handle_socket_message(  # pyright: ignore[reportPrivateUsage]
 		socket_sid, serialize(message)
 	)
@@ -193,7 +191,7 @@ async def test_decide_on_one_path_does_not_serialize_other_path_or_completion():
 
 	@ps.component
 	def PageA():
-		return ps.div["a"]
+		return ps.div()["a"]
 
 	@ps.component
 	def PageB():

--- a/packages/pulse/python/tests/test_app_message_order.py
+++ b/packages/pulse/python/tests/test_app_message_order.py
@@ -112,12 +112,14 @@ async def test_replies_resolve_while_command_middleware_is_parked():
 		app,
 		"socket-1",
 		{
-			"type": "api_result",
+			"type": "reply",
 			"id": "corr-1",
-			"ok": True,
-			"status": 200,
-			"headers": {},
-			"body": {"n": 1},
+			"payload": {
+				"ok": True,
+				"status": 200,
+				"headers": {},
+				"body": {"n": 1},
+			},
 		},
 	)
 	assert api_fut.done()
@@ -127,7 +129,7 @@ async def test_replies_resolve_while_command_middleware_is_parked():
 	await _send(
 		app,
 		"socket-1",
-		{"type": "js_result", "id": "js-1", "result": 42, "error": None},
+		{"type": "reply", "id": "js-1", "payload": 42},
 	)
 	assert js_fut.done()
 	assert js_fut.result() == 42
@@ -135,13 +137,7 @@ async def test_replies_resolve_while_command_middleware_is_parked():
 	await _send(
 		app,
 		"socket-1",
-		{
-			"type": "channel_message",
-			"channel": "ch-1",
-			"event": None,
-			"responseTo": "req-1",
-			"payload": "pong",
-		},
+		{"type": "reply", "id": "req-1", "payload": "pong"},
 	)
 	assert channel_fut.done()
 	assert channel_fut.result() == "pong"
@@ -252,12 +248,14 @@ async def test_parked_command_does_not_block_other_path_or_reply():
 		app,
 		"socket-1",
 		{
-			"type": "api_result",
+			"type": "reply",
 			"id": "corr-b",
-			"ok": True,
-			"status": 200,
-			"headers": {},
-			"body": None,
+			"payload": {
+				"ok": True,
+				"status": 200,
+				"headers": {},
+				"body": None,
+			},
 		},
 	)
 

--- a/packages/pulse/python/tests/test_app_message_order.py
+++ b/packages/pulse/python/tests/test_app_message_order.py
@@ -151,7 +151,7 @@ async def test_replies_resolve_while_command_middleware_is_parked():
 
 
 @pytest.mark.asyncio
-async def test_same_path_attach_then_callback_apply_in_order():
+async def test_awaited_attach_then_callback_sees_mount():
 	seen: list[str] = []
 
 	@ps.component

--- a/packages/pulse/python/tests/test_app_message_order.py
+++ b/packages/pulse/python/tests/test_app_message_order.py
@@ -36,19 +36,21 @@ def _bind_render(
 	app._socket_to_render[socket_sid] = render.id  # pyright: ignore[reportPrivateUsage]
 
 
-async def _send(app: ps.App, socket_sid: str, message: dict[str, object]) -> None:
-	"""Live ingress: replies resolve inline, commands detach."""
-	await app._handle_socket_message(  # pyright: ignore[reportPrivateUsage]
-		socket_sid, serialize(message)
+def _spawn(
+	app: ps.App, socket_sid: str, message: dict[str, object]
+) -> asyncio.Task[None]:
+	"""Live EVENT: Socket.IO async_handlers=True runs the handler as a task."""
+	return asyncio.create_task(
+		app._handle_socket_message(  # pyright: ignore[reportPrivateUsage]
+			socket_sid, serialize(message)
+		)
 	)
 
 
-async def _send_serial(
-	app: ps.App, socket_sid: str, message: dict[str, object]
-) -> None:
-	"""Await the command (connect-drain path) so mutation has finished."""
-	await app._deliver_socket_message(  # pyright: ignore[reportPrivateUsage]
-		socket_sid, serialize(message), detach=False
+async def _send(app: ps.App, socket_sid: str, message: dict[str, object]) -> None:
+	"""Await the handler (connect-drain / reply / finished command)."""
+	await app._handle_socket_message(  # pyright: ignore[reportPrivateUsage]
+		socket_sid, serialize(message)
 	)
 
 
@@ -95,8 +97,7 @@ async def test_replies_resolve_while_command_middleware_is_parked():
 	channel_fut: asyncio.Future[object] = asyncio.get_running_loop().create_future()
 	render.replies.register("req-1", channel_fut, cancel_key="ch-1")
 
-	# Live handler returns immediately; attach middleware is a detached task.
-	await _send(
+	parked = _spawn(
 		app,
 		"socket-1",
 		{"type": "attach", "path": "/", "routeInfo": _route_info("/")},
@@ -146,7 +147,7 @@ async def test_replies_resolve_while_command_middleware_is_parked():
 	assert channel_fut.result() == "pong"
 
 	middleware.release.set()
-	await asyncio.sleep(0)
+	await parked
 	render.close()
 
 
@@ -175,14 +176,14 @@ async def test_awaited_attach_then_callback_sees_mount():
 	callback_key = next(iter(render.route_mounts["/"].tree.callbacks))
 
 	# Awaited commands (connect-drain). Mutation is sync, so callback
-	# sees the mount. Live ingress does not serialize commands — a parked
-	# attach must not block a later callback or reply.
-	await _send_serial(
+	# sees the mount. Live EVENTs are Socket.IO tasks — a parked attach
+	# must not block a later callback or reply.
+	await _send(
 		app,
 		"socket-1",
 		{"type": "attach", "path": "/", "routeInfo": _route_info("/")},
 	)
-	await _send_serial(
+	await _send(
 		app,
 		"socket-1",
 		{"type": "callback", "path": "/", "callback": callback_key, "args": []},
@@ -227,7 +228,7 @@ async def test_parked_command_does_not_block_other_path_or_reply():
 	api_fut: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
 	render.replies.register("corr-b", api_fut)
 
-	await _send(
+	parked = _spawn(
 		app,
 		"socket-1",
 		{"type": "attach", "path": "/a", "routeInfo": _route_info("/a")},
@@ -265,14 +266,15 @@ async def test_parked_command_does_not_block_other_path_or_reply():
 	assert not middleware.release.is_set()
 
 	middleware.release.set()
-	assert await wait_for(lambda: render.route_mounts["/a"].state == "active")
+	await parked
+	assert render.route_mounts["/a"].state == "active"
 	render.close()
 
 
-def test_socketio_handlers_are_ordered():
+def test_socketio_async_handlers():
 	app = ps.App()
 
-	assert app.sio.async_handlers is False
+	assert app.sio.async_handlers is True
 
 
 @pytest.mark.asyncio

--- a/packages/pulse/python/tests/test_app_message_order.py
+++ b/packages/pulse/python/tests/test_app_message_order.py
@@ -47,14 +47,12 @@ class GatingMessageMiddleware(PulseMiddleware):
 	started: asyncio.Event
 	release: asyncio.Event
 	gate_paths: set[str] | None
-	seen: list[str]
 
 	def __init__(self, gate_paths: set[str] | None = None) -> None:
 		super().__init__()
 		self.started = asyncio.Event()
 		self.release = asyncio.Event()
 		self.gate_paths = gate_paths
-		self.seen = []
 
 	@override
 	async def message(
@@ -68,7 +66,6 @@ class GatingMessageMiddleware(PulseMiddleware):
 		if self.gate_paths is None or path in self.gate_paths:
 			self.started.set()
 			await self.release.wait()
-		self.seen.append(f"{data['type']}:{path}")
 		return await next()
 
 

--- a/packages/pulse/python/tests/test_app_message_order.py
+++ b/packages/pulse/python/tests/test_app_message_order.py
@@ -71,7 +71,7 @@ class GatingMessageMiddleware(PulseMiddleware):
 		*,
 		data: ClientMessage,
 		session: dict[str, Any],
-		next: Callable[[], Awaitable[Ok[None]]],
+		next: Callable[[], Awaitable[Ok[None] | Deny]],
 	) -> Ok[None] | Deny:
 		path = str(data.get("path", ""))
 		if self.gate_paths is None or path in self.gate_paths:

--- a/packages/pulse/python/tests/test_app_message_order.py
+++ b/packages/pulse/python/tests/test_app_message_order.py
@@ -1,89 +1,267 @@
 import asyncio
+from collections.abc import Awaitable, Callable
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast, override
 
 import pulse as ps
 import pytest
-from pulse.messages import ClientPulseMessage
+from pulse.messages import ClientMessage, ClientPulseMessage
+from pulse.middleware import Deny, Ok, PulseMiddleware
 from pulse.render_session import RenderSession
 from pulse.serializer import serialize
 from pulse.user_session import UserSession
 
 
-@pytest.mark.asyncio
-async def test_socket_messages_for_render_are_serialized(
-	monkeypatch: pytest.MonkeyPatch,
-):
-	app = ps.App()
-	render = RenderSession("render-1", app.routes)
-	session = SimpleNamespace(sid="session-1", data={})
+def _route_info(path: str) -> dict[str, object]:
+	return {
+		"pathname": path,
+		"hash": "",
+		"query": "",
+		"queryParams": {},
+		"pathParams": {},
+		"catchall": [],
+	}
+
+
+def _bind_render(
+	app: ps.App,
+	render: RenderSession,
+	session: SimpleNamespace,
+	socket_sid: str = "socket-1",
+) -> None:
 	app.render_sessions[render.id] = render
 	app._render_to_user[render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
 	app.user_sessions[session.sid] = cast(UserSession, cast(object, session))
-	app._socket_to_render["socket-1"] = render.id  # pyright: ignore[reportPrivateUsage]
+	app._socket_to_render[socket_sid] = render.id  # pyright: ignore[reportPrivateUsage]
 
-	started_attach = asyncio.Event()
-	release_attach = asyncio.Event()
-	events: list[str] = []
 
-	async def handle_pulse_message(
-		_render: RenderSession, _session: UserSession, msg: ClientPulseMessage
-	) -> None:
-		events.append(f"start:{msg['type']}")
-		if msg["type"] == "attach":
-			started_attach.set()
-			await release_attach.wait()
-		events.append(f"end:{msg['type']}")
+async def _send(
+	app: ps.App, socket_sid: str, message: dict[str, object]
+) -> None:
+	await app._handle_socket_message(  # pyright: ignore[reportPrivateUsage]
+		socket_sid, serialize(message)
+	)
 
-	monkeypatch.setattr(app, "_handle_pulse_message", handle_pulse_message)
 
-	attach_task = asyncio.create_task(
-		app._handle_socket_message(  # pyright: ignore[reportPrivateUsage]
+class GatingMessageMiddleware(PulseMiddleware):
+	"""Decide that parks selected pulse messages until `release` is set."""
+
+	started: asyncio.Event
+	release: asyncio.Event
+	gate_paths: set[str] | None
+	seen: list[str]
+
+	def __init__(self, gate_paths: set[str] | None = None) -> None:
+		super().__init__()
+		self.started = asyncio.Event()
+		self.release = asyncio.Event()
+		self.gate_paths = gate_paths
+		self.seen = []
+
+	@override
+	async def message(
+		self,
+		*,
+		data: ClientMessage,
+		session: dict[str, Any],
+		next: Callable[[], Awaitable[Ok[None]]],
+	) -> Ok[None] | Deny:
+		path = str(data.get("path", ""))
+		if self.gate_paths is None or path in self.gate_paths:
+			self.started.set()
+			await self.release.wait()
+		self.seen.append(f"{data['type']}:{path}")
+		return await next()
+
+
+@pytest.mark.asyncio
+async def test_completion_applies_while_other_message_is_in_decide():
+	middleware = GatingMessageMiddleware()
+	app = ps.App(middleware=middleware)
+	render = RenderSession("render-1", app.routes)
+	session = SimpleNamespace(sid="session-1", data={})
+	_bind_render(app, render, session)
+
+	api_fut: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
+	render._pending_api["corr-1"] = api_fut  # pyright: ignore[reportPrivateUsage]
+	js_fut: asyncio.Future[object] = asyncio.get_running_loop().create_future()
+	render._pending_js_results["js-1"] = js_fut  # pyright: ignore[reportPrivateUsage]
+	channel_fut: asyncio.Future[object] = asyncio.get_running_loop().create_future()
+	render.channels.register_pending("req-1", channel_fut, "ch-1")
+
+	gated = asyncio.create_task(
+		_send(
+			app,
 			"socket-1",
-			serialize(
-				{
-					"type": "attach",
-					"path": "/",
-					"routeInfo": {
-						"pathname": "/",
-						"hash": "",
-						"query": "",
-						"queryParams": {},
-						"pathParams": {},
-						"catchall": [],
-					},
-				}
-			),
+			{"type": "attach", "path": "/", "routeInfo": _route_info("/")},
 		)
 	)
-	await started_attach.wait()
+	await middleware.started.wait()
+	assert not api_fut.done()
+	assert not js_fut.done()
+	assert not channel_fut.done()
 
-	callback_task = asyncio.create_task(
-		app._handle_socket_message(  # pyright: ignore[reportPrivateUsage]
+	await _send(
+		app,
+		"socket-1",
+		{
+			"type": "api_result",
+			"id": "corr-1",
+			"ok": True,
+			"status": 200,
+			"headers": {},
+			"body": {"n": 1},
+		},
+	)
+	assert api_fut.done()
+	assert api_fut.result()["body"] == {"n": 1}
+	assert not middleware.release.is_set()
+
+	await _send(
+		app,
+		"socket-1",
+		{"type": "js_result", "id": "js-1", "result": 42, "error": None},
+	)
+	assert js_fut.done()
+	assert js_fut.result() == 42
+
+	await _send(
+		app,
+		"socket-1",
+		{
+			"type": "channel_message",
+			"channel": "ch-1",
+			"event": None,
+			"responseTo": "req-1",
+			"payload": "pong",
+		},
+	)
+	assert channel_fut.done()
+	assert channel_fut.result() == "pong"
+
+	middleware.release.set()
+	await gated
+	render.close()
+
+
+@pytest.mark.asyncio
+async def test_same_path_attach_then_callback_apply_in_order():
+	seen: list[str] = []
+
+	@ps.component
+	def Home():
+		def on_click():
+			ctx = ps.PulseContext.get()
+			assert ctx.render is not None
+			seen.append(ctx.render.route_mounts["/"].state)
+
+		return ps.button(onClick=on_click)["inc"]
+
+	app = ps.App(routes=[ps.Route("/", Home)])
+	render = RenderSession("render-1", app.routes)
+	session = SimpleNamespace(sid="session-1", data={})
+	_bind_render(app, render, session)
+	render.connect(lambda _message: None)
+
+	with ps.PulseContext.update(render=render):
+		render.prerender(["/"])
+	assert render.route_mounts["/"].state == "pending"
+	callback_key = next(iter(render.route_mounts["/"].tree.callbacks))
+
+	# Sequential inbound messages, no yield between Apply of attach and callback.
+	# Same-path Apply is sync, so the callback lookup sees the mount.
+	await _send(
+		app,
+		"socket-1",
+		{"type": "attach", "path": "/", "routeInfo": _route_info("/")},
+	)
+	await _send(
+		app,
+		"socket-1",
+		{"type": "callback", "path": "/", "callback": callback_key, "args": []},
+	)
+
+	assert render.route_mounts["/"].state == "active"
+	assert seen == ["active"]
+	render.close()
+
+
+@pytest.mark.asyncio
+async def test_decide_on_one_path_does_not_serialize_other_path_or_completion():
+	middleware = GatingMessageMiddleware(gate_paths={"/a"})
+	clicked: list[str] = []
+
+	@ps.component
+	def PageA():
+		return ps.div["a"]
+
+	@ps.component
+	def PageB():
+		def on_click():
+			ctx = ps.PulseContext.get()
+			assert ctx.render is not None
+			clicked.append(ctx.render.route_mounts["/b"].state)
+
+		return ps.button(onClick=on_click)["b"]
+
+	app = ps.App(
+		routes=[ps.Route("/a", PageA), ps.Route("/b", PageB)],
+		middleware=middleware,
+	)
+	render = RenderSession("render-1", app.routes)
+	session = SimpleNamespace(sid="session-1", data={})
+	_bind_render(app, render, session)
+	render.connect(lambda _message: None)
+
+	with ps.PulseContext.update(render=render):
+		render.prerender(["/a", "/b"])
+	callback_key = next(iter(render.route_mounts["/b"].tree.callbacks))
+
+	api_fut: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
+	render._pending_api["corr-b"] = api_fut  # pyright: ignore[reportPrivateUsage]
+
+	gated = asyncio.create_task(
+		_send(
+			app,
 			"socket-1",
-			serialize(
-				{
-					"type": "callback",
-					"path": "/",
-					"callback": "1.onClick",
-					"args": [],
-				}
-			),
+			{"type": "attach", "path": "/a", "routeInfo": _route_info("/a")},
 		)
 	)
-	await asyncio.sleep(0)
-	assert events == ["start:attach"]
+	await middleware.started.wait()
+	assert render.route_mounts["/a"].state == "pending"
 
-	release_attach.set()
-	await asyncio.gather(attach_task, callback_task)
+	await _send(
+		app,
+		"socket-1",
+		{"type": "attach", "path": "/b", "routeInfo": _route_info("/b")},
+	)
+	await _send(
+		app,
+		"socket-1",
+		{"type": "callback", "path": "/b", "callback": callback_key, "args": []},
+	)
+	await _send(
+		app,
+		"socket-1",
+		{
+			"type": "api_result",
+			"id": "corr-b",
+			"ok": True,
+			"status": 200,
+			"headers": {},
+			"body": None,
+		},
+	)
 
-	assert events == [
-		"start:attach",
-		"end:attach",
-		"start:callback",
-		"end:callback",
-	]
+	assert render.route_mounts["/b"].state == "active"
+	assert clicked == ["active"]
+	assert api_fut.done()
+	assert render.route_mounts["/a"].state == "pending"
+	assert not middleware.release.is_set()
 
+	middleware.release.set()
+	await gated
+	assert render.route_mounts["/a"].state == "active"
 	render.close()
 
 

--- a/packages/pulse/python/tests/test_app_message_order.py
+++ b/packages/pulse/python/tests/test_app_message_order.py
@@ -89,11 +89,11 @@ async def test_replies_resolve_while_command_middleware_is_parked():
 	_bind_render(app, render, session)
 
 	api_fut: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
-	render._pending_api["corr-1"] = api_fut  # pyright: ignore[reportPrivateUsage]
+	render.replies.register("corr-1", api_fut)
 	js_fut: asyncio.Future[object] = asyncio.get_running_loop().create_future()
-	render._pending_js_results["js-1"] = js_fut  # pyright: ignore[reportPrivateUsage]
+	render.replies.register("js-1", js_fut)
 	channel_fut: asyncio.Future[object] = asyncio.get_running_loop().create_future()
-	render.channels.register_pending("req-1", channel_fut, "ch-1")
+	render.replies.register("req-1", channel_fut, cancel_key="ch-1")
 
 	# Live handler returns immediately; attach middleware is a detached task.
 	await _send(
@@ -225,7 +225,7 @@ async def test_parked_command_does_not_block_other_path_or_reply():
 	callback_key = next(iter(render.route_mounts["/b"].tree.callbacks))
 
 	api_fut: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
-	render._pending_api["corr-b"] = api_fut  # pyright: ignore[reportPrivateUsage]
+	render.replies.register("corr-b", api_fut)
 
 	await _send(
 		app,

--- a/packages/pulse/python/tests/test_app_message_order.py
+++ b/packages/pulse/python/tests/test_app_message_order.py
@@ -9,6 +9,7 @@ from pulse.messages import ClientMessage, ClientPulseMessage
 from pulse.middleware import Deny, Ok, PulseMiddleware
 from pulse.render_session import RenderSession
 from pulse.serializer import serialize
+from pulse.test_helpers import wait_for
 from pulse.user_session import UserSession
 
 
@@ -36,7 +37,17 @@ def _bind_render(
 
 
 async def _send(app: ps.App, socket_sid: str, message: dict[str, object]) -> None:
+	"""Live ingress: replies resolve inline, commands detach."""
 	await app._handle_socket_message(  # pyright: ignore[reportPrivateUsage]
+		socket_sid, serialize(message)
+	)
+
+
+async def _send_serial(
+	app: ps.App, socket_sid: str, message: dict[str, object]
+) -> None:
+	"""Drain-style: await the command so Apply has finished."""
+	await app._process_socket_message(  # pyright: ignore[reportPrivateUsage]
 		socket_sid, serialize(message)
 	)
 
@@ -84,14 +95,14 @@ async def test_completion_applies_while_other_message_is_in_decide():
 	channel_fut: asyncio.Future[object] = asyncio.get_running_loop().create_future()
 	render.channels.register_pending("req-1", channel_fut, "ch-1")
 
-	gated = asyncio.create_task(
-		_send(
-			app,
-			"socket-1",
-			{"type": "attach", "path": "/", "routeInfo": _route_info("/")},
-		)
+	# Live handler returns immediately; attach Decide is a detached task.
+	await _send(
+		app,
+		"socket-1",
+		{"type": "attach", "path": "/", "routeInfo": _route_info("/")},
 	)
 	await middleware.started.wait()
+	assert not middleware.release.is_set()
 	assert not api_fut.done()
 	assert not js_fut.done()
 	assert not channel_fut.done()
@@ -135,7 +146,7 @@ async def test_completion_applies_while_other_message_is_in_decide():
 	assert channel_fut.result() == "pong"
 
 	middleware.release.set()
-	await gated
+	await asyncio.sleep(0)
 	render.close()
 
 
@@ -163,14 +174,15 @@ async def test_same_path_attach_then_callback_apply_in_order():
 	assert render.route_mounts["/"].state == "pending"
 	callback_key = next(iter(render.route_mounts["/"].tree.callbacks))
 
-	# Sequential inbound messages, no yield between Apply of attach and callback.
-	# Same-path Apply is sync, so the callback lookup sees the mount.
-	await _send(
+	# Sequential Decides (connect-drain path). Apply is sync, so the
+	# callback lookup sees the mount. Live ingress does not promise this
+	# once middleware parks — callback Decide must not wait for attach Decide.
+	await _send_serial(
 		app,
 		"socket-1",
 		{"type": "attach", "path": "/", "routeInfo": _route_info("/")},
 	)
-	await _send(
+	await _send_serial(
 		app,
 		"socket-1",
 		{"type": "callback", "path": "/", "callback": callback_key, "args": []},
@@ -215,12 +227,10 @@ async def test_decide_on_one_path_does_not_serialize_other_path_or_completion():
 	api_fut: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
 	render._pending_api["corr-b"] = api_fut  # pyright: ignore[reportPrivateUsage]
 
-	gated = asyncio.create_task(
-		_send(
-			app,
-			"socket-1",
-			{"type": "attach", "path": "/a", "routeInfo": _route_info("/a")},
-		)
+	await _send(
+		app,
+		"socket-1",
+		{"type": "attach", "path": "/a", "routeInfo": _route_info("/a")},
 	)
 	await middleware.started.wait()
 	assert render.route_mounts["/a"].state == "pending"
@@ -230,11 +240,13 @@ async def test_decide_on_one_path_does_not_serialize_other_path_or_completion():
 		"socket-1",
 		{"type": "attach", "path": "/b", "routeInfo": _route_info("/b")},
 	)
+	assert await wait_for(lambda: render.route_mounts["/b"].state == "active")
 	await _send(
 		app,
 		"socket-1",
 		{"type": "callback", "path": "/b", "callback": callback_key, "args": []},
 	)
+	assert await wait_for(lambda: clicked == ["active"])
 	await _send(
 		app,
 		"socket-1",
@@ -248,15 +260,12 @@ async def test_decide_on_one_path_does_not_serialize_other_path_or_completion():
 		},
 	)
 
-	assert render.route_mounts["/b"].state == "active"
-	assert clicked == ["active"]
 	assert api_fut.done()
 	assert render.route_mounts["/a"].state == "pending"
 	assert not middleware.release.is_set()
 
 	middleware.release.set()
-	await gated
-	assert render.route_mounts["/a"].state == "active"
+	assert await wait_for(lambda: render.route_mounts["/a"].state == "active")
 	render.close()
 
 

--- a/packages/pulse/python/tests/test_app_message_order.py
+++ b/packages/pulse/python/tests/test_app_message_order.py
@@ -47,8 +47,8 @@ async def _send_serial(
 	app: ps.App, socket_sid: str, message: dict[str, object]
 ) -> None:
 	"""Await the command (connect-drain path) so mutation has finished."""
-	await app._process_socket_message(  # pyright: ignore[reportPrivateUsage]
-		socket_sid, serialize(message)
+	await app._deliver_socket_message(  # pyright: ignore[reportPrivateUsage]
+		socket_sid, serialize(message), detach=False
 	)
 
 
@@ -293,7 +293,7 @@ async def test_attach_sends_ack_after_route_is_attached(
 	monkeypatch.setattr(render, "attach", attach)
 	monkeypatch.setattr(render, "send", send)
 
-	await app._handle_pulse_message(  # pyright: ignore[reportPrivateUsage]
+	await app._handle_pulse_command(  # pyright: ignore[reportPrivateUsage]
 		render,
 		cast(UserSession, cast(object, session)),
 		{
@@ -332,7 +332,7 @@ async def test_attach_does_not_ack_when_route_needs_reload(
 	monkeypatch.setattr(render, "attach", attach)
 	monkeypatch.setattr(render, "send", send)
 
-	await app._handle_pulse_message(  # pyright: ignore[reportPrivateUsage]
+	await app._handle_pulse_command(  # pyright: ignore[reportPrivateUsage]
 		render,
 		cast(UserSession, cast(object, session)),
 		{
@@ -360,12 +360,12 @@ async def test_socket_messages_wait_for_connect_to_finish(
 	app = ps.App()
 	events: list[str] = []
 
-	async def handle_pulse_message(
+	async def handle_pulse_command(
 		_render: RenderSession, _session: UserSession, msg: ClientPulseMessage
 	) -> None:
 		events.append(msg["type"])
 
-	monkeypatch.setattr(app, "_handle_pulse_message", handle_pulse_message)
+	monkeypatch.setattr(app, "_handle_pulse_command", handle_pulse_command)
 
 	app._connecting_sockets.add("socket-1")  # pyright: ignore[reportPrivateUsage]
 

--- a/packages/pulse/python/tests/test_app_message_order.py
+++ b/packages/pulse/python/tests/test_app_message_order.py
@@ -46,14 +46,14 @@ async def _send(app: ps.App, socket_sid: str, message: dict[str, object]) -> Non
 async def _send_serial(
 	app: ps.App, socket_sid: str, message: dict[str, object]
 ) -> None:
-	"""Drain-style: await the command so Apply has finished."""
+	"""Await the command (connect-drain path) so mutation has finished."""
 	await app._process_socket_message(  # pyright: ignore[reportPrivateUsage]
 		socket_sid, serialize(message)
 	)
 
 
 class GatingMessageMiddleware(PulseMiddleware):
-	"""Decide that parks selected pulse messages until `release` is set."""
+	"""Parks selected pulse commands until `release` is set."""
 
 	started: asyncio.Event
 	release: asyncio.Event
@@ -81,7 +81,7 @@ class GatingMessageMiddleware(PulseMiddleware):
 
 
 @pytest.mark.asyncio
-async def test_completion_applies_while_other_message_is_in_decide():
+async def test_replies_resolve_while_command_middleware_is_parked():
 	middleware = GatingMessageMiddleware()
 	app = ps.App(middleware=middleware)
 	render = RenderSession("render-1", app.routes)
@@ -95,7 +95,7 @@ async def test_completion_applies_while_other_message_is_in_decide():
 	channel_fut: asyncio.Future[object] = asyncio.get_running_loop().create_future()
 	render.channels.register_pending("req-1", channel_fut, "ch-1")
 
-	# Live handler returns immediately; attach Decide is a detached task.
+	# Live handler returns immediately; attach middleware is a detached task.
 	await _send(
 		app,
 		"socket-1",
@@ -174,9 +174,9 @@ async def test_same_path_attach_then_callback_apply_in_order():
 	assert render.route_mounts["/"].state == "pending"
 	callback_key = next(iter(render.route_mounts["/"].tree.callbacks))
 
-	# Sequential Decides (connect-drain path). Apply is sync, so the
-	# callback lookup sees the mount. Live ingress does not promise this
-	# once middleware parks — callback Decide must not wait for attach Decide.
+	# Awaited commands (connect-drain). Mutation is sync, so callback
+	# sees the mount. Live ingress does not serialize commands — a parked
+	# attach must not block a later callback or reply.
 	await _send_serial(
 		app,
 		"socket-1",
@@ -194,7 +194,7 @@ async def test_same_path_attach_then_callback_apply_in_order():
 
 
 @pytest.mark.asyncio
-async def test_decide_on_one_path_does_not_serialize_other_path_or_completion():
+async def test_parked_command_does_not_block_other_path_or_reply():
 	middleware = GatingMessageMiddleware(gate_paths={"/a"})
 	clicked: list[str] = []
 

--- a/packages/pulse/python/tests/test_channels.py
+++ b/packages/pulse/python/tests/test_channels.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 import pulse as ps
 import pytest
 from pulse.channel import ChannelClosed
-from pulse.messages import ClientChannelResponseMessage
+from pulse.messages import ReplyMessage
 from pulse.user_session import UserSession
 
 
@@ -76,18 +76,10 @@ async def test_channel_request_resolves_on_response():
 	request_id = request_message.get("requestId")
 	assert request_id
 
-	real_render.channels.handle_client_response(
-		message=cast(
-			ClientChannelResponseMessage,
-			cast(
-				object,
-				{
-					"type": "channel_message",
-					"channel": "req-channel",
-					"responseTo": request_id,
-					"payload": {"x": 2},
-				},
-			),
+	real_render.replies.apply(
+		cast(
+			ReplyMessage,
+			{"type": "reply", "id": request_id, "payload": {"x": 2}},
 		)
 	)
 

--- a/packages/pulse/python/tests/test_channels.py
+++ b/packages/pulse/python/tests/test_channels.py
@@ -5,7 +5,6 @@ from typing import Any, cast
 import pulse as ps
 import pytest
 from pulse.channel import ChannelClosed
-from pulse.messages import ReplyMessage
 from pulse.user_session import UserSession
 
 
@@ -77,10 +76,7 @@ async def test_channel_request_resolves_on_response():
 	assert request_id
 
 	real_render.replies.apply(
-		cast(
-			ReplyMessage,
-			{"type": "reply", "id": request_id, "payload": {"x": 2}},
-		)
+		{"type": "reply", "id": str(request_id), "payload": {"x": 2}}
 	)
 
 	result = await pending

--- a/packages/pulse/python/tests/test_middleware.py
+++ b/packages/pulse/python/tests/test_middleware.py
@@ -140,7 +140,6 @@ async def test_inner_deny_reports_deny_error_to_client(
 	await app._deliver_socket_message(  # pyright: ignore[reportPrivateUsage]
 		"socket-1",
 		serialize({"type": "callback", "path": "/", "callback": "k", "args": []}),
-		detach=False,
 	)
 
 	assert len(reported) == 1

--- a/packages/pulse/python/tests/test_middleware.py
+++ b/packages/pulse/python/tests/test_middleware.py
@@ -1,0 +1,179 @@
+"""Decision semantics of MiddlewareStack.
+
+Coercion happens once, where each user hook returns: anything that is
+not Ok/Deny counts as allow. Decisions propagate through `next()` —
+an inner Deny reaches the caller unless an outer middleware overrides it.
+"""
+
+from types import SimpleNamespace
+from typing import Any, cast, override
+
+import pulse as ps
+import pytest
+from pulse.messages import ClientMessage
+from pulse.middleware import Deny, MiddlewareStack, Ok, PulseMiddleware
+from pulse.render_session import RenderSession
+from pulse.serializer import serialize
+from pulse.user_session import UserSession
+
+
+class Passthrough(PulseMiddleware):
+	pass
+
+
+class DenyMessage(PulseMiddleware):
+	@override
+	async def message(self, *, data: Any, session: Any, next: Any) -> Any:
+		return Deny()
+
+
+class ReturnGarbage(PulseMiddleware):
+	@override
+	async def message(self, *, data: Any, session: Any, next: Any) -> Any:
+		await next()
+		return "not a decision"
+
+
+class OverrideInnerDeny(PulseMiddleware):
+	@override
+	async def message(self, *, data: Any, session: Any, next: Any) -> Any:
+		await next()
+		return Ok(None)
+
+
+class DenyChannel(PulseMiddleware):
+	@override
+	async def channel(self, *, next: Any, **kwargs: Any) -> Any:
+		return Deny()
+
+
+_MSG = cast(
+	ClientMessage,
+	cast(object, {"type": "callback", "path": "/", "callback": "k", "args": []}),
+)
+
+
+def _terminal(applied: list[str]):
+	async def next() -> Ok[None]:
+		applied.append("apply")
+		return Ok()
+
+	return next
+
+
+@pytest.mark.asyncio
+async def test_non_decision_return_is_allow():
+	applied: list[str] = []
+	stack = MiddlewareStack([ReturnGarbage()])
+
+	res = await stack.message(data=_MSG, session={}, next=_terminal(applied))
+
+	assert isinstance(res, Ok)
+	assert applied == ["apply"]
+
+
+@pytest.mark.asyncio
+async def test_inner_deny_propagates_through_outer_middleware():
+	applied: list[str] = []
+	stack = MiddlewareStack([Passthrough(), DenyMessage()])
+
+	res = await stack.message(data=_MSG, session={}, next=_terminal(applied))
+
+	assert isinstance(res, Deny)
+	assert applied == []
+
+
+@pytest.mark.asyncio
+async def test_outer_middleware_can_override_inner_deny():
+	applied: list[str] = []
+	stack = MiddlewareStack([OverrideInnerDeny(), DenyMessage()])
+
+	res = await stack.message(data=_MSG, session={}, next=_terminal(applied))
+
+	assert isinstance(res, Ok)
+	assert applied == []
+
+
+@pytest.mark.asyncio
+async def test_channel_inner_deny_propagates():
+	applied: list[str] = []
+	stack = MiddlewareStack([Passthrough(), DenyChannel()])
+
+	async def terminal() -> Ok[None]:
+		applied.append("apply")
+		return Ok()
+
+	res = await stack.channel(
+		channel_id="ch-1",
+		event="ping",
+		payload=None,
+		request_id=None,
+		session={},
+		next=terminal,
+	)
+
+	assert isinstance(res, Deny)
+	assert applied == []
+
+
+@pytest.mark.asyncio
+async def test_inner_deny_reports_deny_error_to_client(
+	monkeypatch: pytest.MonkeyPatch,
+):
+	# Regression: the stack used to mask a non-outermost Deny into Ok, so
+	# the command was dropped without the client ever seeing a deny error.
+	app = ps.App(middleware=[Passthrough(), DenyMessage()])
+	render = RenderSession("render-1", app.routes)
+	session = SimpleNamespace(sid="session-1", data={})
+	app.render_sessions[render.id] = render
+	app._render_to_user[render.id] = session.sid  # pyright: ignore[reportPrivateUsage]
+	app.user_sessions[session.sid] = cast(UserSession, cast(object, session))
+	app._socket_to_render["socket-1"] = render.id  # pyright: ignore[reportPrivateUsage]
+
+	reported: list[tuple[Any, ...]] = []
+
+	def report_error(*args: Any) -> None:
+		reported.append(args)
+
+	monkeypatch.setattr(render, "report_error", report_error)
+
+	await app._deliver_socket_message(  # pyright: ignore[reportPrivateUsage]
+		"socket-1",
+		serialize({"type": "callback", "path": "/", "callback": "k", "args": []}),
+		detach=False,
+	)
+
+	assert len(reported) == 1
+	path, phase, _exc, details = reported[0]
+	assert (path, phase, details) == ("/", "server", {"kind": "deny"})
+	render.close()
+
+
+@pytest.mark.asyncio
+async def test_allow_still_applies_command():
+	applied: list[str] = []
+	stack = MiddlewareStack([Passthrough(), Passthrough()])
+
+	res = await stack.message(data=_MSG, session={}, next=_terminal(applied))
+
+	assert isinstance(res, Ok)
+	assert applied == ["apply"]
+
+
+@pytest.mark.asyncio
+async def test_connect_non_decision_return_is_allow():
+	class GarbageConnect(PulseMiddleware):
+		@override
+		async def connect(self, *, request: Any, session: Any, next: Any) -> Any:
+			await next()
+			return None
+
+	stack = MiddlewareStack([GarbageConnect()])
+
+	async def terminal() -> Ok[None]:
+		return Ok()
+
+	res = await stack.connect(
+		request=cast(Any, SimpleNamespace()), session={}, next=terminal
+	)
+	assert isinstance(res, Ok)

--- a/packages/pulse/python/tests/test_render_session.py
+++ b/packages/pulse/python/tests/test_render_session.py
@@ -1232,13 +1232,16 @@ async def test_call_api_success_before_timeout():
 	api_id = cast(Any, api_msgs[0])["id"]
 
 	# Simulate client response
-	session.handle_api_result(
+	session.replies.apply(
 		{
+			"type": "reply",
 			"id": api_id,
-			"ok": True,
-			"status": 200,
-			"headers": {},
-			"body": {"success": True},
+			"payload": {
+				"ok": True,
+				"status": 200,
+				"headers": {},
+				"body": {"success": True},
+			},
 		}
 	)
 
@@ -1304,7 +1307,7 @@ async def test_run_js_success_before_timeout():
 	exec_id = cast(Any, js_msgs[0])["id"]
 
 	# Simulate client response
-	session.handle_js_result({"id": exec_id, "result": 42, "error": None})
+	session.replies.apply({"type": "reply", "id": exec_id, "payload": 42})
 
 	# The future should resolve with the result
 	result = await future
@@ -1498,28 +1501,13 @@ async def test_session_close_cancels_cleanup_timers():
 	assert state_box[0].fired is False
 
 
-def test_handle_api_result_ignores_unknown_id():
-	"""Test that handle_api_result silently ignores unknown correlation IDs."""
+def test_apply_reply_ignores_unknown_id():
+	"""Unknown reply ids are no-ops."""
 	routes = RouteTree([Route("a", simple_component)])
 	session = RenderSession("test-id", routes)
 	session.connect(lambda _: None)
 
-	# Should not raise
-	session.handle_api_result(
-		{"id": "unknown-id", "ok": True, "status": 200, "headers": {}, "body": None}
-	)
-
-	session.close()
-
-
-def test_handle_js_result_ignores_unknown_id():
-	"""Test that handle_js_result silently ignores unknown exec IDs."""
-	routes = RouteTree([Route("a", simple_component)])
-	session = RenderSession("test-id", routes)
-	session.connect(lambda _: None)
-
-	# Should not raise
-	session.handle_js_result({"id": "unknown-id", "result": 42, "error": None})
+	session.replies.apply({"type": "reply", "id": "unknown-id", "payload": None})
 
 	session.close()
 

--- a/packages/pulse/python/tests/test_render_session.py
+++ b/packages/pulse/python/tests/test_render_session.py
@@ -1200,7 +1200,7 @@ async def test_call_api_timeout():
 		await session.call_api("/test", timeout=0.01)
 
 	# Verify the pending API was cleaned up
-	assert len(session._pending_api) == 0  # pyright: ignore[reportPrivateUsage]
+	assert len(session.replies) == 0
 
 	session.close()
 
@@ -1274,7 +1274,7 @@ async def test_run_js_timeout():
 		await future
 
 	# Verify the pending JS result was cleaned up
-	assert len(session._pending_js_results) == 0  # pyright: ignore[reportPrivateUsage]
+	assert len(session.replies) == 0
 
 	session.close()
 
@@ -1329,14 +1329,14 @@ async def test_session_close_cancels_pending_api():
 	# Create a pending API future manually (simulating an in-flight request)
 	loop = asyncio.get_running_loop()
 	fut: asyncio.Future[Any] = loop.create_future()
-	session._pending_api["test-id"] = fut  # pyright: ignore[reportPrivateUsage]
+	session.replies.register("test-id", fut)
 
 	# Close the session
 	session.close()
 
 	# The future should be cancelled
 	assert fut.cancelled()
-	assert len(session._pending_api) == 0  # pyright: ignore[reportPrivateUsage]
+	assert len(session.replies) == 0
 
 
 @pytest.mark.asyncio
@@ -1355,14 +1355,14 @@ async def test_session_close_cancels_pending_js():
 	# Create a pending JS future manually
 	loop = asyncio.get_running_loop()
 	fut: asyncio.Future[Any] = loop.create_future()
-	session._pending_js_results["test-id"] = fut  # pyright: ignore[reportPrivateUsage]
+	session.replies.register("test-id", fut)
 
 	# Close the session
 	session.close()
 
 	# The future should be cancelled
 	assert fut.cancelled()
-	assert len(session._pending_js_results) == 0  # pyright: ignore[reportPrivateUsage]
+	assert len(session.replies) == 0
 
 
 @pytest.mark.asyncio

--- a/packages/pulse/python/tests/test_replies.py
+++ b/packages/pulse/python/tests/test_replies.py
@@ -38,6 +38,30 @@ async def test_reject_sets_exception_and_pops():
 
 
 @pytest.mark.asyncio
+async def test_apply_reply_resolves_payload():
+	replies = PendingReplies()
+	fut = _future()
+	replies.register("r1", fut)
+
+	replies.apply({"type": "reply", "id": "r1", "payload": 7})
+
+	assert fut.result() == 7
+	assert len(replies) == 0
+
+
+@pytest.mark.asyncio
+async def test_apply_reply_rejects_on_error():
+	replies = PendingReplies()
+	fut = _future()
+	replies.register("r1", fut)
+
+	replies.apply({"type": "reply", "id": "r1", "error": "boom"})
+
+	with pytest.raises(RuntimeError, match="boom"):
+		fut.result()
+
+
+@pytest.mark.asyncio
 async def test_unknown_id_is_a_noop():
 	replies = PendingReplies()
 	replies.resolve("missing", 1)

--- a/packages/pulse/python/tests/test_replies.py
+++ b/packages/pulse/python/tests/test_replies.py
@@ -1,0 +1,111 @@
+"""Spec for the request/reply primitive behind call_api, run_js, and
+Channel.request: correlation id -> future, resolved synchronously."""
+
+import asyncio
+
+import pytest
+from pulse.replies import PendingReplies
+
+
+def _future() -> asyncio.Future[object]:
+	return asyncio.get_running_loop().create_future()
+
+
+@pytest.mark.asyncio
+async def test_resolve_sets_result_and_pops():
+	replies = PendingReplies()
+	fut = _future()
+	replies.register("r1", fut)
+
+	replies.resolve("r1", {"x": 1})
+
+	assert fut.result() == {"x": 1}
+	assert len(replies) == 0
+	assert "r1" not in replies
+
+
+@pytest.mark.asyncio
+async def test_reject_sets_exception_and_pops():
+	replies = PendingReplies()
+	fut = _future()
+	replies.register("r1", fut)
+
+	replies.reject("r1", RuntimeError("boom"))
+
+	with pytest.raises(RuntimeError, match="boom"):
+		fut.result()
+	assert len(replies) == 0
+
+
+@pytest.mark.asyncio
+async def test_unknown_id_is_a_noop():
+	replies = PendingReplies()
+	replies.resolve("missing", 1)
+	replies.reject("missing", RuntimeError("boom"))
+	replies.discard("missing")
+
+
+@pytest.mark.asyncio
+async def test_duplicate_register_fails():
+	replies = PendingReplies()
+	replies.register("r1", _future())
+	with pytest.raises(ValueError, match="Duplicate"):
+		replies.register("r1", _future())
+
+
+@pytest.mark.asyncio
+async def test_resolve_after_discard_is_a_noop():
+	# A late reply racing a timeout must lose silently.
+	replies = PendingReplies()
+	fut = _future()
+	replies.register("r1", fut)
+	replies.discard("r1")
+
+	replies.resolve("r1", 42)
+
+	assert not fut.done()
+
+
+@pytest.mark.asyncio
+async def test_resolve_on_already_done_future_is_a_noop():
+	replies = PendingReplies()
+	fut = _future()
+	replies.register("r1", fut)
+	fut.cancel()
+
+	replies.resolve("r1", 42)
+	assert fut.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_reject_where_only_hits_matching_cancel_key():
+	replies = PendingReplies()
+	ch_a1, ch_a2, ch_b, plain = _future(), _future(), _future(), _future()
+	replies.register("a1", ch_a1, cancel_key="ch-a")
+	replies.register("a2", ch_a2, cancel_key="ch-a")
+	replies.register("b1", ch_b, cancel_key="ch-b")
+	replies.register("p1", plain)
+
+	replies.reject_where("ch-a", RuntimeError("closed"))
+
+	with pytest.raises(RuntimeError):
+		ch_a1.result()
+	with pytest.raises(RuntimeError):
+		ch_a2.result()
+	assert not ch_b.done()
+	assert not plain.done()
+	assert len(replies) == 2
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_cancels_and_clears():
+	replies = PendingReplies()
+	f1, f2 = _future(), _future()
+	replies.register("r1", f1)
+	replies.register("r2", f2, cancel_key="ch")
+
+	replies.cancel_all()
+
+	assert f1.cancelled()
+	assert f2.cancelled()
+	assert len(replies) == 0

--- a/skills/pulse/references/errors.md
+++ b/skills/pulse/references/errors.md
@@ -32,7 +32,7 @@ except ChannelTimeout:
 ### JavaScript Execution Errors
 
 ```python
-from pulse import run_js, JsExecError
+from pulse import run_js
 
 @ps.javascript
 def risky_operation():
@@ -41,13 +41,13 @@ def risky_operation():
 async def handle_action():
     try:
         result = await run_js(risky_operation(), result=True)
-    except JsExecError as e:
+    except RuntimeError as e:
         print(f"JS error: {e}")
     except asyncio.TimeoutError:
         print("JS execution timed out")
 ```
 
-**JsExecError** - Raised when client-side JS throws an exception.
+A `{type: "reply", error}` packet rejects the pending future with `RuntimeError`.
 
 ### Transpiler Errors
 
@@ -263,7 +263,7 @@ When `run_js(..., result=True)` fails:
 async def action():
     try:
         result = await run_js(js_fn(), result=True, timeout=10.0)
-    except JsExecError as e:
+    except RuntimeError as e:
         # JS threw an error
         print(f"JS error: {e}")
     except asyncio.TimeoutError:

--- a/skills/pulse/references/js-interop.md
+++ b/skills/pulse/references/js-interop.md
@@ -453,7 +453,7 @@ def run_js(
 ### Error Handling
 
 ```python
-from pulse import run_js, JsExecError
+from pulse import run_js
 
 @javascript
 def risky_operation():
@@ -462,7 +462,7 @@ def risky_operation():
 async def handle_action():
     try:
         result = await run_js(risky_operation(), result=True)
-    except JsExecError as e:
+    except RuntimeError as e:
         print(f"JS error: {e}")
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Remove `App._render_message_locks`. Request handling stays async. Middleware stays onion/`next()`. The Socket.IO receive loop just does not sit on either.

## Inbound shape

Three steps, two wire classes. Mutation is sync (`def`, not `async def`).

1. **Arrive** — `_handle_socket_message`: queue while connect middleware runs, else deliver. `async_handlers=True` so each live EVENT is already a task. CONNECT is still awaited by python-socketio (correct: render is not mapped yet).
2. **Route** — `sid → rid → RenderSession` (+ owner `UserSession`). Drop on any missing hop.
3. **Dispatch** — `type == "reply"` completes a pending request (`PendingReplies.apply`); everything else is a command (`_run_command` → middleware + sync mutation). Connect drain awaits deliver so first-load attach→callback stays ordered.

Route + dispatch are one method — `_deliver_socket_message(sid, data)`.

No per-path queue. No render-wide lock. Sync mutation gives atomicity, not arrival FIFO.

## One request/reply primitive

`call_api`, `run_js`, and `Channel.request` share `RenderSession.replies`. Completions are one packet in both directions:

```ts
{ type: "reply", id: string, payload?: any, error?: any }
```

Deletes `api_result`, `js_result`, and `channel_message` + `responseTo`. Commands stay typed (`api_call`, `js_exec`, `channel_message` with an event) — they tell the client to do different work.

`PendingReplies.apply` resolves `payload` or rejects `error` as `RuntimeError`. Unknown/already-done ids are no-ops.

## Middleware decisions: normalize once, propagate Deny

`MiddlewareStack` coerces each hook return (anything that is not `Ok`/`Deny` is allow). `next()` in `message`/`channel` returns the downstream decision. A `Deny` from any middleware reaches the client as `{"kind": "deny"}`.

## Tests

Deleted `test_socket_messages_for_render_are_serialized` — it encoded “message N+1 waits for message N.”

- `test_replies.py` — register/resolve/reject/`apply`
- `test_middleware.py` — decision semantics
- `test_app_message_order.py` — replies resolve while command middleware is parked; connect-drain order; parked `/a` doesn't block `/b`; `async_handlers is True`

Out of scope: channel `next()` rewrite (#139), making attach/detach async.

Docs: `ReplyMessage` in pulse-client types; glossary; JS error docs now use `RuntimeError` (`JsExecError` removed).

`make all` green (2033 pytest, 120 bun).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ad4e897-d82b-4072-9687-dd2492a00daf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ad4e897-d82b-4072-9687-dd2492a00daf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

