### PR TITLE
Release Pulse 0.1.112

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -163,7 +163,7 @@
     },
     "packages/pulse/js": {
       "name": "pulse-ui-client",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "dependencies": {
         "socket.io-client": "^4.8.1",
         "ws": "^8.18.3",

--- a/packages/pulse/js/package.json
+++ b/packages/pulse/js/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pulse-ui-client",
-	"version": "0.1.111",
+	"version": "0.1.112",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/erwinkn/pulse-ui",

--- a/packages/pulse/python/pyproject.toml
+++ b/packages/pulse/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pulse-framework"
-version = "0.1.111"
+version = "0.1.112"
 description = "Pulse - Full-stack framework for building real-time React applications in Python"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1323,7 +1323,7 @@ requires-dist = [
 
 [[package]]
 name = "pulse-framework"
-version = "0.1.111"
+version = "0.1.112"
 source = { editable = "packages/pulse/python" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Patch release of `pulse-framework` / `pulse-ui-client` **0.1.111 → 0.1.112**.

Ships `PulseMiddleware.api` from #141 so user-defined FastAPI routes can be wrapped without intercepting prerender, `/_pulse/*`, docs, or the React proxy.

Version files only: `packages/pulse/python/pyproject.toml`, `packages/pulse/js/package.json`, `uv.lock`, `bun.lock`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a44d5d5-7bf7-4373-8c85-e2c8c6eb8451?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a44d5d5-7bf7-4373-8c85-e2c8c6eb8451&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

