### PR TITLE
Dispose unused ps.state instances at render end

### DIFF
--- a/docs/content/docs/(core)/advanced/custom-hooks.mdx
+++ b/docs/content/docs/(core)/advanced/custom-hooks.mdx
@@ -59,7 +59,7 @@ The `HookState` base class provides three lifecycle methods you can override:
 | Method | When it runs | Use case |
 |--------|--------------|----------|
 | `on_render_start(render_cycle)` | Before each render | Reset per-render state, start measurements |
-| `on_render_end(render_cycle)` | After each render | Finalize calculations, trigger side effects |
+| `on_render_end(render_cycle, error)` | After each render, even a failed one (`error` is the exception, or `None` on success) | Finalize calculations, trigger side effects |
 | `dispose()` | When component unmounts | Clean up resources, cancel subscriptions |
 
 ```python
@@ -73,7 +73,7 @@ class RenderCounterState(ps.hooks.State):
         self._render_start = time.time()
         self.total_renders = render_cycle
 
-    def on_render_end(self, render_cycle: int) -> None:
+    def on_render_end(self, render_cycle: int, error: BaseException | None) -> None:
         self.last_render_duration = time.time() - self._render_start
 
     def dispose(self) -> None:

--- a/docs/content/docs/reference/pulse/hooks.mdx
+++ b/docs/content/docs/reference/pulse/hooks.mdx
@@ -57,6 +57,7 @@ def user_profile(user_id):
 - Can only be called once per render at the same location or with the same key
 - Factory is only called on first render; subsequent renders return cached instance
 - State is disposed when the component unmounts, the key changes, or the call is skipped (e.g. a false conditional)
+- A render that raises disposes nothing: it only reached part of its `ps.state` calls
 
 ---
 
@@ -609,7 +610,7 @@ Base class for hook state. Override lifecycle methods:
 ```python
 class HookState(Disposable):
     def on_render_start(self, render_cycle: int) -> None: ...
-    def on_render_end(self, render_cycle: int) -> None: ...
+    def on_render_end(self, render_cycle: int, error: BaseException | None) -> None: ...
     def dispose(self) -> None: ...
 ```
 

--- a/docs/content/docs/reference/pulse/hooks.mdx
+++ b/docs/content/docs/reference/pulse/hooks.mdx
@@ -56,7 +56,7 @@ def user_profile(user_id):
 - Key must be non-empty string if provided
 - Can only be called once per render at the same location or with the same key
 - Factory is only called on first render; subsequent renders return cached instance
-- State is disposed when component unmounts or when key changes
+- State is disposed when the component unmounts, the key changes, or the call is skipped (e.g. a false conditional)
 
 ---
 

--- a/packages/pulse/python/src/pulse/forms.py
+++ b/packages/pulse/python/src/pulse/forms.py
@@ -682,7 +682,7 @@ class FormStorage(HookState):
 		self.render_mark = render_cycle
 
 	@override
-	def on_render_end(self, render_cycle: int) -> None:
+	def on_render_end(self, render_cycle: int, error: BaseException | None) -> None:
 		if not self.prev_forms:
 			return
 		for form in self.prev_forms.values():

--- a/packages/pulse/python/src/pulse/forms.py
+++ b/packages/pulse/python/src/pulse/forms.py
@@ -685,6 +685,15 @@ class FormStorage(HookState):
 	def on_render_end(self, render_cycle: int, error: BaseException | None) -> None:
 		if not self.prev_forms:
 			return
+		if error is not None:
+			# The render stopped at the raise, so forms it never re-registered are
+			# still live and still displayed by the client. Adopt them as current
+			# instead of disposing them, which would deregister them server-side
+			# and break submits until the next successful render.
+			for key, form in self.prev_forms.items():
+				self.forms[key] = form
+			self.prev_forms.clear()
+			return
 		for form in self.prev_forms.values():
 			form.dispose()
 		self.prev_forms.clear()

--- a/packages/pulse/python/src/pulse/hooks/core.py
+++ b/packages/pulse/python/src/pulse/hooks/core.py
@@ -88,11 +88,14 @@ class HookState(Disposable):
 		"""
 		self.render_cycle = render_cycle
 
-	def on_render_end(self, render_cycle: int) -> None:
+	def on_render_end(self, render_cycle: int, error: BaseException | None) -> None:
 		"""Called after the component render has completed.
 
 		Args:
 			render_cycle: The current render cycle number.
+			error: Exception that aborted the render, or None if it succeeded.
+				A failed render only reached part of its hook calls, so
+				per-render bookkeeping must not be treated as complete.
 		"""
 		...
 
@@ -186,9 +189,9 @@ class HookNamespace(Generic[T]):
 		for state in self.states.values():
 			state.on_render_start(render_cycle)
 
-	def on_render_end(self, render_cycle: int):
+	def on_render_end(self, render_cycle: int, error: BaseException | None):
 		for state in self.states.values():
-			state.on_render_end(render_cycle)
+			state.on_render_end(render_cycle, error)
 
 	def ensure(self, ctx: "HookContext", key: str | None) -> T:
 		normalized = self._normalize_key(key)
@@ -262,7 +265,7 @@ class HookContext:
 			HOOK_CONTEXT.reset(self._token)
 			self._token = None
 			for namespace in self.namespaces.values():
-				namespace.on_render_end(self.render_cycle)
+				namespace.on_render_end(self.render_cycle, exc_val)
 		return False
 
 	def namespace_for(self, hook: Hook[T]) -> HookNamespace[T]:

--- a/packages/pulse/python/src/pulse/hooks/effects.py
+++ b/packages/pulse/python/src/pulse/hooks/effects.py
@@ -26,8 +26,8 @@ class EffectState(HookState):
 		self._seen_this_render.clear()
 
 	@override
-	def on_render_end(self, render_cycle: int) -> None:
-		super().on_render_end(render_cycle)
+	def on_render_end(self, render_cycle: int, error: BaseException | None) -> None:
+		super().on_render_end(render_cycle, error)
 		# Dispose effects that weren't seen this render (e.g., inside conditionals that became false)
 		for key in list(self.effects.keys()):
 			if key not in self._seen_this_render:

--- a/packages/pulse/python/src/pulse/hooks/effects.py
+++ b/packages/pulse/python/src/pulse/hooks/effects.py
@@ -28,12 +28,19 @@ class EffectState(HookState):
 	@override
 	def on_render_end(self, render_cycle: int, error: BaseException | None) -> None:
 		super().on_render_end(render_cycle, error)
-		# Dispose effects that weren't seen this render (e.g., inside conditionals that became false)
-		for key in list(self.effects.keys()):
-			if key not in self._seen_this_render:
-				self.effects[key].dispose()
-				del self.effects[key]
+		# Dispose effects that weren't seen this render (e.g., inside conditionals
+		# that became false). A failed render stopped at the raise, so effects
+		# declared after that point are unseen but still live: keep them all and
+		# let the next successful render decide. `_seen_this_render` is rebuilt on
+		# render start, so the partial set never leaks into that decision.
+		if error is None:
+			for key in list(self.effects.keys()):
+				if key not in self._seen_this_render:
+					self.effects[key].dispose()
+					del self.effects[key]
 		# Remove inline effects from the active render scope to avoid parent cleanup.
+		# Effects created before a failure need this too, else the render scope
+		# disposes them while they stay cached here.
 		rc = REACTIVE_CONTEXT.get()
 		scope = rc.scope
 		if scope is None or not scope.effects:

--- a/packages/pulse/python/src/pulse/hooks/state.py
+++ b/packages/pulse/python/src/pulse/hooks/state.py
@@ -39,8 +39,9 @@ class StateHookState(HookState):
 	@override
 	def on_render_end(self, render_cycle: int) -> None:
 		super().on_render_end(render_cycle)
-		# Dispose states that weren't seen this render (key change, or a
-		# conditional that became false). Mirrors EffectState.
+		# Unseen keys only, and only here. Mid-render `called_keys` is "reached
+		# so far", not "live this render" — evicting then would dispose a key
+		# reused later in a loop, or an unkeyed sibling after a keyed replacement.
 		for key in list(self.instances.keys()):
 			if key in self.called_keys:
 				continue

--- a/packages/pulse/python/src/pulse/hooks/state.py
+++ b/packages/pulse/python/src/pulse/hooks/state.py
@@ -37,8 +37,14 @@ class StateHookState(HookState):
 		self.called_keys.clear()
 
 	@override
-	def on_render_end(self, render_cycle: int) -> None:
-		super().on_render_end(render_cycle)
+	def on_render_end(self, render_cycle: int, error: BaseException | None) -> None:
+		super().on_render_end(render_cycle, error)
+		# A failed render stopped at the raise, so `called_keys` is a partial set:
+		# keys after the failure point are still live. Keep every instance; the
+		# next successful render decides. `called_keys` is rebuilt from scratch on
+		# render start, so the partial set never leaks into that decision.
+		if error is not None:
+			return
 		# Unseen keys only, and only here. Mid-render `called_keys` is "reached
 		# so far", not "live this render" — evicting then would dispose a key
 		# reused later in a loop, or an unkeyed sibling after a keyed replacement.

--- a/packages/pulse/python/src/pulse/hooks/state.py
+++ b/packages/pulse/python/src/pulse/hooks/state.py
@@ -36,6 +36,22 @@ class StateHookState(HookState):
 		super().on_render_start(render_cycle)
 		self.called_keys.clear()
 
+	@override
+	def on_render_end(self, render_cycle: int) -> None:
+		super().on_render_end(render_cycle)
+		# Dispose states that weren't seen this render (key change, or a
+		# conditional that became false). Mirrors EffectState.
+		for key in list(self.instances.keys()):
+			if key in self.called_keys:
+				continue
+			instance = self.instances.pop(key)
+			if instance.__disposed__:
+				continue
+			try:
+				instance.dispose()
+			except RuntimeError:
+				pass
+
 	def get_or_create_state(
 		self,
 		identity: Any,
@@ -160,7 +176,8 @@ def state(
 		- Key must be non-empty string
 		- Can only be called once per render with the same key
 		- Factory is only called on first render; subsequent renders return cached instance
-		- State is disposed when component unmounts
+		- State is disposed when the component unmounts, the key changes, or
+		  the call is skipped (e.g. a false conditional)
 	"""
 	if key is not None and not isinstance(key, str):
 		raise TypeError("state() key must be a string")

--- a/packages/pulse/python/src/pulse/state/query_param.py
+++ b/packages/pulse/python/src/pulse/state/query_param.py
@@ -350,6 +350,10 @@ class QueryParamProperty(StateProperty):
 
 	@override
 	def _get_signal(self, obj: Any) -> Signal[Any]:
+		# Slots are session-owned and outlive the states bound to them, so a
+		# disposed state still reads and writes the live slot. Same as a plain
+		# StateProperty, whose Signal also survives disposal: disposal releases
+		# effects, it does not poison attribute access.
 		ctx = PulseContext.get()
 		if ctx.render is None:
 			raise RuntimeError(

--- a/packages/pulse/python/tests/test_forms.py
+++ b/packages/pulse/python/tests/test_forms.py
@@ -5,7 +5,13 @@ import httpx
 import pulse as ps
 import pytest
 from pulse import forms
+from pulse.forms import internal_forms_hook
+from pulse.hooks.core import HookContext
+from pulse.reactive import Signal
+from pulse.render_session import RenderSession
+from pulse.routing import Route, RouteContext, RouteInfo, RouteTree
 from pulse.serializer import serialize
+from pulse.user_session import UserSession
 from starlette.datastructures import FormData as StarletteFormData
 from starlette.datastructures import UploadFile
 
@@ -176,3 +182,107 @@ async def test_invalid_structured_form_payload_returns_400(
 		assert not submitted
 	finally:
 		await app.close()
+
+
+def make_form_context():
+	@ps.component
+	def Page():
+		return ps.div()
+
+	route = Route("/", Page)
+	render = RenderSession(
+		"test", RouteTree([route]), server_address="http://testserver"
+	)
+	app = ps.App(routes=[route])
+	route_info: RouteInfo = {
+		"pathname": "/",
+		"hash": "",
+		"query": "",
+		"queryParams": {},
+		"pathParams": {},
+		"catchall": [],
+	}
+	route_ctx = RouteContext(route_info, route, render)
+	session = UserSession("test-session", {}, app)
+	return app, render, session, route_ctx
+
+
+async def noop_submit(_data: forms.FormData) -> None:
+	return None
+
+
+def test_form_survives_failed_render():
+	"""A render that raises before ps.Form must keep the form registered."""
+	app, render, session, route_ctx = make_form_context()
+	ctx = HookContext()
+	fail = Signal(False)
+	instances: list[forms.ManualForm] = []
+
+	@ps.component
+	def Comp():
+		if fail():
+			raise RuntimeError("transient")
+		node = ps.Form(key="f", onSubmit=noop_submit)
+		instances.append(internal_forms_hook().forms["f"])
+		return node
+
+	with ps.PulseContext(app=app, session=session, render=render, route=route_ctx):
+		with ctx:
+			Comp.fn()  # type: ignore[attr-defined]
+		first = instances[0]
+		registration_id = first.registration.id
+
+		fail.write(True)
+		with pytest.raises(RuntimeError, match="transient"), ctx:
+			Comp.fn()  # type: ignore[attr-defined]
+
+		# Client still displays the form, so its handler must stay registered.
+		assert registration_id in render.forms._handlers  # pyright: ignore[reportPrivateUsage]
+
+		fail.write(False)
+		with ctx:
+			Comp.fn()  # type: ignore[attr-defined]
+
+		assert instances[1] is first
+		assert first.registration.id == registration_id
+
+	session.dispose()
+
+
+def test_form_disposed_by_first_successful_render_after_failure():
+	"""A form genuinely dropped by the next successful render is still disposed."""
+	app, render, session, route_ctx = make_form_context()
+	ctx = HookContext()
+	fail = Signal(False)
+	show = Signal(True)
+	instances: list[forms.ManualForm] = []
+
+	@ps.component
+	def Comp():
+		if fail():
+			raise RuntimeError("transient")
+		if not show():
+			return ps.div()
+		node = ps.Form(key="f", onSubmit=noop_submit)
+		instances.append(internal_forms_hook().forms["f"])
+		return node
+
+	with ps.PulseContext(app=app, session=session, render=render, route=route_ctx):
+		with ctx:
+			Comp.fn()  # type: ignore[attr-defined]
+		registration_id = instances[0].registration.id
+
+		fail.write(True)
+		with pytest.raises(RuntimeError, match="transient"), ctx:
+			Comp.fn()  # type: ignore[attr-defined]
+
+		fail.write(False)
+		show.write(False)
+		with ctx:
+			Comp.fn()  # type: ignore[attr-defined]
+
+		assert registration_id not in render.forms._handlers  # pyright: ignore[reportPrivateUsage]
+		with pytest.raises(ValueError, match="disposed"):
+			_ = instances[0].registration
+
+	session.dispose()

--- a/packages/pulse/python/tests/test_hooks.py
+++ b/packages/pulse/python/tests/test_hooks.py
@@ -226,14 +226,18 @@ def test_state_key_change_keeps_unkeyed_sibling():
 	ctx = HookContext()
 	item_id = Signal("1")
 
-	with ctx:
+	@ps.component
+	def Comp():
 		keyed = state(DummyState, key=item_id())
 		unkeyed = state(DummyState)
+		return keyed, unkeyed
+
+	with ctx:
+		keyed, unkeyed = Comp.fn()  # type: ignore[attr-defined]
 
 	item_id.write("2")
 	with ctx:
-		keyed2 = state(DummyState, key=item_id())
-		unkeyed2 = state(DummyState)
+		keyed2, unkeyed2 = Comp.fn()  # type: ignore[attr-defined]
 
 	assert keyed2 is not keyed
 	assert keyed.dispose_calls == 1

--- a/packages/pulse/python/tests/test_hooks.py
+++ b/packages/pulse/python/tests/test_hooks.py
@@ -193,6 +193,54 @@ def test_state_creates_different_instances_for_different_keys():
 	assert second.dispose_calls == 0
 
 
+def test_state_loop_key_reorder_keeps_surviving_key():
+	"""[a,b] → [c,a] must keep `a`. Mid-render eviction would kill it when creating `c`."""
+	ctx = HookContext()
+	items = Signal(["a", "b"])
+	seen: dict[str, DummyState] = {}
+
+	@ps.component
+	def Comp():
+		for item in items():
+			seen[item] = state(lambda i=item: DummyState(), key=item)
+		return None
+
+	with ctx:
+		Comp.fn()  # type: ignore[attr-defined]
+	first_a = seen["a"]
+	first_b = seen["b"]
+
+	items.write(["c", "a"])
+	with ctx:
+		Comp.fn()  # type: ignore[attr-defined]
+
+	assert seen["a"] is first_a
+	assert first_a.dispose_calls == 0
+	assert first_b.dispose_calls == 1
+	assert seen["c"] is not first_a
+	assert seen["c"].dispose_calls == 0
+
+
+def test_state_key_change_keeps_unkeyed_sibling():
+	"""Keyed replacement must not dispose an unkeyed sibling called later in the same render."""
+	ctx = HookContext()
+	item_id = Signal("1")
+
+	with ctx:
+		keyed = state(DummyState, key=item_id())
+		unkeyed = state(DummyState)
+
+	item_id.write("2")
+	with ctx:
+		keyed2 = state(DummyState, key=item_id())
+		unkeyed2 = state(DummyState)
+
+	assert keyed2 is not keyed
+	assert keyed.dispose_calls == 1
+	assert unkeyed2 is unkeyed
+	assert unkeyed.dispose_calls == 0
+
+
 def test_state_disposes_direct_instances():
 	ctx = HookContext()
 

--- a/packages/pulse/python/tests/test_hooks.py
+++ b/packages/pulse/python/tests/test_hooks.py
@@ -189,7 +189,8 @@ def test_state_creates_different_instances_for_different_keys():
 		second = state(DummyState, key="b")
 
 	assert first is not second
-	assert first.dispose_calls == 0  # States not disposed on key change
+	assert first.dispose_calls == 1
+	assert second.dispose_calls == 0
 
 
 def test_state_disposes_direct_instances():
@@ -306,7 +307,7 @@ def test_state_disposes_all_on_unmount():
 	assert state_c.dispose_calls == 1
 
 
-def test_state_kept_when_not_called_in_render():
+def test_state_disposed_when_not_called_in_render():
 	ctx = HookContext()
 	flag = Signal(True)
 	states: list[DummyState] = []
@@ -329,8 +330,9 @@ def test_state_kept_when_not_called_in_render():
 		Comp.fn()  # type: ignore[attr-defined]
 
 	assert len(states) == 2
-	assert states[0] is states[1]
-	assert states[0].dispose_calls == 0
+	assert states[0] is not states[1]
+	assert states[0].dispose_calls == 1
+	assert states[1].dispose_calls == 0
 
 
 def test_state_branch_disambiguation_with_key():
@@ -356,7 +358,7 @@ def test_state_branch_disambiguation_with_key():
 	assert left is not None
 	assert right is not None
 	assert left is not right
-	assert left.dispose_calls == 0
+	assert left.dispose_calls == 1
 	assert right.dispose_calls == 0
 
 

--- a/packages/pulse/python/tests/test_hooks.py
+++ b/packages/pulse/python/tests/test_hooks.py
@@ -28,6 +28,10 @@ class DummyState(State):
 		return self._dispose_calls
 
 
+class CountingState(DummyState):
+	count: int = 0
+
+
 def make_route_info(
 	pathname: str, *, query_params: dict[str, str] | None = None, hash: str = ""
 ) -> RouteInfo:
@@ -243,6 +247,77 @@ def test_state_key_change_keeps_unkeyed_sibling():
 	assert keyed.dispose_calls == 1
 	assert unkeyed2 is unkeyed
 	assert unkeyed.dispose_calls == 0
+
+
+def test_state_survives_failed_render_and_recovery():
+	"""A render that raises before its `ps.state` call must not evict the state."""
+	ctx = HookContext()
+	fail = Signal(False)
+	seen: list[CountingState] = []
+
+	@ps.component
+	def Comp():
+		if fail():
+			raise RuntimeError("transient")
+		instance = state(CountingState, key="k")
+		seen.append(instance)
+		return None
+
+	with ctx:
+		Comp.fn()  # type: ignore[attr-defined]
+	first = seen[0]
+	first.count = 5
+
+	fail.write(True)
+	with pytest.raises(RuntimeError, match="transient"), ctx:
+		Comp.fn()  # type: ignore[attr-defined]
+
+	assert first.dispose_calls == 0
+
+	fail.write(False)
+	with ctx:
+		Comp.fn()  # type: ignore[attr-defined]
+
+	assert seen[1] is first
+	assert first.count == 5
+	assert first.dispose_calls == 0
+
+
+def test_state_evicted_by_first_successful_render_after_failure():
+	"""A failed render's partial seen-set must not skew the next successful render."""
+	ctx = HookContext()
+	keys = Signal(["a", "b"])
+	fail = Signal(False)
+	seen: dict[str, DummyState] = {}
+
+	@ps.component
+	def Comp():
+		for key in keys():
+			seen[key] = state(DummyState, key=key)
+			if fail() and key == "a":
+				raise RuntimeError("transient")
+		return None
+
+	with ctx:
+		Comp.fn()  # type: ignore[attr-defined]
+	first_a = seen["a"]
+	first_b = seen["b"]
+
+	fail.write(True)
+	with pytest.raises(RuntimeError, match="transient"), ctx:
+		Comp.fn()  # type: ignore[attr-defined]
+
+	assert first_a.dispose_calls == 0
+	assert first_b.dispose_calls == 0
+
+	fail.write(False)
+	keys.write(["a"])
+	with ctx:
+		Comp.fn()  # type: ignore[attr-defined]
+
+	assert seen["a"] is first_a
+	assert first_a.dispose_calls == 0
+	assert first_b.dispose_calls == 1
 
 
 def test_state_disposes_direct_instances():

--- a/packages/pulse/python/tests/test_inline_effects.py
+++ b/packages/pulse/python/tests/test_inline_effects.py
@@ -705,6 +705,89 @@ class TestEdgeCases:
 
 		assert runs == [0]  # Effect did NOT run again
 
+	def test_effect_after_raise_point_survives_failed_render(self):
+		"""A render that raises must not dispose effects declared after the raise."""
+		runs: list[int] = []
+		effects: list[Effect] = []
+		fail = Signal(False)
+		counter = Signal(0)
+
+		@ps.component
+		def Comp():
+			if fail():
+				raise RuntimeError("transient")
+
+			@ps.effect(immediate=True)
+			def my_effect():
+				runs.append(counter())
+
+			effects.append(my_effect)
+			return None
+
+		ctx = HookContext()
+		with ctx:
+			Comp.fn()
+
+		assert runs == [0]
+		first = effects[0]
+
+		fail.write(True)
+		with pytest.raises(RuntimeError, match="transient"), ctx:
+			Comp.fn()
+
+		assert not first.__disposed__
+
+		# Still live: dependency changes keep triggering it during the failure window.
+		with Batch():
+			counter.write(1)
+
+		assert runs == [0, 1]
+
+		fail.write(False)
+		with ctx:
+			Comp.fn()
+
+		assert effects[1] is first
+		assert not first.__disposed__
+
+	def test_effect_disposed_by_first_successful_render_after_failure(self):
+		"""A failed render's partial seen-set must not skew the next successful render."""
+		cleanups: list[str] = []
+		fail = Signal(False)
+		show = Signal(True)
+
+		@ps.component
+		def Comp():
+			if fail():
+				raise RuntimeError("transient")
+			if show():
+
+				@ps.effect(immediate=True)
+				def my_effect():
+					def cleanup():
+						cleanups.append("disposed")
+
+					return cleanup
+
+			return None
+
+		ctx = HookContext()
+		with ctx:
+			Comp.fn()
+
+		fail.write(True)
+		with pytest.raises(RuntimeError, match="transient"), ctx:
+			Comp.fn()
+
+		assert cleanups == []
+
+		fail.write(False)
+		show.write(False)
+		with ctx:
+			Comp.fn()
+
+		assert cleanups == ["disposed"]
+
 	def test_effect_with_closure_captures_current_values(self):
 		captured: list[int] = []
 

--- a/packages/pulse/python/tests/test_query_param.py
+++ b/packages/pulse/python/tests/test_query_param.py
@@ -424,6 +424,27 @@ class TestQueryParam:
 		with ps.PulseContext(app=app, render=session, route=route_ctx):
 			assert second.q == ""
 
+	def test_disposed_state_still_uses_session_owned_slot(self):
+		"""Pinned: slots outlive states, so a disposed state reads/writes the live slot."""
+
+		class QState(ps.State):
+			q: ps.QueryParam[str] = ""
+
+		app, session, route_ctx = make_context(make_route_info("/", query_params={}))
+		session.connect(lambda _msg: None)
+		ctx = HookContext()
+		with ps.PulseContext(app=app, render=session, route=route_ctx):
+			with ctx:
+				stale = ps.state(QState, key="1")
+			with ctx:
+				live = ps.state(QState, key="2")
+
+			assert stale.__disposed__
+			live.q = "from-live"
+			assert stale.q == "from-live"
+			stale.q = "from-stale"
+			assert live.q == "from-stale"
+
 	def test_state_key_change_disposes_eager_query_param_instance(self):
 		class QState(ps.State):
 			q: ps.QueryParam[str] = ""

--- a/packages/pulse/python/tests/test_query_param.py
+++ b/packages/pulse/python/tests/test_query_param.py
@@ -424,6 +424,25 @@ class TestQueryParam:
 		assert len(bindings) == 1
 		assert bindings[0].state is second
 
+	def test_state_key_change_disposes_eager_query_param_instance(self):
+		class QState(ps.State):
+			q: ps.QueryParam[str] = ""
+
+		app, session, route_ctx = make_context(make_route_info("/", query_params={}))
+		session.connect(lambda _msg: None)
+		ctx = HookContext()
+		with ps.PulseContext(app=app, render=session, route=route_ctx):
+			with ctx:
+				first = ps.state(QState(), key="1")
+			with ctx:
+				second = ps.state(QState(), key="2")
+
+		assert first.__disposed__
+		assert not second.__disposed__
+		bindings = session.query_param_sync._bindings["q"]  # pyright: ignore[reportPrivateUsage]
+		assert len(bindings) == 1
+		assert bindings[0].state is second
+
 	def test_path_id_state_key_does_not_collide(self):
 		"""Same mount, new path id: keyed ps.state must release the old binding."""
 
@@ -456,15 +475,11 @@ class TestQueryParam:
 
 		with ps.PulseContext(app=app, render=session):
 			session.prerender([mount_path], info("1"))
-		mount = session.route_mounts[mount_path]
 		assert len(created) == 1
 		first = created[0]
 
-		if mount.effect is not None:
-			mount.effect.pause()
-		with ps.PulseContext(app=app, render=session, route=mount.route):
-			mount.route.info.update(info("2"))
-			mount.tree.rerender()
+		with ps.PulseContext(app=app, render=session):
+			session.prerender([mount_path], info("2"))
 
 		assert len(created) == 2
 		assert first.__disposed__
@@ -472,6 +487,54 @@ class TestQueryParam:
 		bindings = session.query_param_sync._bindings["q"]  # pyright: ignore[reportPrivateUsage]
 		assert len(bindings) == 1
 		assert bindings[0].state is created[1]
+
+	def test_path_id_key_change_keeps_unkeyed_sibling(self):
+		class Shared(ps.State):
+			n: int = 0
+
+		class ItemState(ps.State):
+			q: ps.QueryParam[str] = ""
+
+		shareds: list[Shared] = []
+		items: list[ItemState] = []
+
+		@ps.component
+		def ItemPage():
+			item_id = ps.route()["pathParams"]["id"]
+			item = ps.state(ItemState, key=item_id)
+			shared = ps.state(Shared)
+			items.append(item)
+			shareds.append(shared)
+			return ps.div(item.q)
+
+		route = Route("items/:id", ItemPage)
+		session = RenderSession("test", RouteTree([route]))
+		app = ps.App(routes=[route])
+		mount_path = route.unique_path()
+
+		def info(item_id: str) -> RouteInfo:
+			return {
+				"pathname": f"/items/{item_id}",
+				"hash": "",
+				"query": "",
+				"queryParams": {"q": "hello"},
+				"pathParams": {"id": item_id},
+				"catchall": [],
+			}
+
+		with ps.PulseContext(app=app, render=session):
+			session.prerender([mount_path], info("1"))
+		first_item = items[0]
+		first_shared = shareds[0]
+
+		with ps.PulseContext(app=app, render=session):
+			session.prerender([mount_path], info("2"))
+
+		assert len(items) == 2
+		assert first_item.__disposed__
+		assert items[1] is not first_item
+		assert shareds[-1] is first_shared
+		assert not first_shared.__disposed__
 
 
 def make_two_route_session():

--- a/packages/pulse/python/tests/test_query_param.py
+++ b/packages/pulse/python/tests/test_query_param.py
@@ -420,7 +420,7 @@ class TestQueryParam:
 
 		assert first.__disposed__
 		assert not second.__disposed__
-		assert session.query_param_sync._slots["q"].refs == 1  # pyright: ignore[reportPrivateUsage]
+		assert "q" in session.url._slots  # pyright: ignore[reportPrivateUsage]
 		assert second.q == ""
 
 	def test_state_key_change_disposes_eager_query_param_instance(self):
@@ -438,7 +438,7 @@ class TestQueryParam:
 
 		assert first.__disposed__
 		assert not second.__disposed__
-		assert session.query_param_sync._slots["q"].refs == 1  # pyright: ignore[reportPrivateUsage]
+		assert "q" in session.url._slots  # pyright: ignore[reportPrivateUsage]
 		assert second.q == ""
 
 	def test_path_id_state_key_does_not_collide(self):
@@ -482,7 +482,7 @@ class TestQueryParam:
 		assert len(created) == 2
 		assert first.__disposed__
 		assert not created[1].__disposed__
-		assert session.query_param_sync._slots["q"].refs == 1  # pyright: ignore[reportPrivateUsage]
+		assert "q" in session.url._slots  # pyright: ignore[reportPrivateUsage]
 		assert created[1].q == "hello"
 
 	def test_path_id_key_change_keeps_unkeyed_sibling(self):

--- a/packages/pulse/python/tests/test_query_param.py
+++ b/packages/pulse/python/tests/test_query_param.py
@@ -421,7 +421,8 @@ class TestQueryParam:
 		assert first.__disposed__
 		assert not second.__disposed__
 		assert "q" in session.url._slots  # pyright: ignore[reportPrivateUsage]
-		assert second.q == ""
+		with ps.PulseContext(app=app, render=session, route=route_ctx):
+			assert second.q == ""
 
 	def test_state_key_change_disposes_eager_query_param_instance(self):
 		class QState(ps.State):
@@ -439,7 +440,8 @@ class TestQueryParam:
 		assert first.__disposed__
 		assert not second.__disposed__
 		assert "q" in session.url._slots  # pyright: ignore[reportPrivateUsage]
-		assert second.q == ""
+		with ps.PulseContext(app=app, render=session, route=route_ctx):
+			assert second.q == ""
 
 	def test_path_id_state_key_does_not_collide(self):
 		"""Same mount, new path id: keyed ps.state must release the old binding."""
@@ -483,7 +485,8 @@ class TestQueryParam:
 		assert first.__disposed__
 		assert not created[1].__disposed__
 		assert "q" in session.url._slots  # pyright: ignore[reportPrivateUsage]
-		assert created[1].q == "hello"
+		with ps.PulseContext(app=app, render=session):
+			assert created[1].q == "hello"
 
 	def test_path_id_key_change_keeps_unkeyed_sibling(self):
 		class Shared(ps.State):

--- a/packages/pulse/python/tests/test_query_param.py
+++ b/packages/pulse/python/tests/test_query_param.py
@@ -420,9 +420,8 @@ class TestQueryParam:
 
 		assert first.__disposed__
 		assert not second.__disposed__
-		bindings = session.query_param_sync._bindings["q"]  # pyright: ignore[reportPrivateUsage]
-		assert len(bindings) == 1
-		assert bindings[0].state is second
+		assert session.query_param_sync._slots["q"].refs == 1  # pyright: ignore[reportPrivateUsage]
+		assert second.q == ""
 
 	def test_state_key_change_disposes_eager_query_param_instance(self):
 		class QState(ps.State):
@@ -439,9 +438,8 @@ class TestQueryParam:
 
 		assert first.__disposed__
 		assert not second.__disposed__
-		bindings = session.query_param_sync._bindings["q"]  # pyright: ignore[reportPrivateUsage]
-		assert len(bindings) == 1
-		assert bindings[0].state is second
+		assert session.query_param_sync._slots["q"].refs == 1  # pyright: ignore[reportPrivateUsage]
+		assert second.q == ""
 
 	def test_path_id_state_key_does_not_collide(self):
 		"""Same mount, new path id: keyed ps.state must release the old binding."""
@@ -484,9 +482,8 @@ class TestQueryParam:
 		assert len(created) == 2
 		assert first.__disposed__
 		assert not created[1].__disposed__
-		bindings = session.query_param_sync._bindings["q"]  # pyright: ignore[reportPrivateUsage]
-		assert len(bindings) == 1
-		assert bindings[0].state is created[1]
+		assert session.query_param_sync._slots["q"].refs == 1  # pyright: ignore[reportPrivateUsage]
+		assert created[1].q == "hello"
 
 	def test_path_id_key_change_keeps_unkeyed_sibling(self):
 		class Shared(ps.State):

--- a/packages/pulse/python/tests/test_query_param.py
+++ b/packages/pulse/python/tests/test_query_param.py
@@ -5,6 +5,7 @@ from urllib.parse import parse_qs, urlparse
 
 import pulse as ps
 import pytest
+from pulse.hooks.core import HookContext
 from pulse.messages import ServerMessage, ServerNavigateToMessage
 from pulse.reactive import flush_effects
 from pulse.render_session import RenderSession
@@ -403,6 +404,74 @@ class TestQueryParam:
 		with ps.PulseContext(app=app, render=session, route=route_ctx):
 			assert QState.__dict__["q"].get_signal(state) is sig
 			assert state.q == "hello"
+
+	def test_state_key_change_releases_query_param_binding(self):
+		class QState(ps.State):
+			q: ps.QueryParam[str] = ""
+
+		app, session, route_ctx = make_context(make_route_info("/", query_params={}))
+		session.connect(lambda _msg: None)
+		ctx = HookContext()
+		with ps.PulseContext(app=app, render=session, route=route_ctx):
+			with ctx:
+				first = ps.state(QState, key="1")
+			with ctx:
+				second = ps.state(QState, key="2")
+
+		assert first.__disposed__
+		assert not second.__disposed__
+		bindings = session.query_param_sync._bindings["q"]  # pyright: ignore[reportPrivateUsage]
+		assert len(bindings) == 1
+		assert bindings[0].state is second
+
+	def test_path_id_state_key_does_not_collide(self):
+		"""Same mount, new path id: keyed ps.state must release the old binding."""
+
+		class ItemState(ps.State):
+			q: ps.QueryParam[str] = ""
+
+		created: list[ItemState] = []
+
+		@ps.component
+		def ItemPage():
+			item_id = ps.route()["pathParams"]["id"]
+			item = ps.state(ItemState, key=item_id)
+			created.append(item)
+			return ps.div(item.q)
+
+		route = Route("items/:id", ItemPage)
+		session = RenderSession("test", RouteTree([route]))
+		app = ps.App(routes=[route])
+		mount_path = route.unique_path()
+
+		def info(item_id: str) -> RouteInfo:
+			return {
+				"pathname": f"/items/{item_id}",
+				"hash": "",
+				"query": "",
+				"queryParams": {"q": "hello"},
+				"pathParams": {"id": item_id},
+				"catchall": [],
+			}
+
+		with ps.PulseContext(app=app, render=session):
+			session.prerender([mount_path], info("1"))
+		mount = session.route_mounts[mount_path]
+		assert len(created) == 1
+		first = created[0]
+
+		if mount.effect is not None:
+			mount.effect.pause()
+		with ps.PulseContext(app=app, render=session, route=mount.route):
+			mount.route.info.update(info("2"))
+			mount.tree.rerender()
+
+		assert len(created) == 2
+		assert first.__disposed__
+		assert not created[1].__disposed__
+		bindings = session.query_param_sync._bindings["q"]  # pyright: ignore[reportPrivateUsage]
+		assert len(bindings) == 1
+		assert bindings[0].state is created[1]
 
 
 def make_two_route_session():

--- a/skills/pulse/SKILL.md
+++ b/skills/pulse/SKILL.md
@@ -215,7 +215,7 @@ def UserList(user_ids: list[str]):
         items.append(ps.li(user.name, key=uid))
     return ps.ul(*items)
 
-# Dynamic key changes create new instance (useful for reset)
+# Dynamic key changes dispose the old instance and create a new one
 note = ps.state(lambda: NoteState(), key=f"note-v{version}")
 ```
 

--- a/skills/pulse/references/hooks.md
+++ b/skills/pulse/references/hooks.md
@@ -214,7 +214,7 @@ def ConditionalDemo():
     )
 ```
 
-States skipped this render (false conditional, or a key that is no longer used) are disposed. Same rule as `@ps.effect`.
+States skipped this render (false conditional, or a key that is no longer used) are disposed. Same rule as `@ps.effect`. A render that raises disposes nothing — only successful renders evict.
 
 ## ps.stable()
 

--- a/skills/pulse/references/hooks.md
+++ b/skills/pulse/references/hooks.md
@@ -204,7 +204,7 @@ def ConditionalDemo():
         show = ps.Signal(True)
 
     if show():
-        counter = ps.state(CounterState())  # Cached even when hidden
+        counter = ps.state(CounterState())  # Disposed when hidden
     else:
         counter = None
 
@@ -214,7 +214,7 @@ def ConditionalDemo():
     )
 ```
 
-States in conditionals are not disposed when condition becomes false - they remain cached.
+States skipped this render (false conditional, or a key that is no longer used) are disposed. Same rule as `@ps.effect`.
 
 ## ps.stable()
 

--- a/skills/pulse/references/state.md
+++ b/skills/pulse/references/state.md
@@ -274,7 +274,7 @@ def ItemList():
 
 ### Disposal
 
-State is disposed when component unmounts. Override `on_dispose()` for cleanup:
+State is disposed when the component unmounts, a `ps.state` key changes, or the `ps.state` call is skipped. Override `on_dispose()` for cleanup:
 
 ```python
 class ConnectionState(ps.State):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #149 (`pulse.url.SessionUrl` is a Disposable; one Signal per QueryParam name).

Keyed `ps.state` on a same-mount re-render (`/items/:id` path change, or `key=` swap) left the previous instance alive. Evict unseen keys at **render end only**, same as `@ps.effect`.

#149 makes two states sharing `q` the same Signal, so constructing a replacement no longer throws. This PR still disposes the unused `State` after the render finishes. The URL slot stays on the session until `session.close()`.

#149 no longer caches the QueryParam Signal on the State instance, so eviction tests that still read `state.q` do it under `PulseContext`.

**Not mid-render.** `called_keys` mid-body is "reached so far", not "live this render". Mid-render eviction would kill `a` in `[a,b] → [c,a]` and an unkeyed sibling after a keyed replacement.

**Intentionally not in this PR**
- `HookContext` skipping `on_render_end` on failed renders
- `State.dispose` `finally` / stop swallowing `RuntimeError` in hook dispose
- `ps.init()` locals (`#128`)

**Tests**
- `[a,b] → [c,a]` keeps `a`
- keyed-then-unkeyed + key change keeps the unkeyed sibling
- path-id via a second `prerender`
- key change disposes the old instance; slot remains on `session.url`
- Rebased onto the SessionUrl cache drop

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf1537bc-ee33-4bec-a1a3-f763e0d3ba43?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf1537bc-ee33-4bec-a1a3-f763e0d3ba43&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

