### PR TITLE
Add PulseMiddleware.api hook for user-defined FastAPI routes

### DIFF
--- a/docs/content/docs/(core)/advanced/middleware.mdx
+++ b/docs/content/docs/(core)/advanced/middleware.mdx
@@ -114,7 +114,7 @@ async def prerender_route(self, *, path, route_info, request, session, next):
 
 Called for HTTP requests to FastAPI routes you registered on `app.fastapi` (including routers you include). This is the hook you want for API auth, logging, or error reporting.
 
-It does **not** run for Pulse's own endpoints (`/_pulse/prerender`, health, forms), generated OpenAPI/docs routes, plugin routes added in `on_setup`, or the React proxy. That's the point: wrapping FastAPI with HTTP middleware catches prerender too, so the same exception can get reported twice.
+It does **not** run for Pulse's own endpoints (`/_pulse/prerender`, health, forms), generated OpenAPI/docs routes, or the React proxy. That's the point: wrapping FastAPI with HTTP middleware catches prerender too, so the same exception can get reported twice.
 
 ```python
 from fastapi.responses import JSONResponse

--- a/docs/content/docs/(core)/advanced/middleware.mdx
+++ b/docs/content/docs/(core)/advanced/middleware.mdx
@@ -85,7 +85,7 @@ The key pattern is calling `await next()` to pass control to the next middleware
 
 ## Middleware hooks
 
-Middleware can intercept five different points in the request lifecycle. You only need to override the ones you care about.
+Middleware can intercept six different points in the request lifecycle. You only need to override the ones you care about.
 
 ### `prerender`
 
@@ -109,6 +109,29 @@ async def prerender_route(self, *, path, route_info, request, session, next):
         return ps.Redirect("/login")
     return await next()
 ```
+
+### `api`
+
+Called for HTTP requests to FastAPI routes you registered on `app.fastapi` (including routers you include). This is the hook you want for API auth, logging, or error reporting.
+
+It does **not** run for Pulse's own endpoints (`/_pulse/prerender`, health, forms), generated OpenAPI/docs routes, plugin routes added in `on_setup`, or the React proxy. That's the point: wrapping FastAPI with HTTP middleware catches prerender too, so the same exception can get reported twice.
+
+```python
+from fastapi.responses import JSONResponse
+
+async def api(self, *, request, session, next):
+    # Auth for your API only
+    if request.path.startswith("/api/admin") and not session.get("is_admin"):
+        return JSONResponse({"detail": "forbidden"}, status_code=403)
+
+    try:
+        return await next()
+    except Exception as exc:
+        report_api_error(exc, request)
+        raise
+```
+
+`next()` runs your route handler and returns its HTTP response. Return that, replace it, or let exceptions propagate after you inspect them. Use `request.raw` when you need the underlying FastAPI request (body, path params).
 
 ### `connect`
 
@@ -162,6 +185,7 @@ Middleware can return different values to control what happens next:
 | Return value | Effect |
 |--------------|--------|
 | `await next()` | Continue to the next middleware or handler |
+| `Response` / `JSONResponse` | HTTP response (`api` hook) |
 | `ps.Redirect("/path")` | Redirect the client (prerender hooks only) |
 | `ps.NotFound()` | Return a 404 page (prerender hooks only) |
 | `ps.Deny()` | Reject the request (connect, message, channel hooks) |

--- a/docs/content/docs/(core)/cookbook/auth/auth-middleware.mdx
+++ b/docs/content/docs/(core)/cookbook/auth/auth-middleware.mdx
@@ -82,6 +82,8 @@ async def api_login(request: Request):
     return {"ok": True}
 ```
 
+To protect those FastAPI routes themselves (without also wrapping prerender), override `api` on the same middleware class. See [Advanced: Middleware](/docs/advanced/middleware).
+
 ## See also
 
 - [Advanced: Middleware](/docs/advanced/middleware)

--- a/docs/content/docs/(core)/glossary.mdx
+++ b/docs/content/docs/(core)/glossary.mdx
@@ -265,7 +265,7 @@ Repeatedly fetching data at fixed intervals. Implemented with `repeat()` for sim
 Code that runs before/after the main request handler. Used for authentication, logging, error handling, or modifying requests/responses. Pulse middleware hooks cover prerender, user-defined FastAPI routes (`api`), WebSocket connect, messages, and channels.
 
 **User API route**
-A FastAPI endpoint you register on `app.fastapi` (or via `include_router`). Distinct from Pulse framework endpoints under `/_pulse/*` (prerender, health, forms) and from page prerender. The `api` middleware hook intercepts only these routes.
+A FastAPI endpoint registered on `app.fastapi` (or via `include_router`). Distinct from Pulse framework endpoints under `/_pulse/*` (prerender, health, forms) and from page prerender. The `api` middleware hook intercepts these routes.
 
 **Context**
 A way to pass data through the component tree without explicitly passing props at every level. Useful for themes, user data, or other "global" state.

--- a/docs/content/docs/(core)/glossary.mdx
+++ b/docs/content/docs/(core)/glossary.mdx
@@ -262,7 +262,10 @@ Repeatedly fetching data at fixed intervals. Implemented with `repeat()` for sim
 ## Architecture
 
 **Middleware**
-Code that runs before/after the main request handler. Used for authentication, logging, error handling, or modifying requests/responses.
+Code that runs before/after the main request handler. Used for authentication, logging, error handling, or modifying requests/responses. Pulse middleware hooks cover prerender, user-defined FastAPI routes (`api`), WebSocket connect, messages, and channels.
+
+**User API route**
+A FastAPI endpoint you register on `app.fastapi` (or via `include_router`). Distinct from Pulse framework endpoints under `/_pulse/*` (prerender, health, forms) and from page prerender. The `api` middleware hook intercepts only these routes.
 
 **Context**
 A way to pass data through the component tree without explicitly passing props at every level. Useful for themes, user data, or other "global" state.

--- a/docs/content/docs/reference/pulse/middleware.mdx
+++ b/docs/content/docs/reference/pulse/middleware.mdx
@@ -71,6 +71,29 @@ Handle batch prerender at the top level (HTTP request).
 
 **Returns:** `Ok[Prerender]`, `Redirect`, or `NotFound`.
 
+##### api
+
+```python
+async def api(
+    self,
+    *,
+    request: PulseRequest,
+    session: dict[str, Any],
+    next: Callable[[], Awaitable[ApiResponse]],
+) -> ApiResponse
+```
+
+Handle user-defined FastAPI routes registered on `app.fastapi`, including included routers.
+
+Does not run for Pulse framework endpoints (`/_pulse/*`), generated OpenAPI/docs routes, plugin routes added in `on_setup`, or the React proxy.
+
+**Parameters:**
+- `request` - Normalized request object. Use `request.raw` for the FastAPI request.
+- `session` - Session data dictionary.
+- `next` - Callable that invokes the route handler and returns its HTTP response.
+
+**Returns:** A Starlette/FastAPI `Response`.
+
 ##### prerender_route
 
 ```python
@@ -187,6 +210,7 @@ def __init__(
     self,
     *,
     prerender_ms: float = 80.0,
+    api_ms: float = 25.0,
     prerender_route_ms: float = 60.0,
     connect_ms: float = 40.0,
     message_ms: float = 25.0,
@@ -196,6 +220,7 @@ def __init__(
 
 **Parameters:**
 - `prerender_ms` - Latency for batch prerender requests. Default: 80ms.
+- `api_ms` - Latency for user-defined FastAPI routes. Default: 25ms.
 - `prerender_route_ms` - Latency for individual route prerenders. Default: 60ms.
 - `connect_ms` - Latency for WebSocket connections. Default: 40ms.
 - `message_ms` - Latency for WebSocket messages. Default: 25ms.
@@ -251,6 +276,14 @@ class Deny
 Denial response. Blocks the request.
 
 ## Type Aliases
+
+### ApiResponse
+
+```python
+ApiResponse = Response
+```
+
+Starlette/FastAPI HTTP response returned by the `api` hook.
 
 ### ConnectResponse
 

--- a/docs/content/docs/reference/pulse/middleware.mdx
+++ b/docs/content/docs/reference/pulse/middleware.mdx
@@ -85,7 +85,7 @@ async def api(
 
 Handle user-defined FastAPI routes registered on `app.fastapi`, including included routers.
 
-Does not run for Pulse framework endpoints (`/_pulse/*`), generated OpenAPI/docs routes, plugin routes added in `on_setup`, or the React proxy.
+Does not run for Pulse framework endpoints (`/_pulse/*`), generated OpenAPI/docs routes, or the React proxy.
 
 **Parameters:**
 - `request` - Normalized request object. Use `request.raw` for the FastAPI request.

--- a/packages/pulse/python/README.md
+++ b/packages/pulse/python/README.md
@@ -31,6 +31,7 @@ Server-driven UI model: Python components render to VDOM, synced to React via We
 ```
 src/pulse/
 ├── app.py              # Main App class, FastAPI + Socket.IO setup
+├── api_router.py       # FastAPI route/router classes (user API + /_pulse)
 ├── channel.py          # Bidirectional real-time channels
 ├── routing.py          # Route/Layout definitions, URL matching
 ├── vdom.py             # VDOM node types (Element, Component, Node)

--- a/packages/pulse/python/src/pulse/__init__.py
+++ b/packages/pulse/python/src/pulse/__init__.py
@@ -1302,6 +1302,9 @@ from pulse.messages import SocketIODirectives as SocketIODirectives
 
 # Middleware
 from pulse.middleware import (
+	ApiResponse as ApiResponse,
+)
+from pulse.middleware import (
 	ConnectResponse as ConnectResponse,
 )
 from pulse.middleware import (

--- a/packages/pulse/python/src/pulse/api_router.py
+++ b/packages/pulse/python/src/pulse/api_router.py
@@ -24,19 +24,16 @@ def _wrap_user_api_handler(
 		from pulse.context import PULSE_CONTEXT
 
 		ctx = PULSE_CONTEXT.get()
-		if ctx is None:
+		if ctx is None or ctx.session is None:
+			# No Pulse request: raw FastAPI, or session_middleware hasn't run.
 			return await original(request)
-		# session_middleware mounts a UserSession before the route runs.
-		session = ctx.session
-		if session is None:
-			raise RuntimeError("Internal error: couldn't resolve user session")
 
 		async def _next() -> Response:
 			return await original(request)
 
 		response = await ctx.app.middleware.api(
 			request=PulseRequest.from_fastapi(request),
-			session=session.data,
+			session=ctx.session.data,
 			next=_next,
 		)
 		if not isinstance(response, Response):

--- a/packages/pulse/python/src/pulse/api_router.py
+++ b/packages/pulse/python/src/pulse/api_router.py
@@ -26,15 +26,17 @@ def _wrap_user_api_handler(
 		ctx = PULSE_CONTEXT.get()
 		if ctx is None:
 			return await original(request)
-
-		session: dict[str, Any] = ctx.session.data if ctx.session is not None else {}
+		# session_middleware mounts a UserSession before the route runs.
+		session = ctx.session
+		if session is None:
+			raise RuntimeError("Internal error: couldn't resolve user session")
 
 		async def _next() -> Response:
 			return await original(request)
 
 		response = await ctx.app.middleware.api(
 			request=PulseRequest.from_fastapi(request),
-			session=session,
+			session=session.data,
 			next=_next,
 		)
 		if not isinstance(response, Response):

--- a/packages/pulse/python/src/pulse/api_router.py
+++ b/packages/pulse/python/src/pulse/api_router.py
@@ -15,8 +15,6 @@ from starlette.responses import Response
 from pulse.reactive_extensions import unwrap
 from pulse.request import PulseRequest
 
-PULSE_ENDPOINT_UNWRAP_MARKER = "__pulse_endpoint_unwrap__"
-
 
 def _wrap_user_api_handler(
 	original: Callable[[Request], Coroutine[Any, Any, Response]],
@@ -50,23 +48,18 @@ def _wrap_user_api_handler(
 
 
 def _wrap_fastapi_endpoint(endpoint: Callable[..., Any]) -> Callable[..., Any]:
-	if endpoint.__dict__.get(PULSE_ENDPOINT_UNWRAP_MARKER):
-		return endpoint
-
 	if asyncio.iscoroutinefunction(endpoint):
 
 		@wraps(endpoint)
 		async def async_endpoint(*args: Any, **kwargs: Any) -> Any:
 			return _unwrap_fastapi_response(await endpoint(*args, **kwargs))
 
-		async_endpoint.__dict__[PULSE_ENDPOINT_UNWRAP_MARKER] = True
 		return async_endpoint
 
 	@wraps(endpoint)
 	def sync_endpoint(*args: Any, **kwargs: Any) -> Any:
 		return _unwrap_fastapi_response(endpoint(*args, **kwargs))
 
-	sync_endpoint.__dict__[PULSE_ENDPOINT_UNWRAP_MARKER] = True
 	return sync_endpoint
 
 
@@ -85,7 +78,14 @@ class PulseFrameworkAPIRoute(APIRoute):
 		endpoint: Callable[..., Any],
 		**kwargs: Any,
 	) -> None:
-		super().__init__(path, _wrap_fastapi_endpoint(endpoint), **kwargs)
+		# Leave endpoint as the user function. include_router copies route.endpoint
+		# into a new route; wrapping that would stack wrappers. Unwrap the call
+		# FastAPI actually invokes — rebuilt per copy.
+		super().__init__(path, endpoint, **kwargs)
+		call = self.dependant.call
+		if call is None:
+			raise TypeError("FastAPI route has no endpoint")
+		self.dependant.call = _wrap_fastapi_endpoint(call)
 
 
 class PulseAPIRoute(PulseFrameworkAPIRoute):

--- a/packages/pulse/python/src/pulse/api_router.py
+++ b/packages/pulse/python/src/pulse/api_router.py
@@ -1,0 +1,131 @@
+"""FastAPI route/router classes for user APIs and Pulse built-in endpoints."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+from functools import wraps
+from typing import Any, Callable, override
+
+from fastapi import APIRouter, FastAPI
+from fastapi.routing import APIRoute
+from starlette.requests import Request
+from starlette.responses import Response
+
+from pulse.reactive_extensions import unwrap
+from pulse.request import PulseRequest
+
+PULSE_ENDPOINT_UNWRAP_MARKER = "__pulse_endpoint_unwrap__"
+
+
+def _wrap_user_api_handler(
+	original: Callable[[Request], Coroutine[Any, Any, Response]],
+) -> Callable[[Request], Coroutine[Any, Any, Response]]:
+	async def handler(request: Request) -> Response:
+		# Late import: pulse.context ↔ pulse.app cycle.
+		from pulse.context import PULSE_CONTEXT
+
+		ctx = PULSE_CONTEXT.get()
+		if ctx is None:
+			return await original(request)
+
+		session: dict[str, Any] = ctx.session.data if ctx.session is not None else {}
+
+		async def _next() -> Response:
+			return await original(request)
+
+		response = await ctx.app.middleware.api(
+			request=PulseRequest.from_fastapi(request),
+			session=session,
+			next=_next,
+		)
+		if not isinstance(response, Response):
+			raise TypeError(
+				"PulseMiddleware.api() must return a Response, "
+				+ f"got {type(response).__name__}"
+			)
+		return response
+
+	return handler
+
+
+def _wrap_fastapi_endpoint(endpoint: Callable[..., Any]) -> Callable[..., Any]:
+	if endpoint.__dict__.get(PULSE_ENDPOINT_UNWRAP_MARKER):
+		return endpoint
+
+	if asyncio.iscoroutinefunction(endpoint):
+
+		@wraps(endpoint)
+		async def async_endpoint(*args: Any, **kwargs: Any) -> Any:
+			return _unwrap_fastapi_response(await endpoint(*args, **kwargs))
+
+		async_endpoint.__dict__[PULSE_ENDPOINT_UNWRAP_MARKER] = True
+		return async_endpoint
+
+	@wraps(endpoint)
+	def sync_endpoint(*args: Any, **kwargs: Any) -> Any:
+		return _unwrap_fastapi_response(endpoint(*args, **kwargs))
+
+	sync_endpoint.__dict__[PULSE_ENDPOINT_UNWRAP_MARKER] = True
+	return sync_endpoint
+
+
+def _unwrap_fastapi_response(value: Any) -> Any:
+	if isinstance(value, Response):
+		return value
+	return unwrap(value, untrack=True)
+
+
+class PulseFrameworkAPIRoute(APIRoute):
+	"""Pulse built-in FastAPI routes: unwrap reactives, no ``api`` hook."""
+
+	def __init__(
+		self,
+		path: str,
+		endpoint: Callable[..., Any],
+		**kwargs: Any,
+	) -> None:
+		super().__init__(path, _wrap_fastapi_endpoint(endpoint), **kwargs)
+
+
+class PulseAPIRoute(PulseFrameworkAPIRoute):
+	"""User-defined FastAPI routes: unwrap reactives and run ``PulseMiddleware.api``."""
+
+	@override
+	def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
+		return _wrap_user_api_handler(super().get_route_handler())
+
+
+class PulseAPIRouter(APIRouter):
+	"""App router that keeps ``PulseAPIRoute`` when including foreign routers.
+
+	``APIRouter.include_router`` copies routes with ``route_class_override=type(source)``,
+	which would drop ``PulseMiddleware.api``. Ignore that override unless the
+	source is a Pulse framework route.
+	"""
+
+	@override
+	def add_api_route(
+		self,
+		path: str,
+		endpoint: Callable[..., Any],
+		**kwargs: Any,
+	) -> None:
+		override = kwargs.get("route_class_override")
+		if override is not None and not issubclass(override, PulseFrameworkAPIRoute):
+			kwargs["route_class_override"] = None
+		super().add_api_route(path, endpoint, **kwargs)
+
+
+class PulseFastAPI(FastAPI):
+	def __init__(self, *args: Any, **kwargs: Any) -> None:
+		super().__init__(*args, **kwargs)
+		# FastAPI hardcodes APIRouter(); adopt it in place so include_router
+		# keeps PulseAPIRoute. PulseAPIRouter is stateless — methods only.
+		if type(self.router) is not APIRouter:
+			raise TypeError(
+				"Expected FastAPI to construct a stock APIRouter, "
+				+ f"got {type(self.router).__name__}"
+			)
+		self.router.__class__ = PulseAPIRouter
+		self.router.route_class = PulseAPIRoute

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -9,23 +9,22 @@ import asyncio
 import logging
 import os
 from collections import defaultdict
-from collections.abc import Awaitable, Coroutine, Sequence
+from collections.abc import Awaitable, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from enum import IntEnum
-from functools import wraps
-from typing import Any, Callable, Literal, TypeVar, cast, override
+from typing import Any, Callable, Literal, TypeVar, cast
 
 import socketio
 import uvicorn
 from fastapi import APIRouter, FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from fastapi.routing import APIRoute
 from socketio.exceptions import ConnectionRefusedError as SocketIOConnectionRefusedError
 from starlette.types import ASGIApp
 from starlette.websockets import WebSocket
 
+from pulse.api_router import PulseFastAPI, PulseFrameworkAPIRoute
 from pulse.codegen.codegen import Codegen, CodegenConfig
 from pulse.context import PULSE_CONTEXT, PulseContext
 from pulse.cookies import (
@@ -73,7 +72,6 @@ from pulse.middleware import (
 )
 from pulse.plugin import Plugin
 from pulse.proxy import Proxy, ReactProxy
-from pulse.reactive_extensions import unwrap
 from pulse.render_session import RenderSession
 from pulse.request import PulseRequest
 from pulse.routing import Layout, Route, RouteTree, ensure_absolute_path
@@ -92,7 +90,6 @@ FRAMEWORK_API_PREFIX = "/_pulse"
 PAGE_INSTANCE_AUTH_KEY = "__pulse_page_instance_id"
 RENDER_ID_COLLISION_CODE = "render_id_collision"
 MAX_PENDING_SOCKET_MESSAGES = 100
-PULSE_ENDPOINT_UNWRAP_MARKER = "__pulse_endpoint_unwrap__"
 
 
 class AppStatus(IntEnum):
@@ -164,117 +161,6 @@ class FastAPIConfig:
 	swagger_ui_parameters: dict[str, Any] | None = None
 	separate_input_output_schemas: bool = True
 	openapi_external_docs: dict[str, Any] | None = None
-
-
-def _wrap_user_api_handler(
-	original: Callable[[Request], Coroutine[Any, Any, Response]],
-) -> Callable[[Request], Coroutine[Any, Any, Response]]:
-	async def handler(request: Request) -> Response:
-		ctx = PULSE_CONTEXT.get()
-		if ctx is None:
-			return await original(request)
-
-		session: dict[str, Any] = ctx.session.data if ctx.session is not None else {}
-
-		async def _next() -> Response:
-			return await original(request)
-
-		response = await ctx.app.middleware.api(
-			request=PulseRequest.from_fastapi(request),
-			session=session,
-			next=_next,
-		)
-		if not isinstance(response, Response):
-			raise TypeError(
-				"PulseMiddleware.api() must return a Response, "
-				+ f"got {type(response).__name__}"
-			)
-		return response
-
-	return handler
-
-
-class PulseAPIRoute(APIRoute):
-	"""User-defined FastAPI routes: unwrap reactives and run ``PulseMiddleware.api``."""
-
-	def __init__(
-		self,
-		path: str,
-		endpoint: Callable[..., Any],
-		**kwargs: Any,
-	) -> None:
-		super().__init__(path, _wrap_fastapi_endpoint(endpoint), **kwargs)
-
-	@override
-	def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
-		return _wrap_user_api_handler(super().get_route_handler())
-
-
-class PulseFrameworkAPIRoute(APIRoute):
-	"""Pulse built-in FastAPI routes: unwrap reactives, no ``api`` hook."""
-
-	def __init__(
-		self,
-		path: str,
-		endpoint: Callable[..., Any],
-		**kwargs: Any,
-	) -> None:
-		super().__init__(path, _wrap_fastapi_endpoint(endpoint), **kwargs)
-
-
-class PulseAPIRouter(APIRouter):
-	"""App router that keeps ``PulseAPIRoute`` when including foreign routers.
-
-	``APIRouter.include_router`` copies routes with ``route_class_override=type(source)``,
-	which would drop ``PulseMiddleware.api``. Ignore that override unless the
-	source is a Pulse framework route.
-	"""
-
-	@override
-	def add_api_route(
-		self,
-		path: str,
-		endpoint: Callable[..., Any],
-		**kwargs: Any,
-	) -> None:
-		override = kwargs.get("route_class_override")
-		if override is not None and not issubclass(override, PulseFrameworkAPIRoute):
-			kwargs["route_class_override"] = None
-		super().add_api_route(path, endpoint, **kwargs)
-
-
-class PulseFastAPI(FastAPI):
-	def __init__(self, *args: Any, **kwargs: Any) -> None:
-		super().__init__(*args, **kwargs)
-		self.router.__class__ = PulseAPIRouter
-		self.router.route_class = PulseAPIRoute
-
-
-def _wrap_fastapi_endpoint(endpoint: Callable[..., Any]) -> Callable[..., Any]:
-	if endpoint.__dict__.get(PULSE_ENDPOINT_UNWRAP_MARKER):
-		return endpoint
-
-	if asyncio.iscoroutinefunction(endpoint):
-
-		@wraps(endpoint)
-		async def async_endpoint(*args: Any, **kwargs: Any) -> Any:
-			return _unwrap_fastapi_response(await endpoint(*args, **kwargs))
-
-		async_endpoint.__dict__[PULSE_ENDPOINT_UNWRAP_MARKER] = True
-		return async_endpoint
-
-	@wraps(endpoint)
-	def sync_endpoint(*args: Any, **kwargs: Any) -> Any:
-		return _unwrap_fastapi_response(endpoint(*args, **kwargs))
-
-	sync_endpoint.__dict__[PULSE_ENDPOINT_UNWRAP_MARKER] = True
-	return sync_endpoint
-
-
-def _unwrap_fastapi_response(value: Any) -> Any:
-	if isinstance(value, Response):
-		return value
-	return unwrap(value, untrack=True)
 
 
 class App:

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -167,6 +167,16 @@ class FastAPIConfig:
 
 
 class PulseAPIRoute(APIRoute):
+	"""FastAPI route class for user-defined Pulse API endpoints.
+
+	Unwraps reactive return values and runs ``PulseMiddleware.api`` around the
+	handler. Framework routes registered during ``App.setup`` use
+	``PulseFrameworkAPIRoute`` so prerender and other ``/_pulse/*`` endpoints
+	are not intercepted.
+	"""
+
+	_intercept_user_api = True
+
 	def __init__(
 		self,
 		path: str,
@@ -174,6 +184,45 @@ class PulseAPIRoute(APIRoute):
 		**kwargs: Any,
 	) -> None:
 		super().__init__(path, _wrap_fastapi_endpoint(endpoint), **kwargs)
+
+	@override
+	def get_route_handler(self) -> Callable[[Request], Awaitable[Response]]:
+		original = super().get_route_handler()
+		if not self._intercept_user_api:
+			return original
+
+		async def handler(request: Request) -> Response:
+			app = getattr(request.app.state, "pulse_app", None)
+			if app is None:
+				return await original(request)
+
+			ctx = PULSE_CONTEXT.get()
+			session = (
+				ctx.session.data if ctx is not None and ctx.session is not None else {}
+			)
+
+			async def _next() -> Response:
+				return await original(request)
+
+			response = await app.middleware.api(
+				request=PulseRequest.from_fastapi(request),
+				session=session,
+				next=_next,
+			)
+			if not isinstance(response, Response):
+				raise TypeError(
+					"PulseMiddleware.api() must return a Response, "
+					+ f"got {type(response).__name__}"
+				)
+			return response
+
+		return handler
+
+
+class PulseFrameworkAPIRoute(PulseAPIRoute):
+	"""Route class for Pulse framework and plugin FastAPI endpoints."""
+
+	_intercept_user_api = False
 
 
 class PulseFastAPI(FastAPI):
@@ -429,6 +478,7 @@ class App:
 			lifespan=self.fastapi_lifespan,
 		)
 		self.fastapi.router.route_class = PulseAPIRoute
+		self.fastapi.state.pulse_app = self
 		self.sio = socketio.AsyncServer(
 			async_mode="asgi", cors_allowed_origins="*", async_handlers=False
 		)
@@ -673,6 +723,10 @@ class App:
 					# so dropping the in-memory object is safe.
 					self.close_session_if_inactive(session.sid)
 
+		# User-defined FastAPI routes keep PulseAPIRoute so middleware.api
+		# intercepts them. Framework and plugin routes skip that hook.
+		self.fastapi.router.route_class = PulseFrameworkAPIRoute
+
 		# Apply prefix to all routes
 		prefix = self.api_prefix
 
@@ -813,8 +867,11 @@ class App:
 			return await render.forms.handle_submit(form_id, request, session)
 
 		# Call on_setup hooks after FastAPI routes/middleware are in place
-		for plugin in self.plugins:
-			plugin.on_setup(self)
+		try:
+			for plugin in self.plugins:
+				plugin.on_setup(self)
+		finally:
+			self.fastapi.router.route_class = PulseAPIRoute
 
 		# In single-server mode, add catch-all route to proxy unmatched requests to React server.
 		# This route must be registered last so FastAPI tries all specific routes first.

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -9,7 +9,7 @@ import asyncio
 import logging
 import os
 from collections import defaultdict
-from collections.abc import Awaitable, Sequence
+from collections.abc import Awaitable, Coroutine, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from enum import IntEnum
@@ -21,7 +21,7 @@ import uvicorn
 from fastapi import APIRouter, FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from fastapi.routing import APIRoute
+from fastapi.routing import APIRoute, request_response
 from socketio.exceptions import ConnectionRefusedError as SocketIOConnectionRefusedError
 from starlette.types import ASGIApp
 from starlette.websockets import WebSocket
@@ -166,6 +166,37 @@ class FastAPIConfig:
 	openapi_external_docs: dict[str, Any] | None = None
 
 
+def _wrap_user_api_handler(
+	original: Callable[[Request], Coroutine[Any, Any, Response]],
+) -> Callable[[Request], Coroutine[Any, Any, Response]]:
+	async def handler(request: Request) -> Response:
+		app = getattr(request.app.state, "pulse_app", None)
+		if app is None:
+			return await original(request)
+
+		ctx = PULSE_CONTEXT.get()
+		session = (
+			ctx.session.data if ctx is not None and ctx.session is not None else {}
+		)
+
+		async def _next() -> Response:
+			return await original(request)
+
+		response = await app.middleware.api(
+			request=PulseRequest.from_fastapi(request),
+			session=session,
+			next=_next,
+		)
+		if not isinstance(response, Response):
+			raise TypeError(
+				"PulseMiddleware.api() must return a Response, "
+				+ f"got {type(response).__name__}"
+			)
+		return response
+
+	return handler
+
+
 class PulseAPIRoute(APIRoute):
 	"""FastAPI route class for user-defined Pulse API endpoints.
 
@@ -175,7 +206,7 @@ class PulseAPIRoute(APIRoute):
 	are not intercepted.
 	"""
 
-	_intercept_user_api = True
+	_intercept_user_api: bool = True
 
 	def __init__(
 		self,
@@ -186,50 +217,36 @@ class PulseAPIRoute(APIRoute):
 		super().__init__(path, _wrap_fastapi_endpoint(endpoint), **kwargs)
 
 	@override
-	def get_route_handler(self) -> Callable[[Request], Awaitable[Response]]:
+	def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
 		original = super().get_route_handler()
 		if not self._intercept_user_api:
 			return original
-
-		async def handler(request: Request) -> Response:
-			app = getattr(request.app.state, "pulse_app", None)
-			if app is None:
-				return await original(request)
-
-			ctx = PULSE_CONTEXT.get()
-			session = (
-				ctx.session.data if ctx is not None and ctx.session is not None else {}
-			)
-
-			async def _next() -> Response:
-				return await original(request)
-
-			response = await app.middleware.api(
-				request=PulseRequest.from_fastapi(request),
-				session=session,
-				next=_next,
-			)
-			if not isinstance(response, Response):
-				raise TypeError(
-					"PulseMiddleware.api() must return a Response, "
-					+ f"got {type(response).__name__}"
-				)
-			return response
-
-		return handler
+		return _wrap_user_api_handler(original)
 
 
 class PulseFrameworkAPIRoute(PulseAPIRoute):
 	"""Route class for Pulse framework and plugin FastAPI endpoints."""
 
-	_intercept_user_api = False
+	_intercept_user_api: bool = False
 
 
 class PulseFastAPI(FastAPI):
 	@override
 	def include_router(self, router: APIRouter, **kwargs: Any) -> None:
 		_wrap_router_endpoints(router)
+		# FastAPI copies included routes with the source route class, so
+		# user routers stay as APIRoute unless we wrap them here.
+		before = {id(route) for route in self.router.routes}
 		super().include_router(router, **kwargs)
+		if self.router.route_class is PulseFrameworkAPIRoute:
+			return
+		for route in self.router.routes:
+			if id(route) in before:
+				continue
+			if isinstance(route, APIRoute) and not isinstance(route, PulseAPIRoute):
+				route.app = request_response(
+					_wrap_user_api_handler(route.get_route_handler())
+				)
 
 
 def _wrap_router_endpoints(router: APIRouter) -> None:

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -14,7 +14,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from enum import IntEnum
 from functools import wraps
-from typing import Any, Callable, Literal, TypeVar, cast, override
+from typing import Any, Callable, Literal, Self, TypeVar, cast, override
 
 import socketio
 import uvicorn
@@ -205,6 +205,42 @@ class PulseAPIRoute(APIRoute):
 	) -> None:
 		super().__init__(path, _wrap_fastapi_endpoint(endpoint), **kwargs)
 
+	@classmethod
+	def wrap(cls, route: APIRoute) -> Self:
+		"""Rebuild an ``APIRoute`` as a ``PulseAPIRoute``.
+
+		``APIRouter.include_router`` copies routes with ``type(source_route)``, so
+		user routers stay as stock ``APIRoute`` unless we reconstruct them.
+		"""
+		return cls(
+			path=route.path,
+			endpoint=route.endpoint,
+			response_model=route.response_model,
+			status_code=route.status_code,
+			tags=route.tags,
+			dependencies=route.dependencies,
+			summary=route.summary,
+			description=route.description,
+			response_description=route.response_description,
+			responses=route.responses,
+			deprecated=route.deprecated,
+			name=route.name,
+			methods=route.methods,
+			operation_id=route.operation_id,
+			response_model_include=route.response_model_include,
+			response_model_exclude=route.response_model_exclude,
+			response_model_by_alias=route.response_model_by_alias,
+			response_model_exclude_unset=route.response_model_exclude_unset,
+			response_model_exclude_defaults=route.response_model_exclude_defaults,
+			response_model_exclude_none=route.response_model_exclude_none,
+			include_in_schema=route.include_in_schema,
+			response_class=route.response_class,
+			dependency_overrides_provider=route.dependency_overrides_provider,
+			callbacks=route.callbacks,
+			openapi_extra=route.openapi_extra,
+			generate_unique_id_function=route.generate_unique_id_function,
+		)
+
 	@override
 	def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
 		return _wrap_user_api_handler(super().get_route_handler())
@@ -222,42 +258,6 @@ class PulseFrameworkAPIRoute(APIRoute):
 		super().__init__(path, _wrap_fastapi_endpoint(endpoint), **kwargs)
 
 
-def _as_user_api_route(route: APIRoute) -> PulseAPIRoute:
-	"""Rebuild an included FastAPI route as ``PulseAPIRoute``.
-
-	``APIRouter.include_router`` copies routes with ``type(source_route)``, so
-	user routers stay as stock ``APIRoute`` unless we reconstruct them.
-	"""
-	return PulseAPIRoute(
-		path=route.path,
-		endpoint=route.endpoint,
-		response_model=route.response_model,
-		status_code=route.status_code,
-		tags=route.tags,
-		dependencies=route.dependencies,
-		summary=route.summary,
-		description=route.description,
-		response_description=route.response_description,
-		responses=route.responses,
-		deprecated=route.deprecated,
-		name=route.name,
-		methods=route.methods,
-		operation_id=route.operation_id,
-		response_model_include=route.response_model_include,
-		response_model_exclude=route.response_model_exclude,
-		response_model_by_alias=route.response_model_by_alias,
-		response_model_exclude_unset=route.response_model_exclude_unset,
-		response_model_exclude_defaults=route.response_model_exclude_defaults,
-		response_model_exclude_none=route.response_model_exclude_none,
-		include_in_schema=route.include_in_schema,
-		response_class=route.response_class,
-		dependency_overrides_provider=route.dependency_overrides_provider,
-		callbacks=route.callbacks,
-		openapi_extra=route.openapi_extra,
-		generate_unique_id_function=route.generate_unique_id_function,
-	)
-
-
 class PulseFastAPI(FastAPI):
 	@override
 	def include_router(self, router: APIRouter, **kwargs: Any) -> None:
@@ -271,7 +271,7 @@ class PulseFastAPI(FastAPI):
 			if isinstance(route, (PulseAPIRoute, PulseFrameworkAPIRoute)):
 				continue
 			if isinstance(route, APIRoute):
-				routes[index] = _as_user_api_route(route)
+				routes[index] = PulseAPIRoute.wrap(route)
 
 
 def _wrap_router_endpoints(router: APIRouter) -> None:

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -14,7 +14,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from enum import IntEnum
 from functools import wraps
-from typing import Any, Callable, Literal, Self, TypeVar, cast, override
+from typing import Any, Callable, Literal, TypeVar, cast, override
 
 import socketio
 import uvicorn
@@ -205,42 +205,6 @@ class PulseAPIRoute(APIRoute):
 	) -> None:
 		super().__init__(path, _wrap_fastapi_endpoint(endpoint), **kwargs)
 
-	@classmethod
-	def wrap(cls, route: APIRoute) -> Self:
-		"""Rebuild an ``APIRoute`` as a ``PulseAPIRoute``.
-
-		``APIRouter.include_router`` copies routes with ``type(source_route)``, so
-		user routers stay as stock ``APIRoute`` unless we reconstruct them.
-		"""
-		return cls(
-			path=route.path,
-			endpoint=route.endpoint,
-			response_model=route.response_model,
-			status_code=route.status_code,
-			tags=route.tags,
-			dependencies=route.dependencies,
-			summary=route.summary,
-			description=route.description,
-			response_description=route.response_description,
-			responses=route.responses,
-			deprecated=route.deprecated,
-			name=route.name,
-			methods=route.methods,
-			operation_id=route.operation_id,
-			response_model_include=route.response_model_include,
-			response_model_exclude=route.response_model_exclude,
-			response_model_by_alias=route.response_model_by_alias,
-			response_model_exclude_unset=route.response_model_exclude_unset,
-			response_model_exclude_defaults=route.response_model_exclude_defaults,
-			response_model_exclude_none=route.response_model_exclude_none,
-			include_in_schema=route.include_in_schema,
-			response_class=route.response_class,
-			dependency_overrides_provider=route.dependency_overrides_provider,
-			callbacks=route.callbacks,
-			openapi_extra=route.openapi_extra,
-			generate_unique_id_function=route.generate_unique_id_function,
-		)
-
 	@override
 	def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
 		return _wrap_user_api_handler(super().get_route_handler())
@@ -258,26 +222,32 @@ class PulseFrameworkAPIRoute(APIRoute):
 		super().__init__(path, _wrap_fastapi_endpoint(endpoint), **kwargs)
 
 
-class PulseFastAPI(FastAPI):
+class PulseAPIRouter(APIRouter):
+	"""App router that keeps ``PulseAPIRoute`` when including foreign routers.
+
+	``APIRouter.include_router`` copies routes with ``route_class_override=type(source)``,
+	which would drop ``PulseMiddleware.api``. Ignore that override unless the
+	source is a Pulse framework route.
+	"""
+
 	@override
-	def include_router(self, router: APIRouter, **kwargs: Any) -> None:
-		_wrap_router_endpoints(router)
-		before = {id(route) for route in self.router.routes}
-		super().include_router(router, **kwargs)
-		routes = self.router.routes
-		for index, route in enumerate(routes):
-			if id(route) in before:
-				continue
-			if isinstance(route, (PulseAPIRoute, PulseFrameworkAPIRoute)):
-				continue
-			if isinstance(route, APIRoute):
-				routes[index] = PulseAPIRoute.wrap(route)
+	def add_api_route(
+		self,
+		path: str,
+		endpoint: Callable[..., Any],
+		**kwargs: Any,
+	) -> None:
+		override = kwargs.get("route_class_override")
+		if override is not None and not issubclass(override, PulseFrameworkAPIRoute):
+			kwargs["route_class_override"] = None
+		super().add_api_route(path, endpoint, **kwargs)
 
 
-def _wrap_router_endpoints(router: APIRouter) -> None:
-	for route in router.routes:
-		if isinstance(route, APIRoute):
-			route.endpoint = _wrap_fastapi_endpoint(route.endpoint)
+class PulseFastAPI(FastAPI):
+	def __init__(self, *args: Any, **kwargs: Any) -> None:
+		super().__init__(*args, **kwargs)
+		self.router.__class__ = PulseAPIRouter
+		self.router.route_class = PulseAPIRoute
 
 
 def _wrap_fastapi_endpoint(endpoint: Callable[..., Any]) -> Callable[..., Any]:
@@ -519,7 +489,6 @@ class App:
 			openapi_external_docs=fastapi_config.openapi_external_docs,
 			lifespan=self.fastapi_lifespan,
 		)
-		self.fastapi.router.route_class = PulseAPIRoute
 		self.sio = socketio.AsyncServer(
 			async_mode="asgi", cors_allowed_origins="*", async_handlers=False
 		)

--- a/packages/pulse/python/src/pulse/app.py
+++ b/packages/pulse/python/src/pulse/app.py
@@ -21,7 +21,7 @@ import uvicorn
 from fastapi import APIRouter, FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from fastapi.routing import APIRoute, request_response
+from fastapi.routing import APIRoute
 from socketio.exceptions import ConnectionRefusedError as SocketIOConnectionRefusedError
 from starlette.types import ASGIApp
 from starlette.websockets import WebSocket
@@ -170,19 +170,16 @@ def _wrap_user_api_handler(
 	original: Callable[[Request], Coroutine[Any, Any, Response]],
 ) -> Callable[[Request], Coroutine[Any, Any, Response]]:
 	async def handler(request: Request) -> Response:
-		app = getattr(request.app.state, "pulse_app", None)
-		if app is None:
+		ctx = PULSE_CONTEXT.get()
+		if ctx is None:
 			return await original(request)
 
-		ctx = PULSE_CONTEXT.get()
-		session = (
-			ctx.session.data if ctx is not None and ctx.session is not None else {}
-		)
+		session: dict[str, Any] = ctx.session.data if ctx.session is not None else {}
 
 		async def _next() -> Response:
 			return await original(request)
 
-		response = await app.middleware.api(
+		response = await ctx.app.middleware.api(
 			request=PulseRequest.from_fastapi(request),
 			session=session,
 			next=_next,
@@ -198,15 +195,7 @@ def _wrap_user_api_handler(
 
 
 class PulseAPIRoute(APIRoute):
-	"""FastAPI route class for user-defined Pulse API endpoints.
-
-	Unwraps reactive return values and runs ``PulseMiddleware.api`` around the
-	handler. Framework routes registered during ``App.setup`` use
-	``PulseFrameworkAPIRoute`` so prerender and other ``/_pulse/*`` endpoints
-	are not intercepted.
-	"""
-
-	_intercept_user_api: bool = True
+	"""User-defined FastAPI routes: unwrap reactives and run ``PulseMiddleware.api``."""
 
 	def __init__(
 		self,
@@ -218,35 +207,71 @@ class PulseAPIRoute(APIRoute):
 
 	@override
 	def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
-		original = super().get_route_handler()
-		if not self._intercept_user_api:
-			return original
-		return _wrap_user_api_handler(original)
+		return _wrap_user_api_handler(super().get_route_handler())
 
 
-class PulseFrameworkAPIRoute(PulseAPIRoute):
-	"""Route class for Pulse framework and plugin FastAPI endpoints."""
+class PulseFrameworkAPIRoute(APIRoute):
+	"""Pulse built-in FastAPI routes: unwrap reactives, no ``api`` hook."""
 
-	_intercept_user_api: bool = False
+	def __init__(
+		self,
+		path: str,
+		endpoint: Callable[..., Any],
+		**kwargs: Any,
+	) -> None:
+		super().__init__(path, _wrap_fastapi_endpoint(endpoint), **kwargs)
+
+
+def _as_user_api_route(route: APIRoute) -> PulseAPIRoute:
+	"""Rebuild an included FastAPI route as ``PulseAPIRoute``.
+
+	``APIRouter.include_router`` copies routes with ``type(source_route)``, so
+	user routers stay as stock ``APIRoute`` unless we reconstruct them.
+	"""
+	return PulseAPIRoute(
+		path=route.path,
+		endpoint=route.endpoint,
+		response_model=route.response_model,
+		status_code=route.status_code,
+		tags=route.tags,
+		dependencies=route.dependencies,
+		summary=route.summary,
+		description=route.description,
+		response_description=route.response_description,
+		responses=route.responses,
+		deprecated=route.deprecated,
+		name=route.name,
+		methods=route.methods,
+		operation_id=route.operation_id,
+		response_model_include=route.response_model_include,
+		response_model_exclude=route.response_model_exclude,
+		response_model_by_alias=route.response_model_by_alias,
+		response_model_exclude_unset=route.response_model_exclude_unset,
+		response_model_exclude_defaults=route.response_model_exclude_defaults,
+		response_model_exclude_none=route.response_model_exclude_none,
+		include_in_schema=route.include_in_schema,
+		response_class=route.response_class,
+		dependency_overrides_provider=route.dependency_overrides_provider,
+		callbacks=route.callbacks,
+		openapi_extra=route.openapi_extra,
+		generate_unique_id_function=route.generate_unique_id_function,
+	)
 
 
 class PulseFastAPI(FastAPI):
 	@override
 	def include_router(self, router: APIRouter, **kwargs: Any) -> None:
 		_wrap_router_endpoints(router)
-		# FastAPI copies included routes with the source route class, so
-		# user routers stay as APIRoute unless we wrap them here.
 		before = {id(route) for route in self.router.routes}
 		super().include_router(router, **kwargs)
-		if self.router.route_class is PulseFrameworkAPIRoute:
-			return
-		for route in self.router.routes:
+		routes = self.router.routes
+		for index, route in enumerate(routes):
 			if id(route) in before:
 				continue
-			if isinstance(route, APIRoute) and not isinstance(route, PulseAPIRoute):
-				route.app = request_response(
-					_wrap_user_api_handler(route.get_route_handler())
-				)
+			if isinstance(route, (PulseAPIRoute, PulseFrameworkAPIRoute)):
+				continue
+			if isinstance(route, APIRoute):
+				routes[index] = _as_user_api_route(route)
 
 
 def _wrap_router_endpoints(router: APIRouter) -> None:
@@ -495,7 +520,6 @@ class App:
 			lifespan=self.fastapi_lifespan,
 		)
 		self.fastapi.router.route_class = PulseAPIRoute
-		self.fastapi.state.pulse_app = self
 		self.sio = socketio.AsyncServer(
 			async_mode="asgi", cors_allowed_origins="*", async_handlers=False
 		)
@@ -740,23 +764,25 @@ class App:
 					# so dropping the in-memory object is safe.
 					self.close_session_if_inactive(session.sid)
 
-		# User-defined FastAPI routes keep PulseAPIRoute so middleware.api
-		# intercepts them. Framework and plugin routes skip that hook.
-		self.fastapi.router.route_class = PulseFrameworkAPIRoute
-
-		# Apply prefix to all routes
+		# Pulse built-ins live on a router with PulseFrameworkAPIRoute so
+		# middleware.api never sees prerender/health/forms. App.fastapi stays
+		# PulseAPIRoute for user and plugin routes.
 		prefix = self.api_prefix
+		framework = APIRouter(
+			route_class=PulseFrameworkAPIRoute,
+			include_in_schema=False,
+		)
 
-		@self.fastapi.get(f"{prefix}/health", include_in_schema=False)
+		@framework.get(f"{prefix}/health")
 		def healthcheck():  # pyright: ignore[reportUnusedFunction]
 			return {"health": "ok", "message": "Pulse server is running"}
 
-		@self.fastapi.get(f"{prefix}/set-cookies", include_in_schema=False)
+		@framework.get(f"{prefix}/set-cookies")
 		def set_cookies():  # pyright: ignore[reportUnusedFunction]
 			return {"health": "ok", "message": "Cookies updated"}
 
 		# RouteInfo is the request body
-		@self.fastapi.post(f"{prefix}/prerender", include_in_schema=False)
+		@framework.post(f"{prefix}/prerender")
 		async def prerender(payload: PrerenderPayload, request: Request):  # pyright: ignore[reportUnusedFunction]
 			"""
 			POST /prerender
@@ -866,10 +892,7 @@ class App:
 			# Fallback (shouldn't happen)
 			raise ValueError("Unexpected prerender result type")
 
-		@self.fastapi.post(
-			f"{prefix}/forms/{{render_id}}/{{form_id}}",
-			include_in_schema=False,
-		)
+		@framework.post(f"{prefix}/forms/{{render_id}}/{{form_id}}")
 		async def handle_form_submit(  # pyright: ignore[reportUnusedFunction]
 			render_id: str, form_id: str, request: Request
 		) -> Response:
@@ -883,12 +906,11 @@ class App:
 
 			return await render.forms.handle_submit(form_id, request, session)
 
+		self.fastapi.include_router(framework)
+
 		# Call on_setup hooks after FastAPI routes/middleware are in place
-		try:
-			for plugin in self.plugins:
-				plugin.on_setup(self)
-		finally:
-			self.fastapi.router.route_class = PulseAPIRoute
+		for plugin in self.plugins:
+			plugin.on_setup(self)
 
 		# In single-server mode, add catch-all route to proxy unmatched requests to React server.
 		# This route must be registered last so FastAPI tries all specific routes first.

--- a/packages/pulse/python/src/pulse/middleware.py
+++ b/packages/pulse/python/src/pulse/middleware.py
@@ -4,6 +4,8 @@ import asyncio
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Any, Generic, TypeVar, overload, override
 
+from starlette.responses import Response
+
 from pulse.env import env
 from pulse.messages import (
 	ClientMessage,
@@ -84,6 +86,9 @@ PrerenderResponse = Ok[Prerender] | Redirect | NotFound
 ConnectResponse = Ok[None] | Deny
 """Response type for WebSocket connection: ``Ok[None] | Deny``."""
 
+ApiResponse = Response
+"""Response type for user-defined FastAPI routes: a Starlette/FastAPI ``Response``."""
+
 
 class PulseMiddleware:
 	"""Base middleware class with pass-through defaults.
@@ -110,6 +115,13 @@ class PulseMiddleware:
 	        if path.startswith("/admin") and not session.get("is_admin"):
 	            return ps.Redirect("/login")
 	        return await next()
+
+	    async def api(self, *, request, session, next):
+	        try:
+	            return await next()
+	        except Exception as exc:
+	            report_user_api_error(exc, request)
+	            raise
 
 	    async def connect(self, *, request, session, next):
 	        if not session.get("user_id"):
@@ -140,6 +152,37 @@ class PulseMiddleware:
 
 		Receives the full PrerenderPayload (all paths). Call next() to get the
 		Prerender result and can modify it (views and directives) before returning.
+		"""
+		return await next()
+
+	async def api(
+		self,
+		*,
+		request: PulseRequest,
+		session: dict[str, Any],
+		next: Callable[[], Awaitable[ApiResponse]],
+	) -> ApiResponse:
+		"""Handle user-defined FastAPI routes.
+
+		Runs only for routes registered on ``app.fastapi`` by the application
+		(including included routers). Does not run for Pulse framework
+		endpoints (``/_pulse/*``), generated OpenAPI/docs routes, plugin
+		routes added in ``on_setup``, or the React proxy.
+
+		``next()`` invokes the route handler and returns its HTTP response.
+		Return that response, replace it, or raise after inspecting it.
+		Exceptions from the handler propagate through this hook, so you can
+		report them without also intercepting prerender errors.
+
+		Args:
+			request: Normalized request object. Use ``request.raw`` for the
+				underlying FastAPI request (body, path params, etc.).
+			session: Session data dictionary.
+			next: Callable to continue the middleware chain and invoke the
+				route handler.
+
+		Returns:
+			A Starlette/FastAPI ``Response``.
 		"""
 		return await next()
 
@@ -263,6 +306,26 @@ class MiddlewareStack(PulseMiddleware):
 				session=session,
 				next=_next,
 			)
+
+		return await dispatch(0)
+
+	@override
+	async def api(
+		self,
+		*,
+		request: PulseRequest,
+		session: dict[str, Any],
+		next: Callable[[], Awaitable[ApiResponse]],
+	) -> ApiResponse:
+		async def dispatch(index: int) -> ApiResponse:
+			if index >= len(self._middlewares):
+				return await next()
+			mw = self._middlewares[index]
+
+			async def _next() -> ApiResponse:
+				return await dispatch(index + 1)
+
+			return await mw.api(request=request, session=session, next=_next)
 
 		return await dispatch(0)
 
@@ -392,6 +455,7 @@ class LatencyMiddleware(PulseMiddleware):
 	"""
 
 	prerender_ms: float
+	api_ms: float
 	connect_ms: float
 	message_ms: float
 	channel_ms: float
@@ -400,6 +464,7 @@ class LatencyMiddleware(PulseMiddleware):
 		self,
 		*,
 		prerender_ms: float = 80.0,
+		api_ms: float = 25.0,
 		connect_ms: float = 40.0,
 		message_ms: float = 25.0,
 		channel_ms: float = 20.0,
@@ -408,12 +473,14 @@ class LatencyMiddleware(PulseMiddleware):
 
 		Args:
 			prerender_ms: Latency for batch prerender requests (HTTP). Default: 80ms
+			api_ms: Latency for user-defined FastAPI routes. Default: 25ms
 			connect_ms: Latency for WebSocket connections. Default: 40ms
 			message_ms: Latency for WebSocket messages (including API calls). Default: 25ms
 			channel_ms: Latency for channel messages. Default: 20ms
 		"""
 		super().__init__(dev=True)
 		self.prerender_ms = prerender_ms
+		self.api_ms = api_ms
 		self.connect_ms = connect_ms
 		self.message_ms = message_ms
 		self.channel_ms = channel_ms
@@ -429,6 +496,18 @@ class LatencyMiddleware(PulseMiddleware):
 	) -> PrerenderResponse:
 		if self.prerender_ms > 0:
 			await asyncio.sleep(self.prerender_ms / 1000.0)
+		return await next()
+
+	@override
+	async def api(
+		self,
+		*,
+		request: PulseRequest,
+		session: dict[str, Any],
+		next: Callable[[], Awaitable[ApiResponse]],
+	) -> ApiResponse:
+		if self.api_ms > 0:
+			await asyncio.sleep(self.api_ms / 1000.0)
 		return await next()
 
 	@override

--- a/packages/pulse/python/src/pulse/middleware.py
+++ b/packages/pulse/python/src/pulse/middleware.py
@@ -165,9 +165,9 @@ class PulseMiddleware:
 		"""Handle user-defined FastAPI routes.
 
 		Runs only for routes registered on ``app.fastapi`` by the application
-		(including included routers). Does not run for Pulse framework
-		endpoints (``/_pulse/*``), generated OpenAPI/docs routes, plugin
-		routes added in ``on_setup``, or the React proxy.
+		(including included routers and plugin routes added in ``on_setup``).
+		Does not run for Pulse framework endpoints (``/_pulse/*``), generated
+		OpenAPI/docs routes, or the React proxy.
 
 		``next()`` invokes the route handler and returns its HTTP response.
 		Return that response, replace it, or raise after inspecting it.

--- a/packages/pulse/python/tests/test_fastapi_routes.py
+++ b/packages/pulse/python/tests/test_fastapi_routes.py
@@ -4,6 +4,7 @@ import httpx
 import pulse as ps
 import pytest
 from fastapi import APIRouter, Response
+from fastapi.routing import APIRoute
 from pulse.api_router import PulseAPIRoute
 from starlette.responses import PlainTextResponse
 from starlette.types import Receive, Scope, Send
@@ -72,9 +73,9 @@ async def test_included_fastapi_routers_unwrap_reactive_response_values():
 	assert response.json() == {"count": 3}
 
 
-def _route_at(app: ps.App, path: str):
+def _route_at(app: ps.App, path: str) -> APIRoute:
 	for route in app.fastapi.routes:
-		if getattr(route, "path", None) == path:
+		if isinstance(route, APIRoute) and route.path == path:
 			return route
 	raise AssertionError(f"no route {path}")
 

--- a/packages/pulse/python/tests/test_fastapi_routes.py
+++ b/packages/pulse/python/tests/test_fastapi_routes.py
@@ -4,6 +4,7 @@ import httpx
 import pulse as ps
 import pytest
 from fastapi import APIRouter, Response
+from pulse.api_router import PulseAPIRoute
 from starlette.responses import PlainTextResponse
 from starlette.types import Receive, Scope, Send
 
@@ -69,6 +70,47 @@ async def test_included_fastapi_routers_unwrap_reactive_response_values():
 
 	assert response.status_code == 200
 	assert response.json() == {"count": 3}
+
+
+def _route_at(app: ps.App, path: str):
+	for route in app.fastapi.routes:
+		if getattr(route, "path", None) == path:
+			return route
+	raise AssertionError(f"no route {path}")
+
+
+def test_pulse_api_route_keeps_user_endpoint():
+	app = ps.App(routes=[])
+
+	def hello() -> dict[str, Any]:
+		return {"n": ps.Signal(1)}
+
+	app.fastapi.get("/hello")(hello)
+
+	assert _route_at(app, "/hello").endpoint is hello
+
+
+@pytest.mark.asyncio
+async def test_included_pulse_route_class_router_keeps_user_endpoint():
+	app = ps.App(routes=[])
+	router = APIRouter(route_class=PulseAPIRoute)
+
+	def reactive_payload() -> dict[str, Any]:
+		return {"count": ps.Signal(4)}
+
+	router.get("/reactive")(reactive_payload)
+	app.fastapi.include_router(router, prefix="/api")
+
+	assert _route_at(app, "/api/reactive").endpoint is reactive_payload
+
+	transport = httpx.ASGITransport(app=app.fastapi)
+	async with httpx.AsyncClient(
+		transport=transport, base_url="http://testserver"
+	) as client:
+		response = await client.get("/api/reactive")
+
+	assert response.status_code == 200
+	assert response.json() == {"count": 4}
 
 
 @pytest.mark.asyncio

--- a/packages/pulse/python/tests/test_middleware_api.py
+++ b/packages/pulse/python/tests/test_middleware_api.py
@@ -1,0 +1,380 @@
+from collections.abc import Awaitable, Callable
+from typing import Any, override
+
+import httpx
+import pulse as ps
+import pytest
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+from pulse.middleware import ApiResponse
+from pulse.plugin import Plugin
+from pulse.request import PulseRequest
+from pulse.routing import Route
+
+
+class RecordingApiMiddleware(ps.PulseMiddleware):
+	def __init__(self) -> None:
+		super().__init__()
+		self.paths: list[str] = []
+		self.methods: list[str] = []
+		self.sessions: list[dict[str, Any]] = []
+
+	@override
+	async def api(
+		self,
+		*,
+		request: PulseRequest,
+		session: dict[str, Any],
+		next: Callable[[], Awaitable[ApiResponse]],
+	) -> ApiResponse:
+		self.paths.append(request.path)
+		self.methods.append(request.method)
+		self.sessions.append(dict(session))
+		return await next()
+
+
+class ErrorReportingApiMiddleware(ps.PulseMiddleware):
+	def __init__(self) -> None:
+		super().__init__()
+		self.errors: list[Exception] = []
+
+	@override
+	async def api(
+		self,
+		*,
+		request: PulseRequest,
+		session: dict[str, Any],
+		next: Callable[[], Awaitable[ApiResponse]],
+	) -> ApiResponse:
+		try:
+			return await next()
+		except Exception as exc:
+			self.errors.append(exc)
+			raise
+
+
+class ShortCircuitApiMiddleware(ps.PulseMiddleware):
+	@override
+	async def api(
+		self,
+		*,
+		request: PulseRequest,
+		session: dict[str, Any],
+		next: Callable[[], Awaitable[ApiResponse]],
+	) -> ApiResponse:
+		if request.path == "/secret":
+			return JSONResponse({"detail": "unauthorized"}, status_code=401)
+		return await next()
+
+
+class HeaderApiMiddleware(ps.PulseMiddleware):
+	@override
+	async def api(
+		self,
+		*,
+		request: PulseRequest,
+		session: dict[str, Any],
+		next: Callable[[], Awaitable[ApiResponse]],
+	) -> ApiResponse:
+		response = await next()
+		response.headers["x-pulse-api"] = "1"
+		return response
+
+
+class PluginRoutePlugin(Plugin):
+	@override
+	def on_setup(self, app: ps.App) -> None:
+		@app.fastapi.get("/plugin-route")
+		def plugin_route() -> dict[str, bool]:  # pyright: ignore[reportUnusedFunction]
+			return {"plugin": True}
+
+
+@ps.component
+def prerender_home():
+	return ps.div("ok")
+
+
+def _client(app: ps.App) -> httpx.AsyncClient:
+	transport = httpx.ASGITransport(app=app.fastapi)
+	return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.mark.asyncio
+async def test_api_middleware_runs_for_user_fastapi_routes():
+	mw = RecordingApiMiddleware()
+	app = ps.App(routes=[], middleware=mw)
+
+	@app.fastapi.get("/api/hello")
+	def hello() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
+		return {"hello": "world"}
+
+	async with _client(app) as client:
+		response = await client.get("/api/hello")
+
+	assert response.status_code == 200
+	assert response.json() == {"hello": "world"}
+	assert mw.paths == ["/api/hello"]
+	assert mw.methods == ["GET"]
+
+
+@pytest.mark.asyncio
+async def test_api_middleware_runs_for_included_routers():
+	mw = RecordingApiMiddleware()
+	app = ps.App(routes=[], middleware=mw)
+	router = APIRouter()
+
+	@router.post("/items")
+	def create_item() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
+		return {"created": "yes"}
+
+	app.fastapi.include_router(router, prefix="/api")
+
+	async with _client(app) as client:
+		response = await client.post("/api/items")
+
+	assert response.status_code == 200
+	assert response.json() == {"created": "yes"}
+	assert mw.paths == ["/api/items"]
+	assert mw.methods == ["POST"]
+
+
+@pytest.mark.asyncio
+async def test_api_middleware_can_short_circuit_user_routes():
+	app = ps.App(routes=[], middleware=ShortCircuitApiMiddleware())
+
+	@app.fastapi.get("/secret")
+	def secret() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
+		return {"secret": "value"}
+
+	@app.fastapi.get("/public")
+	def public() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
+		return {"ok": "yes"}
+
+	async with _client(app) as client:
+		denied = await client.get("/secret")
+		allowed = await client.get("/public")
+
+	assert denied.status_code == 401
+	assert denied.json() == {"detail": "unauthorized"}
+	assert allowed.status_code == 200
+	assert allowed.json() == {"ok": "yes"}
+
+
+@pytest.mark.asyncio
+async def test_api_middleware_can_modify_response_headers():
+	app = ps.App(routes=[], middleware=HeaderApiMiddleware())
+
+	@app.fastapi.get("/api/hello")
+	def hello() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
+		return {"hello": "world"}
+
+	async with _client(app) as client:
+		response = await client.get("/api/hello")
+
+	assert response.status_code == 200
+	assert response.headers["x-pulse-api"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_api_middleware_can_catch_user_route_exceptions():
+	mw = ErrorReportingApiMiddleware()
+	app = ps.App(routes=[], middleware=mw)
+
+	@app.fastapi.get("/api/boom")
+	def boom() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
+		raise RuntimeError("user api failed")
+
+	async with _client(app) as client:
+		response = await client.get("/api/boom")
+
+	assert response.status_code == 500
+	assert len(mw.errors) == 1
+	assert str(mw.errors[0]) == "user api failed"
+
+
+@pytest.mark.asyncio
+async def test_api_middleware_skips_pulse_framework_and_docs_routes():
+	mw = RecordingApiMiddleware()
+	app = ps.App(
+		routes=[Route("/", prerender_home)],
+		middleware=mw,
+		mode="subdomains",
+	)
+	app.setup("http://testserver")
+
+	try:
+		async with _client(app) as client:
+			health = await client.get("/_pulse/health")
+			docs = await client.get("/_pulse/docs")
+			openapi = await client.get("/_pulse/openapi.json")
+			prerender = await client.post(
+				"/_pulse/prerender",
+				json={
+					"paths": ["/"],
+					"routeInfo": {
+						"pathname": "/",
+						"hash": "",
+						"query": "",
+						"queryParams": {},
+						"pathParams": {},
+						"catchall": [],
+					},
+				},
+			)
+	finally:
+		await app.close()
+
+	assert health.status_code == 200
+	assert docs.status_code == 200
+	assert openapi.status_code == 200
+	assert prerender.status_code == 200
+	assert mw.paths == []
+
+
+@pytest.mark.asyncio
+async def test_api_middleware_skips_plugin_on_setup_routes():
+	mw = RecordingApiMiddleware()
+	app = ps.App(
+		routes=[],
+		middleware=mw,
+		plugins=[PluginRoutePlugin()],
+		mode="subdomains",
+	)
+	app.setup("http://testserver")
+
+	try:
+		async with _client(app) as client:
+			response = await client.get("/plugin-route")
+	finally:
+		await app.close()
+
+	assert response.status_code == 200
+	assert response.json() == {"plugin": True}
+	assert mw.paths == []
+
+
+@pytest.mark.asyncio
+async def test_api_middleware_runs_for_user_routes_after_setup():
+	mw = RecordingApiMiddleware()
+	app = ps.App(routes=[], middleware=mw, mode="subdomains")
+
+	@app.fastapi.get("/api/before")
+	def before() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
+		return {"when": "before"}
+
+	app.setup("http://testserver")
+
+	@app.fastapi.get("/api/after")
+	def after() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
+		return {"when": "after"}
+
+	try:
+		async with _client(app) as client:
+			before_res = await client.get("/api/before")
+			after_res = await client.get("/api/after")
+			health = await client.get("/_pulse/health")
+	finally:
+		await app.close()
+
+	assert before_res.json() == {"when": "before"}
+	assert after_res.json() == {"when": "after"}
+	assert health.status_code == 200
+	assert mw.paths == ["/api/before", "/api/after"]
+
+
+@pytest.mark.asyncio
+async def test_api_middleware_receives_session_after_setup():
+	mw = RecordingApiMiddleware()
+	app = ps.App(routes=[], middleware=mw, mode="subdomains")
+
+	@app.fastapi.get("/api/session")
+	def read_session() -> dict[str, Any]:  # pyright: ignore[reportUnusedFunction]
+		ps.session()["seen"] = True
+		return {"ok": True}
+
+	app.setup("http://testserver")
+
+	try:
+		async with _client(app) as client:
+			response = await client.get("/api/session")
+	finally:
+		await app.close()
+
+	assert response.status_code == 200
+	assert len(mw.sessions) == 1
+	# Session exists (cookie store mints one) even if empty at hook entry
+	assert isinstance(mw.sessions[0], dict)
+
+
+@pytest.mark.asyncio
+async def test_api_middleware_stack_runs_in_order():
+	order: list[str] = []
+
+	class First(ps.PulseMiddleware):
+		@override
+		async def api(
+			self,
+			*,
+			request: PulseRequest,
+			session: dict[str, Any],
+			next: Callable[[], Awaitable[ApiResponse]],
+		) -> ApiResponse:
+			order.append("first")
+			response = await next()
+			order.append("first-after")
+			return response
+
+	class Second(ps.PulseMiddleware):
+		@override
+		async def api(
+			self,
+			*,
+			request: PulseRequest,
+			session: dict[str, Any],
+			next: Callable[[], Awaitable[ApiResponse]],
+		) -> ApiResponse:
+			order.append("second")
+			return await next()
+
+	app = ps.App(routes=[], middleware=[First(), Second()])
+
+	@app.fastapi.get("/api/hello")
+	def hello() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
+		order.append("handler")
+		return {"hello": "world"}
+
+	async with _client(app) as client:
+		response = await client.get("/api/hello")
+
+	assert response.status_code == 200
+	assert order == ["first", "second", "handler", "first-after"]
+
+
+@pytest.mark.asyncio
+async def test_api_middleware_rejects_non_response_return():
+	class BadMiddleware(ps.PulseMiddleware):
+		@override
+		async def api(
+			self,
+			*,
+			request: PulseRequest,
+			session: dict[str, Any],
+			next: Callable[[], Awaitable[ApiResponse]],
+		) -> ApiResponse:
+			return {"not": "a response"}  # type: ignore[return-value]
+
+	app = ps.App(routes=[], middleware=BadMiddleware())
+
+	@app.fastapi.get("/api/hello")
+	def hello() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
+		return {"hello": "world"}
+
+	async with _client(app) as client:
+		response = await client.get("/api/hello")
+
+	assert response.status_code == 500
+
+
+def test_latency_middleware_accepts_api_ms():
+	mw = ps.LatencyMiddleware(api_ms=10.0)
+	assert mw.api_ms == 10.0

--- a/packages/pulse/python/tests/test_middleware_api.py
+++ b/packages/pulse/python/tests/test_middleware_api.py
@@ -88,6 +88,14 @@ class PluginRoutePlugin(Plugin):
 		def plugin_route() -> dict[str, bool]:  # pyright: ignore[reportUnusedFunction]
 			return {"plugin": True}
 
+		router = APIRouter()
+
+		@router.get("/included")
+		def plugin_included() -> dict[str, bool]:  # pyright: ignore[reportUnusedFunction]
+			return {"plugin": True}
+
+		app.fastapi.include_router(router, prefix="/plugin")
+
 
 @ps.component
 def prerender_home():
@@ -184,7 +192,10 @@ async def test_api_middleware_can_catch_user_route_exceptions():
 	def boom() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
 		raise RuntimeError("user api failed")
 
-	async with _client(app) as client:
+	transport = httpx.ASGITransport(app=app.fastapi, raise_app_exceptions=False)
+	async with httpx.AsyncClient(
+		transport=transport, base_url="http://testserver"
+	) as client:
 		response = await client.get("/api/boom")
 
 	assert response.status_code == 500
@@ -244,12 +255,15 @@ async def test_api_middleware_skips_plugin_on_setup_routes():
 
 	try:
 		async with _client(app) as client:
-			response = await client.get("/plugin-route")
+			direct = await client.get("/plugin-route")
+			included = await client.get("/plugin/included")
 	finally:
 		await app.close()
 
-	assert response.status_code == 200
-	assert response.json() == {"plugin": True}
+	assert direct.status_code == 200
+	assert direct.json() == {"plugin": True}
+	assert included.status_code == 200
+	assert included.json() == {"plugin": True}
 	assert mw.paths == []
 
 
@@ -268,18 +282,28 @@ async def test_api_middleware_runs_for_user_routes_after_setup():
 	def after() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
 		return {"when": "after"}
 
+	router = APIRouter()
+
+	@router.get("/included")
+	def included() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
+		return {"when": "after-include"}
+
+	app.fastapi.include_router(router, prefix="/api")
+
 	try:
 		async with _client(app) as client:
 			before_res = await client.get("/api/before")
 			after_res = await client.get("/api/after")
+			included_res = await client.get("/api/included")
 			health = await client.get("/_pulse/health")
 	finally:
 		await app.close()
 
 	assert before_res.json() == {"when": "before"}
 	assert after_res.json() == {"when": "after"}
+	assert included_res.json() == {"when": "after-include"}
 	assert health.status_code == 200
-	assert mw.paths == ["/api/before", "/api/after"]
+	assert mw.paths == ["/api/before", "/api/after", "/api/included"]
 
 
 @pytest.mark.asyncio
@@ -361,7 +385,7 @@ async def test_api_middleware_rejects_non_response_return():
 			session: dict[str, Any],
 			next: Callable[[], Awaitable[ApiResponse]],
 		) -> ApiResponse:
-			return {"not": "a response"}  # type: ignore[return-value]
+			return {"not": "a response"}  # pyright: ignore[reportReturnType]
 
 	app = ps.App(routes=[], middleware=BadMiddleware())
 
@@ -369,7 +393,10 @@ async def test_api_middleware_rejects_non_response_return():
 	def hello() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
 		return {"hello": "world"}
 
-	async with _client(app) as client:
+	transport = httpx.ASGITransport(app=app.fastapi, raise_app_exceptions=False)
+	async with httpx.AsyncClient(
+		transport=transport, base_url="http://testserver"
+	) as client:
 		response = await client.get("/api/hello")
 
 	assert response.status_code == 500

--- a/packages/pulse/python/tests/test_middleware_api.py
+++ b/packages/pulse/python/tests/test_middleware_api.py
@@ -340,7 +340,6 @@ async def test_api_middleware_receives_session_after_setup():
 
 	assert response.status_code == 200
 	assert len(mw.sessions) == 1
-	# Session exists (cookie store mints one) even if empty at hook entry
 	assert isinstance(mw.sessions[0], dict)
 
 

--- a/packages/pulse/python/tests/test_middleware_api.py
+++ b/packages/pulse/python/tests/test_middleware_api.py
@@ -127,7 +127,7 @@ async def _client(
 @pytest.mark.asyncio
 async def test_api_middleware_runs_for_user_fastapi_routes():
 	mw = RecordingApiMiddleware()
-	app = ps.App(routes=[], middleware=mw)
+	app = ps.App(routes=[], middleware=mw, mode="subdomains")
 
 	@app.fastapi.get("/api/hello")
 	def hello() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
@@ -145,7 +145,7 @@ async def test_api_middleware_runs_for_user_fastapi_routes():
 @pytest.mark.asyncio
 async def test_api_middleware_runs_for_included_routers():
 	mw = RecordingApiMiddleware()
-	app = ps.App(routes=[], middleware=mw)
+	app = ps.App(routes=[], middleware=mw, mode="subdomains")
 	router = APIRouter()
 
 	@router.post("/items")
@@ -165,7 +165,7 @@ async def test_api_middleware_runs_for_included_routers():
 
 @pytest.mark.asyncio
 async def test_api_middleware_can_short_circuit_user_routes():
-	app = ps.App(routes=[], middleware=ShortCircuitApiMiddleware())
+	app = ps.App(routes=[], middleware=ShortCircuitApiMiddleware(), mode="subdomains")
 
 	@app.fastapi.get("/secret")
 	def secret() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
@@ -187,7 +187,7 @@ async def test_api_middleware_can_short_circuit_user_routes():
 
 @pytest.mark.asyncio
 async def test_api_middleware_can_modify_response_headers():
-	app = ps.App(routes=[], middleware=HeaderApiMiddleware())
+	app = ps.App(routes=[], middleware=HeaderApiMiddleware(), mode="subdomains")
 
 	@app.fastapi.get("/api/hello")
 	def hello() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
@@ -203,7 +203,7 @@ async def test_api_middleware_can_modify_response_headers():
 @pytest.mark.asyncio
 async def test_api_middleware_can_catch_user_route_exceptions():
 	mw = ErrorReportingApiMiddleware()
-	app = ps.App(routes=[], middleware=mw)
+	app = ps.App(routes=[], middleware=mw, mode="subdomains")
 
 	@app.fastapi.get("/api/boom")
 	def boom() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
@@ -373,7 +373,7 @@ async def test_api_middleware_stack_runs_in_order():
 			order.append("second")
 			return await next()
 
-	app = ps.App(routes=[], middleware=[First(), Second()])
+	app = ps.App(routes=[], middleware=[First(), Second()], mode="subdomains")
 
 	@app.fastapi.get("/api/hello")
 	def hello() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
@@ -400,7 +400,7 @@ async def test_api_middleware_rejects_non_response_return():
 		) -> ApiResponse:
 			return {"not": "a response"}  # pyright: ignore[reportReturnType]
 
-	app = ps.App(routes=[], middleware=BadMiddleware())
+	app = ps.App(routes=[], middleware=BadMiddleware(), mode="subdomains")
 
 	@app.fastapi.get("/api/hello")
 	def hello() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]

--- a/packages/pulse/python/tests/test_middleware_api.py
+++ b/packages/pulse/python/tests/test_middleware_api.py
@@ -1,4 +1,5 @@
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
 from typing import Any, override
 
 import httpx
@@ -6,6 +7,7 @@ import pulse as ps
 import pytest
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
+from pulse.context import PulseContext
 from pulse.middleware import ApiResponse
 from pulse.plugin import Plugin
 from pulse.request import PulseRequest
@@ -102,9 +104,18 @@ def prerender_home():
 	return ps.div("ok")
 
 
-def _client(app: ps.App) -> httpx.AsyncClient:
-	transport = httpx.ASGITransport(app=app.fastapi)
-	return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+@asynccontextmanager
+async def _client(
+	app: ps.App, *, raise_app_exceptions: bool = True
+) -> AsyncIterator[httpx.AsyncClient]:
+	transport = httpx.ASGITransport(
+		app=app.fastapi, raise_app_exceptions=raise_app_exceptions
+	)
+	with PulseContext(app=app):
+		async with httpx.AsyncClient(
+			transport=transport, base_url="http://testserver"
+		) as client:
+			yield client
 
 
 @pytest.mark.asyncio
@@ -192,10 +203,7 @@ async def test_api_middleware_can_catch_user_route_exceptions():
 	def boom() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
 		raise RuntimeError("user api failed")
 
-	transport = httpx.ASGITransport(app=app.fastapi, raise_app_exceptions=False)
-	async with httpx.AsyncClient(
-		transport=transport, base_url="http://testserver"
-	) as client:
+	async with _client(app, raise_app_exceptions=False) as client:
 		response = await client.get("/api/boom")
 
 	assert response.status_code == 500
@@ -243,7 +251,7 @@ async def test_api_middleware_skips_pulse_framework_and_docs_routes():
 
 
 @pytest.mark.asyncio
-async def test_api_middleware_skips_plugin_on_setup_routes():
+async def test_api_middleware_runs_for_plugin_on_setup_routes():
 	mw = RecordingApiMiddleware()
 	app = ps.App(
 		routes=[],
@@ -264,7 +272,7 @@ async def test_api_middleware_skips_plugin_on_setup_routes():
 	assert direct.json() == {"plugin": True}
 	assert included.status_code == 200
 	assert included.json() == {"plugin": True}
-	assert mw.paths == []
+	assert mw.paths == ["/plugin-route", "/plugin/included"]
 
 
 @pytest.mark.asyncio
@@ -393,10 +401,7 @@ async def test_api_middleware_rejects_non_response_return():
 	def hello() -> dict[str, str]:  # pyright: ignore[reportUnusedFunction]
 		return {"hello": "world"}
 
-	transport = httpx.ASGITransport(app=app.fastapi, raise_app_exceptions=False)
-	async with httpx.AsyncClient(
-		transport=transport, base_url="http://testserver"
-	) as client:
+	async with _client(app, raise_app_exceptions=False) as client:
 		response = await client.get("/api/hello")
 
 	assert response.status_code == 500

--- a/packages/pulse/python/tests/test_middleware_api.py
+++ b/packages/pulse/python/tests/test_middleware_api.py
@@ -7,7 +7,7 @@ import pulse as ps
 import pytest
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
-from pulse.context import PulseContext
+from pulse.app import AppStatus
 from pulse.middleware import ApiResponse
 from pulse.plugin import Plugin
 from pulse.request import PulseRequest
@@ -108,14 +108,20 @@ def prerender_home():
 async def _client(
 	app: ps.App, *, raise_app_exceptions: bool = True
 ) -> AsyncIterator[httpx.AsyncClient]:
+	owns_setup = app.status < AppStatus.initialized
+	if owns_setup:
+		app.setup("http://testserver")
 	transport = httpx.ASGITransport(
 		app=app.fastapi, raise_app_exceptions=raise_app_exceptions
 	)
-	with PulseContext(app=app):
+	try:
 		async with httpx.AsyncClient(
 			transport=transport, base_url="http://testserver"
 		) as client:
 			yield client
+	finally:
+		if owns_setup:
+			await app.close()
 
 
 @pytest.mark.asyncio

--- a/skills/pulse/references/middleware.md
+++ b/skills/pulse/references/middleware.md
@@ -348,7 +348,7 @@ Adds artificial latency for testing:
 ```python
 app = ps.App(
     routes=[...],
-    middleware=[ps.LatencyMiddleware()],  # Dev only
+    middleware=[ps.LatencyMiddleware()],  # Dev only; includes api_ms
 )
 ```
 

--- a/skills/pulse/references/middleware.md
+++ b/skills/pulse/references/middleware.md
@@ -122,7 +122,7 @@ async def prerender(
 
 ### `api`
 
-Called only for FastAPI routes you registered on `app.fastapi` (including included routers). Does **not** run for `/_pulse/*` (prerender, health, forms), generated docs, plugin `on_setup` routes, or the React proxy.
+Called only for FastAPI routes you registered on `app.fastapi` (including included routers). Does **not** run for `/_pulse/*` (prerender, health, forms), generated docs, or the React proxy.
 
 Use this instead of FastAPI HTTP middleware when you need to log, auth, or report errors for your API without also catching prerender.
 

--- a/skills/pulse/references/middleware.md
+++ b/skills/pulse/references/middleware.md
@@ -46,6 +46,21 @@ class AuthMiddleware(ps.PulseMiddleware):
         return await next()
 
     @override
+    async def api(
+        self,
+        *,
+        request: PulseRequest,
+        session: dict,
+        next,
+    ):
+        # User-defined FastAPI routes only (not prerender or /_pulse/*)
+        try:
+            return await next()
+        except Exception as exc:
+            report_user_api_error(exc, request)
+            raise
+
+    @override
     async def message(
         self,
         *,
@@ -104,6 +119,37 @@ async def prerender(
 - `routeInfo`: Route metadata (params, query, etc.)
 - `ttlSeconds`: Optional cache TTL
 - `renderId`: Optional render correlation ID
+
+### `api`
+
+Called only for FastAPI routes you registered on `app.fastapi` (including included routers). Does **not** run for `/_pulse/*` (prerender, health, forms), generated docs, plugin `on_setup` routes, or the React proxy.
+
+Use this instead of FastAPI HTTP middleware when you need to log, auth, or report errors for your API without also catching prerender.
+
+```python
+from fastapi.responses import JSONResponse
+
+@override
+async def api(
+    self,
+    *,
+    request: PulseRequest,
+    session: dict,
+    next,
+) -> ps.ApiResponse:
+    if request.path.startswith("/api/admin") and not session.get("is_admin"):
+        return JSONResponse({"detail": "forbidden"}, status_code=403)
+
+    try:
+        response = await next()
+    except Exception as exc:
+        report_user_api_error(exc, request)
+        raise
+
+    return response
+```
+
+**Returns:** the HTTP `Response` from `await next()`, or a replacement response.
 
 ### `connect`
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add `PulseMiddleware.api` so error-reporting / auth / logging middleware can wrap **user-defined FastAPI routes only**, without also catching Pulse prerender, `/_pulse/*` built-ins, generated docs, or the React proxy.

FastAPI HTTP middleware wraps everything. A prerender exception would get reported there **and** via `render.report_error`. This hook is the route-class seam instead.

```python
async def api(self, *, request: PulseRequest, session: dict, next) -> Response:
    return await next()
```

`next()` is the FastAPI route handler and returns a Starlette/FastAPI `Response`. Exceptions propagate. App comes from `PulseContext` (`PULSE_CONTEXT.get()`). The hook no-ops if context is unset **or** `ctx.session` is unset (raw FastAPI / session_middleware hasn't run). After `App.setup()`, session_middleware always mounts a `UserSession` before the route; `session` is that `session.data`. No throwaway `{}`.

### Wiring

- **`PulseAPIRoute`**: unwraps reactive return values + wraps `get_route_handler` with `middleware.api`
- **`PulseFrameworkAPIRoute`**: unwrap only, no `api` hook
- **`PulseAPIRouter.add_api_route`**: `include_router` copies with `route_class_override=type(source)`. Drop that override unless the source is a Pulse framework route, so stock user `APIRouter()`s become `PulseAPIRoute`
- **`PulseFastAPI`**: after `super().__init__()`, `self.router.__class__ = PulseAPIRouter` and `self.router.route_class = PulseAPIRoute`
- Pulse built-ins (`/_pulse/health`, `set-cookies`, `prerender`, forms) live on a separate `APIRouter(route_class=PulseFrameworkAPIRoute, include_in_schema=False)`
- Docs/OpenAPI are stock Starlette `Route`s; React proxy is a `Mount` — never wrapped
- Plugin `on_setup` `@app.fastapi.get` routes **do** hit `api`

Route/router classes live in `packages/pulse/python/src/pulse/api_router.py`. Reactive unwrap is applied to `dependant.call` after `APIRoute` init, so `route.endpoint` stays the user function and `include_router` copies do not stack wrappers.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a44d5d5-7bf7-4373-8c85-e2c8c6eb8451?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a44d5d5-7bf7-4373-8c85-e2c8c6eb8451&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

