### PR TITLE
Re-enter PulseContext on user @ps.effect runs

### DIFF
--- a/docs/content/docs/(core)/concepts/effects.mdx
+++ b/docs/content/docs/(core)/concepts/effects.mdx
@@ -29,7 +29,7 @@ class ToggleState(ps.State):
 
 Pulse tracks what the effect reads. When `self.enabled` changes, the effect runs again automatically.
 
-If the effect was created during a render, Pulse puts you back in that render session on every run — including cleanup. Route-scoped effects (component `@ps.effect`, `ps.state(...)`) also get that mount's `RouteContext`. `ps.global_state` effects get the session but not a route.
+If the effect was created during a render, Pulse puts you back in that render session on every run — including cleanup. Route-scoped effects (component `@ps.effect`, `ps.state(...)`) resolve their live mount and get its `RouteContext`; if the mount is gone, they run without route metadata. `ps.global_state` effects get the session but not a route.
 
 ### With cleanup
 

--- a/docs/content/docs/(core)/concepts/effects.mdx
+++ b/docs/content/docs/(core)/concepts/effects.mdx
@@ -29,7 +29,7 @@ class ToggleState(ps.State):
 
 Pulse tracks what the effect reads. When `self.enabled` changes, the effect runs again automatically.
 
-If the effect was created during a render, Pulse puts you back in that render session on every run — including cleanup. Route-scoped effects (component `@ps.effect`, `ps.state(...)`) resolve their live mount and get its `RouteContext`; if the mount is gone, they run without route metadata. `ps.global_state` effects get the session but not a route.
+If the effect was created during a render, Pulse puts you back in that render session on every run — including cleanup. Route-scoped effects (component `@ps.effect`, `ps.state(...)`) resolve the creating mount generation: a live or replayed-and-reattached generation gets its current `RouteContext`, while a detached grace-window generation is stale and cannot navigate with its route identity. If the generation is gone or replaced, the effect runs without route metadata. `ps.global_state` effects get the session but not a route; states constructed inside its factory inherit those session-scoped semantics.
 
 ### With cleanup
 
@@ -61,6 +61,8 @@ class TimerState(ps.State):
 Cleanup runs:
 - Before the effect runs again (when tracked dependencies change)
 - When the state is disposed
+
+Async cleanups are awaited by async effects and scheduled by synchronous cleanup paths, so returning an `async def` cleanup does not silently drop it.
 
 <Callout type="info">
 Pulse's `ps.later()` and `ps.repeat()` are automatically cleaned up when the render session closes. Route unmounting does not cancel `ps.later()` callbacks; cancel the returned handle in cleanup if the callback should not run after unmount. See [Scheduling](/docs/reference/pulse/scheduling) for details.

--- a/docs/content/docs/(core)/concepts/effects.mdx
+++ b/docs/content/docs/(core)/concepts/effects.mdx
@@ -29,6 +29,8 @@ class ToggleState(ps.State):
 
 Pulse tracks what the effect reads. When `self.enabled` changes, the effect runs again automatically.
 
+If the effect was created during a render, Pulse puts you back in that render session on every run — including cleanup. Route-scoped effects (component `@ps.effect`, `ps.state(...)`) also get that mount's `RouteContext`. `ps.global_state` effects get the session but not a route.
+
 ### With cleanup
 
 Effects can return a cleanup function. This is useful for timers, subscriptions, or anything that needs to be torn down:

--- a/docs/content/docs/reference/pulse/context.mdx
+++ b/docs/content/docs/reference/pulse/context.mdx
@@ -65,9 +65,9 @@ Create a new context with updated values, inheriting unspecified values from cur
 def bind(cls, fn: F) -> F
 ```
 
-Re-enter the PulseContext that is current when `bind` is called, on every later invocation. Captures `app`, `session`, `render`, `route`, and the `source_*` mount identity. No-op if there is no render session. A cleanup callable returned by `fn` is bound too.
+Re-enter the PulseContext that is current when `bind` is called, on every later invocation. Captures `app`, `session`, and `render`, then resolves the live route mount on each invocation. No-op if there is no render session. A cleanup callable returned by `fn` is bound too.
 
-`@ps.effect` uses this so effect bodies and cleanups see the creating render (and route, when the effect is route-scoped).
+`@ps.effect` uses this so effect bodies and cleanups see the creating render. Route-scoped effects resolve the current mount identity; if that mount no longer exists, they run without route metadata.
 
 **Returns:** The original function, or a wrapper that mounts the captured context.
 

--- a/docs/content/docs/reference/pulse/context.mdx
+++ b/docs/content/docs/reference/pulse/context.mdx
@@ -65,7 +65,7 @@ Create a new context with updated values, inheriting unspecified values from cur
 def bind(cls, fn: F) -> F
 ```
 
-Re-enter the PulseContext that is current when `bind` is called, on every later invocation. Captures `app`, `session`, `render`, and `route`. No-op if there is no render session. A cleanup callable returned by `fn` is bound too.
+Re-enter the PulseContext that is current when `bind` is called, on every later invocation. Captures `app`, `session`, `render`, `route`, and the `source_*` mount identity. No-op if there is no render session. A cleanup callable returned by `fn` is bound too.
 
 `@ps.effect` uses this so effect bodies and cleanups see the creating render (and route, when the effect is route-scoped).
 

--- a/docs/content/docs/reference/pulse/context.mdx
+++ b/docs/content/docs/reference/pulse/context.mdx
@@ -21,6 +21,7 @@ Composite context accessible to hooks and internals. Manages per-request state v
 | `session` | `UserSession \| None` | Per-user session (set during HTTP requests and WebSocket connections) |
 | `render` | `RenderSession \| None` | Per-connection render session (set during render sessions) |
 | `route` | `RouteContext \| None` | Active route context (set when rendering a route) |
+| `session_scoped_effects` | `bool` | Marks effects created while constructing session-scoped state; nested effects omit route identity |
 
 #### Class Methods
 
@@ -46,6 +47,7 @@ def update(
     session: UserSession | None = None,
     render: RenderSession | None = None,
     route: RouteContext | None = None,
+    session_scoped_effects: bool = False,
 ) -> PulseContext
 ```
 
@@ -55,6 +57,7 @@ Create a new context with updated values, inheriting unspecified values from cur
 - `session` - New session (optional, inherits if not provided).
 - `render` - New render session (optional, inherits if not provided).
 - `route` - New route context (optional, inherits if not provided).
+- `session_scoped_effects` - Mark effects created in session-scoped state construction as route-free (optional, inherits if not provided).
 
 **Returns:** New `PulseContext` instance.
 
@@ -65,9 +68,11 @@ Create a new context with updated values, inheriting unspecified values from cur
 def bind(cls, fn: F) -> F
 ```
 
-Re-enter the PulseContext that is current when `bind` is called, on every later invocation. Captures `app`, `session`, and `render`, then resolves the live route mount on each invocation. No-op if there is no render session. A cleanup callable returned by `fn` is bound too.
+Re-enter the PulseContext that is current when `bind` is called, on every later invocation. Captures `app`, `session`, `render`, and the creating `RouteContext`, then resolves the mount generation on each invocation. No-op if there is no render session. A cleanup callable returned by `fn` is bound too.
 
-`@ps.effect` uses this so effect bodies and cleanups see the creating render. Route-scoped effects resolve the current mount identity; if that mount no longer exists, they run without route metadata.
+`@ps.effect` uses this so effect bodies and cleanups see the creating render. A same-generation mount provides its current route and mount identity, including after a successful StrictMode replay. A detached grace-window generation keeps its creation-time identity and is stale, so route-bound navigation is dropped. If the generation is gone or replaced, the effect runs route-free instead of reading another generation's route.
+
+Effects created while a `ps.global_state` factory constructs a state keep the render session but run route-free. This marker is inherited by nested states because they remain owned by the session-scoped state.
 
 **Returns:** The original function, or a wrapper that mounts the captured context.
 

--- a/docs/content/docs/reference/pulse/context.mdx
+++ b/docs/content/docs/reference/pulse/context.mdx
@@ -58,6 +58,19 @@ Create a new context with updated values, inheriting unspecified values from cur
 
 **Returns:** New `PulseContext` instance.
 
+##### bind
+
+```python
+@classmethod
+def bind(cls, fn: F) -> F
+```
+
+Re-enter the PulseContext that is current when `bind` is called, on every later invocation. Captures `app`, `session`, `render`, and `route`. No-op if there is no render session. A cleanup callable returned by `fn` is bound too.
+
+`@ps.effect` uses this so effect bodies and cleanups see the creating render (and route, when the effect is route-scoped).
+
+**Returns:** The original function, or a wrapper that mounts the captured context.
+
 #### Context Manager
 
 `PulseContext` can be used as a context manager to temporarily set the active context:

--- a/docs/content/docs/reference/pulse/hooks.mdx
+++ b/docs/content/docs/reference/pulse/hooks.mdx
@@ -153,7 +153,7 @@ state = ps.setup(lambda: CounterState())
 
 ## effect (inline)
 
-When `@ps.effect` is used inside a component, effects are automatically registered and cached by code location.
+When `@ps.effect` is used inside a component, effects are automatically registered and cached by code location. Each run (and cleanup) re-enters the creating render session and that mount's `RouteContext`.
 
 ```python
 @ps.effect

--- a/docs/content/docs/reference/pulse/state.mdx
+++ b/docs/content/docs/reference/pulse/state.mdx
@@ -142,7 +142,7 @@ def effect(fn: AsyncEffectFn, ...) -> AsyncEffect: ...
 def effect(fn: StateEffectFn[Any] | AsyncStateEffectFn[Any]) -> StateEffect[Any]: ...
 ```
 
-On a State method, `@ps.effect` leaves a `StateEffect` descriptor on the class; accessing it on an instance returns the per-instance `Effect`. The effect's debug name is always `"ClassName.method_name"`.
+On a State method, `@ps.effect` leaves a `StateEffect` descriptor on the class; accessing it on an instance returns the per-instance `Effect`. The effect's debug name is always `"ClassName.method_name"`. If the state was created under a render session, each run (and cleanup) re-enters that session. Mount-local state also keeps the creating `RouteContext`; `ps.global_state` does not.
 
 ### Parameters
 

--- a/packages/pulse/python/src/pulse/context.py
+++ b/packages/pulse/python/src/pulse/context.py
@@ -113,8 +113,9 @@ class PulseContext:
 	def bind(cls, fn: F) -> F:
 		"""Re-enter the current PulseContext on every call.
 
-		Captures ``app`` / ``session`` / ``render`` / ``route`` now. No-op if
-		there is no render session. A returned cleanup callable is also bound.
+		Captures ``app`` / ``session`` / ``render`` / ``route`` and the
+		``source_*`` mount identity. No-op if there is no render session. A
+		returned cleanup callable is also bound.
 		"""
 		current = PULSE_CONTEXT.get()
 		if current is None or current.render is None:
@@ -123,9 +124,20 @@ class PulseContext:
 		session = current.session
 		render = current.render
 		route = current.route
+		source_route_path = current.source_route_path
+		source_path = current.source_path
+		source_mount_id = current.source_mount_id
 
 		def enter() -> PulseContext:
-			return PulseContext(app=app, session=session, render=render, route=route)
+			return PulseContext(
+				app=app,
+				session=session,
+				render=render,
+				route=route,
+				source_route_path=source_route_path,
+				source_path=source_path,
+				source_mount_id=source_mount_id,
+			)
 
 		def bind_cleanup(result: Any) -> Any:
 			if not callable(result):

--- a/packages/pulse/python/src/pulse/context.py
+++ b/packages/pulse/python/src/pulse/context.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
 
+from pulse.reactive import Untrack
 from pulse.routing import RouteContext
 
 if TYPE_CHECKING:
@@ -29,6 +30,7 @@ class PulseContext:
 		session: Per-user session (UserSession or None).
 		render: Per-connection render session (RenderSession or None).
 		route: Active route context (RouteContext or None).
+		session_scoped_effects: Whether bound effects should omit route identity.
 		source_route_path: Route mount path that originated the active callback/effect.
 		source_path: URL pathname that originated the active callback/effect.
 		source_mount_id: Route mount lifecycle id that originated the active callback/effect.
@@ -47,6 +49,7 @@ class PulseContext:
 	session: "UserSession | None" = None
 	render: "RenderSession | None" = None
 	route: "RouteContext | None" = None
+	session_scoped_effects: bool = False
 	source_route_path: str | None = None
 	source_path: str | None = None
 	source_mount_id: str | None = None
@@ -73,6 +76,7 @@ class PulseContext:
 		session: Any = _UNSET,
 		render: Any = _UNSET,
 		route: Any = _UNSET,
+		session_scoped_effects: Any = _UNSET,
 		source_route_path: Any = _UNSET,
 		source_path: Any = _UNSET,
 		source_mount_id: Any = _UNSET,
@@ -85,6 +89,7 @@ class PulseContext:
 			session: New session (optional, inherits if not provided).
 			render: New render session (optional, inherits if not provided).
 			route: New route context (optional, inherits if not provided).
+			session_scoped_effects: Whether bound effects omit route identity.
 			source_route_path: New source route path (optional, inherits if not provided).
 			source_path: New source URL path (optional, inherits if not provided).
 			source_mount_id: New source mount id (optional, inherits if not provided).
@@ -98,6 +103,11 @@ class PulseContext:
 			session=ctx.session if session is _UNSET else session,
 			render=ctx.render if render is _UNSET else render,
 			route=ctx.route if route is _UNSET else route,
+			session_scoped_effects=(
+				ctx.session_scoped_effects
+				if session_scoped_effects is _UNSET
+				else session_scoped_effects
+			),
 			source_route_path=(
 				ctx.source_route_path
 				if source_route_path is _UNSET
@@ -113,8 +123,8 @@ class PulseContext:
 	def bind(cls, fn: F) -> F:
 		"""Re-enter the current PulseContext on every call.
 
-		Captures ``app`` / ``session`` / ``render`` / ``route`` and the
-		``source_*`` mount identity. No-op if there is no render session. A
+		Captures ``app`` / ``session`` / ``render`` and resolves the current
+		route mount on every call. No-op if there is no render session. A
 		returned cleanup callable is also bound.
 		"""
 		current = PULSE_CONTEXT.get()
@@ -123,12 +133,25 @@ class PulseContext:
 		app = current.app
 		session = current.session
 		render = current.render
-		route = current.route
-		source_route_path = current.source_route_path
-		source_path = current.source_path
-		source_mount_id = current.source_mount_id
+		route_path = (
+			None
+			if current.session_scoped_effects or current.route is None
+			else current.route.route_path
+		)
 
 		def enter() -> PulseContext:
+			route = None
+			source_route_path = None
+			source_path = None
+			source_mount_id = None
+			if route_path is not None:
+				mount = render.route_mounts.get(route_path)
+				if mount is not None:
+					route = mount.route
+					source_route_path = route_path
+					with Untrack():
+						source_path = mount.route.pathname
+						source_mount_id = mount.mount_id
 			return PulseContext(
 				app=app,
 				session=session,
@@ -143,11 +166,19 @@ class PulseContext:
 			if not callable(result):
 				return result
 
-			def cleanup() -> None:
+			if inspect.iscoroutinefunction(result):
+
+				async def bound_async_cleanup() -> None:
+					with enter():
+						await result()
+
+				return bound_async_cleanup
+
+			def bound_cleanup() -> None:
 				with enter():
 					result()
 
-			return cleanup
+			return bound_cleanup
 
 		if inspect.iscoroutinefunction(fn):
 

--- a/packages/pulse/python/src/pulse/context.py
+++ b/packages/pulse/python/src/pulse/context.py
@@ -1,8 +1,10 @@
 # pyright: reportImportCycles=false
+import inspect
+from collections.abc import Callable
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
 
 from pulse.routing import RouteContext
 
@@ -12,6 +14,7 @@ if TYPE_CHECKING:
 	from pulse.user_session import UserSession
 
 _UNSET = object()
+F = TypeVar("F", bound=Callable[..., Any])
 
 
 @dataclass
@@ -105,6 +108,48 @@ class PulseContext:
 				ctx.source_mount_id if source_mount_id is _UNSET else source_mount_id
 			),
 		)
+
+	@classmethod
+	def bind(cls, fn: F) -> F:
+		"""Re-enter the current PulseContext on every call.
+
+		Captures ``app`` / ``session`` / ``render`` / ``route`` now. No-op if
+		there is no render session. A returned cleanup callable is also bound.
+		"""
+		current = PULSE_CONTEXT.get()
+		if current is None or current.render is None:
+			return fn
+		app = current.app
+		session = current.session
+		render = current.render
+		route = current.route
+
+		def enter() -> PulseContext:
+			return PulseContext(app=app, session=session, render=render, route=route)
+
+		def bind_cleanup(result: Any) -> Any:
+			if not callable(result):
+				return result
+
+			def cleanup() -> None:
+				with enter():
+					result()
+
+			return cleanup
+
+		if inspect.iscoroutinefunction(fn):
+
+			async def wrapped_async(*args: Any, **kwargs: Any) -> Any:
+				with enter():
+					return bind_cleanup(await fn(*args, **kwargs))
+
+			return cast(F, wrapped_async)
+
+		def wrapped(*args: Any, **kwargs: Any) -> Any:
+			with enter():
+				return bind_cleanup(fn(*args, **kwargs))
+
+		return cast(F, wrapped)
 
 	def __enter__(self):
 		self._token = PULSE_CONTEXT.set(self)

--- a/packages/pulse/python/src/pulse/context.py
+++ b/packages/pulse/python/src/pulse/context.py
@@ -30,7 +30,8 @@ class PulseContext:
 		session: Per-user session (UserSession or None).
 		render: Per-connection render session (RenderSession or None).
 		route: Active route context (RouteContext or None).
-		session_scoped_effects: Whether bound effects should omit route identity.
+		session_scoped_effects: Whether effects created during a session-scoped
+			state construction should omit route identity, including nested states.
 		source_route_path: Route mount path that originated the active callback/effect.
 		source_path: URL pathname that originated the active callback/effect.
 		source_mount_id: Route mount lifecycle id that originated the active callback/effect.
@@ -89,7 +90,8 @@ class PulseContext:
 			session: New session (optional, inherits if not provided).
 			render: New render session (optional, inherits if not provided).
 			route: New route context (optional, inherits if not provided).
-			session_scoped_effects: Whether bound effects omit route identity.
+			session_scoped_effects: Whether effects created during session-scoped
+				state construction omit route identity, including nested states.
 			source_route_path: New source route path (optional, inherits if not provided).
 			source_path: New source URL path (optional, inherits if not provided).
 			source_mount_id: New source mount id (optional, inherits if not provided).
@@ -123,9 +125,9 @@ class PulseContext:
 	def bind(cls, fn: F) -> F:
 		"""Re-enter the current PulseContext on every call.
 
-		Captures ``app`` / ``session`` / ``render`` and resolves the current
-		route mount on every call. No-op if there is no render session. A
-		returned cleanup callable is also bound.
+		Captures ``app`` / ``session`` / ``render`` and the creating route
+		generation, then resolves that generation on every call. No-op if
+		there is no render session. A returned cleanup callable is also bound.
 		"""
 		current = PULSE_CONTEXT.get()
 		if current is None or current.render is None:
@@ -133,11 +135,24 @@ class PulseContext:
 		app = current.app
 		session = current.session
 		render = current.render
+		captured_route = current.route
 		route_path = (
 			None
-			if current.session_scoped_effects or current.route is None
-			else current.route.route_path
+			if current.session_scoped_effects or captured_route is None
+			else captured_route.route_path
 		)
+		captured_source_path = current.source_path
+		captured_source_mount_id = current.source_mount_id
+		if route_path is not None and (
+			captured_source_path is None or captured_source_mount_id is None
+		):
+			with Untrack():
+				mount = render.route_mounts.get(route_path)
+				if mount is not None and mount.route is captured_route:
+					if captured_source_path is None:
+						captured_source_path = mount.route.pathname
+					if captured_source_mount_id is None:
+						captured_source_mount_id = mount.mount_id
 
 		def enter() -> PulseContext:
 			route = None
@@ -146,12 +161,18 @@ class PulseContext:
 			source_mount_id = None
 			if route_path is not None:
 				mount = render.route_mounts.get(route_path)
-				if mount is not None:
+				if mount is not None and mount.route is captured_route:
 					route = mount.route
 					source_route_path = route_path
-					with Untrack():
-						source_path = mount.route.pathname
-						source_mount_id = mount.mount_id
+					if mount.dispose_on_timeout:
+						# A grace-window mount is stale; a replayed mount clears
+						# this flag when it reattaches and remains valid.
+						source_path = captured_source_path
+						source_mount_id = captured_source_mount_id
+					else:
+						with Untrack():
+							source_path = mount.route.pathname
+							source_mount_id = mount.mount_id
 			return PulseContext(
 				app=app,
 				session=session,

--- a/packages/pulse/python/src/pulse/decorators.py
+++ b/packages/pulse/python/src/pulse/decorators.py
@@ -4,6 +4,7 @@ import inspect
 from collections.abc import Awaitable, Callable
 from typing import Any, ParamSpec, Protocol, TypeVar, cast, overload
 
+from pulse.context import PulseContext
 from pulse.hooks.core import HOOK_CONTEXT
 from pulse.hooks.effects import effect_state
 from pulse.hooks.state import collect_component_identity
@@ -253,9 +254,10 @@ def effect(
 		ctx = HOOK_CONTEXT.get()
 
 		def create_effect() -> Effect | AsyncEffect:
+			bound = PulseContext.bind(func)
 			if inspect.iscoroutinefunction(func):
 				return AsyncEffect(
-					func,  # type: ignore[arg-type]
+					bound,  # type: ignore[arg-type]
 					name=func.__name__,
 					lazy=lazy,
 					on_error=on_error,
@@ -264,7 +266,7 @@ def effect(
 					interval=interval,
 				)
 			return Effect(
-				func,  # type: ignore[arg-type]
+				bound,  # type: ignore[arg-type]
 				name=func.__name__,
 				immediate=immediate,
 				lazy=lazy,

--- a/packages/pulse/python/src/pulse/hooks/runtime.py
+++ b/packages/pulse/python/src/pulse/hooks/runtime.py
@@ -466,6 +466,7 @@ def global_state(
 				"ps.global_state must be called inside a Pulse render/callback context"
 			)
 		key = base_key if id is None else f"{base_key}|{id}"
+
 		def factory() -> S:
 			# Session-scoped: do not pin the creating mount's RouteContext.
 			with PulseContext.update(route=None):

--- a/packages/pulse/python/src/pulse/hooks/runtime.py
+++ b/packages/pulse/python/src/pulse/hooks/runtime.py
@@ -468,13 +468,7 @@ def global_state(
 		key = base_key if id is None else f"{base_key}|{id}"
 
 		def factory() -> S:
-			# Session-scoped: do not pin the creating mount.
-			with PulseContext.update(
-				route=None,
-				source_route_path=None,
-				source_path=None,
-				source_mount_id=None,
-			):
+			with PulseContext.update(session_scoped_effects=True):
 				return mk(*args, **kwargs)
 
 		return cast(S, ctx.render.get_global_state(key, factory))

--- a/packages/pulse/python/src/pulse/hooks/runtime.py
+++ b/packages/pulse/python/src/pulse/hooks/runtime.py
@@ -402,6 +402,10 @@ def global_state(
 	two users, always get separate instances. Use ``ps.session()``
 	(``UserSession``) to coordinate state across a single user's tabs.
 
+	States constructed while a global-state factory runs are owned by that
+	session-scoped state. Their effects therefore keep the render session but
+	omit route identity, including for nested state construction.
+
 	Can be used as a decorator on a State class or with a factory function.
 
 	Args:

--- a/packages/pulse/python/src/pulse/hooks/runtime.py
+++ b/packages/pulse/python/src/pulse/hooks/runtime.py
@@ -468,8 +468,13 @@ def global_state(
 		key = base_key if id is None else f"{base_key}|{id}"
 
 		def factory() -> S:
-			# Session-scoped: do not pin the creating mount's RouteContext.
-			with PulseContext.update(route=None):
+			# Session-scoped: do not pin the creating mount.
+			with PulseContext.update(
+				route=None,
+				source_route_path=None,
+				source_path=None,
+				source_mount_id=None,
+			):
 				return mk(*args, **kwargs)
 
 		return cast(S, ctx.render.get_global_state(key, factory))

--- a/packages/pulse/python/src/pulse/hooks/runtime.py
+++ b/packages/pulse/python/src/pulse/hooks/runtime.py
@@ -466,7 +466,12 @@ def global_state(
 				"ps.global_state must be called inside a Pulse render/callback context"
 			)
 		key = base_key if id is None else f"{base_key}|{id}"
-		return cast(S, ctx.render.get_global_state(key, lambda: mk(*args, **kwargs)))
+		def factory() -> S:
+			# Session-scoped: do not pin the creating mount's RouteContext.
+			with PulseContext.update(route=None):
+				return mk(*args, **kwargs)
+
+		return cast(S, ctx.render.get_global_state(key, factory))
 
 	return accessor
 

--- a/packages/pulse/python/src/pulse/reactive.py
+++ b/packages/pulse/python/src/pulse/reactive.py
@@ -454,7 +454,9 @@ class Effect(Disposable):
 		for child in self.children:
 			child._cleanup_before_run()
 		if self.cleanup_fn:
-			self.cleanup_fn()
+			result = self.cleanup_fn()
+			if inspect.isawaitable(result):
+				create_task(result, name=f"cleanup:{self.name or 'unnamed'}")
 
 	@override
 	def dispose(self):
@@ -463,7 +465,9 @@ class Effect(Disposable):
 		for child in self.children.copy():
 			child.dispose()
 		if self.cleanup_fn:
-			self.cleanup_fn()
+			result = self.cleanup_fn()
+			if inspect.isawaitable(result):
+				create_task(result, name=f"cleanup:{self.name or 'unnamed'}")
 		for dep in self.deps:
 			dep.obs.remove(self)
 		if self.parent and self in self.parent.children:
@@ -882,21 +886,6 @@ class AsyncEffect(Effect):
 				# Effect task was cancelled, check if a new task was started
 				# and continue waiting if so
 				continue
-
-	@override
-	def dispose(self):
-		# Run children cleanups first, then cancel in-flight task and interval
-		self.cancel(cancel_interval=True)
-		for child in self.children.copy():
-			child.dispose()
-		if self.cleanup_fn:
-			result = self.cleanup_fn()
-			if inspect.isawaitable(result):
-				create_task(result, name=f"cleanup:{self.name or 'unnamed'}")
-		for dep in self.deps:
-			dep.obs.remove(self)
-		if self.parent and self in self.parent.children:
-			self.parent.children.remove(self)
 
 
 class Batch:

--- a/packages/pulse/python/src/pulse/reactive.py
+++ b/packages/pulse/python/src/pulse/reactive.py
@@ -352,7 +352,7 @@ class Computed(Generic[T_co]):
 		return off
 
 
-EffectCleanup = Callable[[], None]
+EffectCleanup = Callable[[], None | Awaitable[None]]
 # Split effect function types into sync and async for clearer typing
 EffectFn = Callable[[], EffectCleanup | None]
 AsyncEffectFn = Callable[[], Awaitable[EffectCleanup | None]]
@@ -800,7 +800,10 @@ class AsyncEffect(Effect):
 				# Perform cleanups in the new task
 				with Untrack():
 					try:
-						self._cleanup_before_run()
+						for child in self.children:
+							child._cleanup_before_run()
+						if self.cleanup_fn:
+							await maybe_await(self.cleanup_fn())
 					except Exception as e:
 						self.handle_error(e)
 
@@ -887,7 +890,9 @@ class AsyncEffect(Effect):
 		for child in self.children.copy():
 			child.dispose()
 		if self.cleanup_fn:
-			self.cleanup_fn()
+			result = self.cleanup_fn()
+			if inspect.isawaitable(result):
+				create_task(result, name=f"cleanup:{self.name or 'unnamed'}")
 		for dep in self.deps:
 			dep.obs.remove(self)
 		if self.parent and self in self.parent.children:

--- a/packages/pulse/python/src/pulse/state/property.py
+++ b/packages/pulse/python/src/pulse/state/property.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Generic, Never, TypeVar, override
 
+from pulse.context import PulseContext
 from pulse.reactive import AsyncEffect, Computed, Effect, Signal
 from pulse.reactive_extensions import ReactiveProperty
 
@@ -233,7 +234,7 @@ class StateEffect(StateMemberDescriptor, Generic[T], InitializableProperty):
 		effect: Effect | None = cache.get(self)
 		if effect is not None:
 			return effect
-		bound_method = self.fn.__get__(state, state.__class__)
+		bound_method = PulseContext.bind(self.fn.__get__(state, state.__class__))
 		# Select sync/async effect type based on bound method
 		if inspect.iscoroutinefunction(bound_method):
 			effect = AsyncEffect(

--- a/packages/pulse/python/tests/test_effect_context.py
+++ b/packages/pulse/python/tests/test_effect_context.py
@@ -15,14 +15,16 @@ from pulse.test_helpers import wait_for
 
 
 def make_route_info(
-	pathname: str, query_params: dict[str, str] | None = None
+	pathname: str,
+	query_params: dict[str, str] | None = None,
+	path_params: dict[str, str] | None = None,
 ) -> RouteInfo:
 	return {
 		"pathname": pathname,
 		"hash": "",
 		"query": "",
 		"queryParams": query_params or {},
-		"pathParams": {},
+		"pathParams": path_params or {},
 		"catchall": [],
 	}
 
@@ -241,9 +243,94 @@ class TestEffectPulseContext:
 		app, session, route_ctx = make_session()
 		with ps.PulseContext(app=app, render=session, route=route_ctx):
 			state = Tracked()
+		assert await wait_for(lambda: state.track.runs == 1, timeout=0.2)
+		state.n += 1
+		assert await wait_for(lambda: cleaned == [session], timeout=0.2)
+
+	@pytest.mark.asyncio
+	async def test_sync_effect_async_cleanup_is_scheduled(self):
+		cleaned: list[object] = []
+
+		class Tracked(ps.State):
+			n: int = 0
+
+			@ps.effect
+			def track(self):
+				_ = self.n
+
+				async def cleanup():
+					cleaned.append(PulseContext.get().render)
+
+				return cleanup
+
+		app, session, route_ctx = make_session()
+		with ps.PulseContext(app=app, render=session, route=route_ctx):
+			state = Tracked()
 			assert await wait_for(lambda: state.track.runs == 1, timeout=0.2)
 			state.n += 1
 			assert await wait_for(lambda: cleaned == [session], timeout=0.2)
+
+	@pytest.mark.asyncio
+	async def test_nested_async_effect_async_cleanup_is_scheduled(self):
+		cleaned: list[str] = []
+		trigger = ps.Signal(0)
+
+		class Tracked(ps.State):
+			n: int = 0
+
+			@ps.effect
+			async def track(self):
+				_ = self.n
+
+				@ps.effect
+				async def child():
+					_ = trigger()
+
+					async def cleanup():
+						cleaned.append("child")
+
+					return cleanup
+
+				_ = child
+
+		app, session, route_ctx = make_session()
+		with ps.PulseContext(app=app, render=session, route=route_ctx):
+			state = Tracked()
+			assert await wait_for(lambda: state.track.runs == 1, timeout=0.2)
+			state.n += 1
+			assert await wait_for(lambda: cleaned == ["child"], timeout=0.2)
+
+	def test_nested_state_in_global_state_init_is_session_scoped(self):
+		seen: list[tuple[object, object]] = []
+
+		class Child(ps.State):
+			@ps.effect
+			def watch(self):
+				ctx = PulseContext.get()
+				seen.append((ctx.render, ctx.route))
+
+		class Holder(ps.State):
+			child: Any = None
+
+			def __init__(self):
+				super().__init__()
+				self.child = Child()
+
+		accessor = ps.global_state(Holder)
+		app, session, route_ctx = make_session("/a")
+		mount = session.route_mounts["/a"]
+		with ps.PulseContext(
+			app=app,
+			render=session,
+			route=route_ctx,
+			source_route_path=route_ctx.route_path,
+			source_path=route_ctx.pathname,
+			source_mount_id=mount.mount_id,
+		):
+			accessor()
+			flush_effects()
+		assert seen == [(session, None)]
+		session.close()
 
 
 class TestEffectMountIdentity:
@@ -251,11 +338,13 @@ class TestEffectMountIdentity:
 
 	def test_navigate_survives_strict_mode_replay(self):
 		trigger = ps.Signal(0)
+		stamped_mount_ids: list[str | None] = []
 
 		@ps.component
 		def Page():
 			@ps.effect
 			def go():
+				stamped_mount_ids.append(PulseContext.get().source_mount_id)
 				if trigger() > 0:
 					ps.navigate("/b")
 
@@ -271,14 +360,110 @@ class TestEffectMountIdentity:
 		with ps.PulseContext(app=app, render=session):
 			session.prerender(["/a"], make_route_info("/a"))
 			session.attach("/a", make_route_info("/a"))
+			session.flush()
+			flush_effects()
+			creation_mount_id = session.route_mounts["/a"].mount_id
 			# React StrictMode replays attach -> detach -> attach; detach renews
 			# the mount id without re-rendering.
 			session.detach("/a")
 			session.attach("/a", make_route_info("/a"))
+			live_mount_id = session.route_mounts["/a"].mount_id
 			trigger.write(1)
 			session.flush()
 			flush_effects()
 		assert navigations(msgs) == ["/b"]
+		assert live_mount_id != creation_mount_id
+		assert stamped_mount_ids[-1] == live_mount_id
+		session.close()
+
+	def test_detached_mount_effect_cannot_navigate(self):
+		trigger = ps.Signal(0)
+		runs: list[int] = []
+		stamped_mount_ids: list[str | None] = []
+
+		@ps.component
+		def Page():
+			@ps.effect
+			def go():
+				runs.append(trigger())
+				stamped_mount_ids.append(PulseContext.get().source_mount_id)
+				if trigger() > 0:
+					ps.navigate("/b")
+
+			return ps.div()["page"]
+
+		routes = [Route("a", Page), Route("b", ps.component(lambda: ps.div()))]
+		app = ps.App(routes=routes)
+		session = RenderSession(
+			"s", RouteTree(routes), dev_strict_mode_detach_timeout=5.0
+		)
+		msgs: list[ServerMessage] = []
+		session.connect(msgs.append)
+		with ps.PulseContext(app=app, render=session):
+			session.prerender(["/a"], make_route_info("/a"))
+			session.attach("/a", make_route_info("/a"))
+			session.flush()
+			flush_effects()
+			creation_mount_id = session.route_mounts["/a"].mount_id
+			session.detach("/a")
+			renewed_mount_id = session.route_mounts["/a"].mount_id
+			trigger.write(1)
+			session.flush()
+			flush_effects()
+		assert runs[-1] == 1
+		assert stamped_mount_ids[-1] == creation_mount_id
+		assert renewed_mount_id != creation_mount_id
+		assert navigations(msgs) == []
+		session.close()
+
+	def test_effect_does_not_adopt_a_different_mount_generation(self):
+		seen: list[dict[str, str] | None] = []
+		holder: list[Any] = []
+
+		class Item(ps.State):
+			n: int = 0
+
+			@ps.effect
+			def watch(self):
+				_ = self.n
+				route = PulseContext.get().route
+				seen.append(None if route is None else dict(route.info["pathParams"]))
+				if self.n > 0:
+					ps.navigate("/c")
+
+		@ps.component
+		def UserPage():
+			def create():
+				holder.append(Item())
+
+			return ps.div(onClick=create)["users"]
+
+		routes = [
+			Route("users/:id", UserPage),
+			Route("c", ps.component(lambda: ps.div())),
+		]
+		app = ps.App(routes=routes)
+		session = RenderSession("s", RouteTree(routes))
+		msgs: list[ServerMessage] = []
+		session.connect(msgs.append)
+		with ps.PulseContext(app=app, render=session):
+			key_path = "/users/:id"
+			info1 = make_route_info("/users/1", path_params={"id": "1"})
+			session.prerender([key_path], info1)
+			session.attach(key_path, info1)
+			callback = next(iter(session.route_mounts[key_path].tree.callbacks))
+			session.execute_callback(key_path, callback, [])
+			session.flush()
+			flush_effects()
+			session.detach(key_path)
+			info2 = make_route_info("/users/2", path_params={"id": "2"})
+			session.prerender([key_path], info2)
+			session.attach(key_path, info2)
+			holder[0].n = 1
+			session.flush()
+			flush_effects()
+		assert seen[-1] is None
+		assert navigations(msgs) == ["/c"]
 		session.close()
 
 	def test_state_outliving_creating_mount_can_navigate(self):

--- a/packages/pulse/python/tests/test_effect_context.py
+++ b/packages/pulse/python/tests/test_effect_context.py
@@ -1,25 +1,34 @@
 # pyright: reportUnusedFunction=false
 from __future__ import annotations
 
+from typing import Any
+
 import pulse as ps
 import pytest
 from pulse.context import PulseContext
 from pulse.hooks.core import HookContext
+from pulse.messages import ServerMessage
 from pulse.reactive import flush_effects
 from pulse.render_session import RenderSession
 from pulse.routing import Route, RouteInfo, RouteTree
 from pulse.test_helpers import wait_for
 
 
-def make_route_info(pathname: str) -> RouteInfo:
+def make_route_info(
+	pathname: str, query_params: dict[str, str] | None = None
+) -> RouteInfo:
 	return {
 		"pathname": pathname,
 		"hash": "",
 		"query": "",
-		"queryParams": {},
+		"queryParams": query_params or {},
 		"pathParams": {},
 		"catchall": [],
 	}
+
+
+def navigations(msgs: list[ServerMessage]) -> list[Any]:
+	return [m.get("path") for m in msgs if m.get("type") == "navigate_to"]
 
 
 def make_session(pathname: str = "/"):
@@ -212,3 +221,129 @@ class TestEffectPulseContext:
 		with ps.PulseContext(app=app, render=session, route=route_ctx):
 			Tracked()
 		assert await wait_for(lambda: seen == [session], timeout=0.2)
+
+	@pytest.mark.asyncio
+	async def test_async_cleanup_is_awaited_in_bound_context(self):
+		cleaned: list[object] = []
+
+		class Tracked(ps.State):
+			n: int = 0
+
+			@ps.effect
+			async def track(self):
+				_ = self.n
+
+				async def cleanup():
+					cleaned.append(PulseContext.get().render)
+
+				return cleanup
+
+		app, session, route_ctx = make_session()
+		with ps.PulseContext(app=app, render=session, route=route_ctx):
+			state = Tracked()
+			assert await wait_for(lambda: state.track.runs == 1, timeout=0.2)
+			state.n += 1
+			assert await wait_for(lambda: cleaned == [session], timeout=0.2)
+
+
+class TestEffectMountIdentity:
+	"""Mount identity is resolved when the effect runs, never frozen."""
+
+	def test_navigate_survives_strict_mode_replay(self):
+		trigger = ps.Signal(0)
+
+		@ps.component
+		def Page():
+			@ps.effect
+			def go():
+				if trigger() > 0:
+					ps.navigate("/b")
+
+			return ps.div()["page"]
+
+		routes = [Route("a", Page), Route("b", ps.component(lambda: ps.div()))]
+		app = ps.App(routes=routes)
+		session = RenderSession(
+			"s", RouteTree(routes), dev_strict_mode_detach_timeout=5.0
+		)
+		msgs: list[ServerMessage] = []
+		session.connect(msgs.append)
+		with ps.PulseContext(app=app, render=session):
+			session.prerender(["/a"], make_route_info("/a"))
+			session.attach("/a", make_route_info("/a"))
+			# React StrictMode replays attach -> detach -> attach; detach renews
+			# the mount id without re-rendering.
+			session.detach("/a")
+			session.attach("/a", make_route_info("/a"))
+			trigger.write(1)
+			session.flush()
+			flush_effects()
+		assert navigations(msgs) == ["/b"]
+		session.close()
+
+	def test_state_outliving_creating_mount_can_navigate(self):
+		holder: list[Item] = []
+
+		class Item(ps.State):
+			n: int = 0
+
+			@ps.effect
+			def watch(self):
+				if self.n > 0:
+					ps.navigate("/c")
+
+		@ps.component
+		def PageA():
+			def create():
+				holder.append(Item())
+
+			return ps.div(onClick=create)["a"]
+
+		routes = [
+			Route("a", PageA),
+			Route("b", ps.component(lambda: ps.div())),
+			Route("c", ps.component(lambda: ps.div())),
+		]
+		app = ps.App(routes=routes)
+		session = RenderSession("s", RouteTree(routes))
+		msgs: list[ServerMessage] = []
+		session.connect(msgs.append)
+		with ps.PulseContext(app=app, render=session):
+			session.prerender(["/a"], make_route_info("/a"))
+			session.attach("/a", make_route_info("/a"))
+			key = next(iter(session.route_mounts["/a"].tree.callbacks))
+			# State created while /a is the current mount, but kept outside it.
+			session.execute_callback("/a", key, [])
+			session.flush()
+			flush_effects()
+			session.prerender(["/b"], make_route_info("/b"))
+			session.attach("/b", make_route_info("/b"))
+			session.detach("/a")
+			holder[0].n = 1
+			session.flush()
+			flush_effects()
+		assert navigations(msgs) == ["/c"]
+		session.close()
+
+	def test_global_state_init_can_read_route(self):
+		seen: list[RouteInfo] = []
+
+		class Cfg(ps.State):
+			def __init__(self):
+				super().__init__()
+				seen.append(ps.route())
+
+		accessor = ps.global_state(Cfg)
+		app, session, route_ctx = make_session("/a")
+		mount = session.route_mounts["/a"]
+		with ps.PulseContext(
+			app=app,
+			render=session,
+			route=route_ctx,
+			source_route_path=route_ctx.route_path,
+			source_path=route_ctx.pathname,
+			source_mount_id=mount.mount_id,
+		):
+			_ = accessor()
+		assert [info["pathname"] for info in seen] == ["/a"]
+		session.close()

--- a/packages/pulse/python/tests/test_effect_context.py
+++ b/packages/pulse/python/tests/test_effect_context.py
@@ -68,9 +68,7 @@ class TestEffectPulseContext:
 		):
 			state = Tracked()
 		flush_effects()
-		assert seen == [
-			(session, route_ctx, route_ctx.route_path, "/", mount.mount_id)
-		]
+		assert seen == [(session, route_ctx, route_ctx.route_path, "/", mount.mount_id)]
 
 		state.n += 1
 		flush_effects()

--- a/packages/pulse/python/tests/test_effect_context.py
+++ b/packages/pulse/python/tests/test_effect_context.py
@@ -37,7 +37,7 @@ def make_session(pathname: str = "/"):
 
 class TestEffectPulseContext:
 	def test_state_effect_reenters_render_and_route(self):
-		seen: list[tuple[object, object]] = []
+		seen: list[tuple[object, ...]] = []
 
 		class Tracked(ps.State):
 			n: int = 0
@@ -46,17 +46,36 @@ class TestEffectPulseContext:
 			def track(self):
 				_ = self.n
 				ctx = PulseContext.get()
-				seen.append((ctx.render, ctx.route))
+				seen.append(
+					(
+						ctx.render,
+						ctx.route,
+						ctx.source_route_path,
+						ctx.source_path,
+						ctx.source_mount_id,
+					)
+				)
 
 		app, session, route_ctx = make_session()
-		with ps.PulseContext(app=app, render=session, route=route_ctx):
+		mount = session.route_mounts["/"]
+		with ps.PulseContext(
+			app=app,
+			render=session,
+			route=route_ctx,
+			source_route_path=route_ctx.route_path,
+			source_path=route_ctx.pathname,
+			source_mount_id=mount.mount_id,
+		):
 			state = Tracked()
 		flush_effects()
-		assert seen == [(session, route_ctx)]
+		assert seen == [
+			(session, route_ctx, route_ctx.route_path, "/", mount.mount_id)
+		]
 
 		state.n += 1
 		flush_effects()
-		assert seen == [(session, route_ctx), (session, route_ctx)]
+		identity = (session, route_ctx, route_ctx.route_path, "/", mount.mount_id)
+		assert seen == [identity, identity]
 
 	def test_state_effect_sees_updated_route(self):
 		pathnames: list[str] = []
@@ -83,7 +102,7 @@ class TestEffectPulseContext:
 		assert pathnames == ["/", "/next"]
 
 	def test_global_state_effect_has_render_but_no_route(self):
-		seen: list[tuple[object, object]] = []
+		seen: list[tuple[object, ...]] = []
 
 		class Tracked(ps.State):
 			n: int = 0
@@ -92,18 +111,34 @@ class TestEffectPulseContext:
 			def track(self):
 				_ = self.n
 				ctx = PulseContext.get()
-				seen.append((ctx.render, ctx.route))
+				seen.append(
+					(
+						ctx.render,
+						ctx.route,
+						ctx.source_route_path,
+						ctx.source_path,
+						ctx.source_mount_id,
+					)
+				)
 
 		session_state = ps.global_state(Tracked)
 		app, session, route_ctx = make_session()
-		with ps.PulseContext(app=app, render=session, route=route_ctx):
+		mount = session.route_mounts["/"]
+		with ps.PulseContext(
+			app=app,
+			render=session,
+			route=route_ctx,
+			source_route_path=route_ctx.route_path,
+			source_path=route_ctx.pathname,
+			source_mount_id=mount.mount_id,
+		):
 			state = session_state()
 		flush_effects()
-		assert seen == [(session, None)]
+		assert seen == [(session, None, None, None, None)]
 
 		state.n += 1
 		flush_effects()
-		assert seen == [(session, None), (session, None)]
+		assert seen == [(session, None, None, None, None)] * 2
 
 	def test_cleanup_reenters_context(self):
 		cleaned: list[object] = []

--- a/packages/pulse/python/tests/test_effect_context.py
+++ b/packages/pulse/python/tests/test_effect_context.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import pulse as ps
+import pytest
+from pulse.context import PulseContext
+from pulse.hooks.core import HookContext
+from pulse.reactive import flush_effects
+from pulse.render_session import RenderSession
+from pulse.routing import Route, RouteInfo, RouteTree
+from pulse.test_helpers import wait_for
+
+
+def make_route_info(pathname: str) -> RouteInfo:
+	return {
+		"pathname": pathname,
+		"hash": "",
+		"query": "",
+		"queryParams": {},
+		"pathParams": {},
+		"catchall": [],
+	}
+
+
+def make_session(pathname: str = "/"):
+	def render():
+		return ps.div()
+
+	route = Route(pathname.lstrip("/") or "/", ps.component(render))
+	routes = RouteTree([route])
+	session = RenderSession("test", routes)
+	app = ps.App(routes=[route])
+	info = make_route_info(pathname)
+	session.prerender([pathname], info)
+	return app, session, session.route_mounts[pathname].route
+
+
+class TestEffectPulseContext:
+	def test_state_effect_reenters_render_and_route(self):
+		seen: list[tuple[object, object]] = []
+
+		class Tracked(ps.State):
+			n: int = 0
+
+			@ps.effect
+			def track(self):
+				_ = self.n
+				ctx = PulseContext.get()
+				seen.append((ctx.render, ctx.route))
+
+		app, session, route_ctx = make_session()
+		with ps.PulseContext(app=app, render=session, route=route_ctx):
+			state = Tracked()
+		flush_effects()
+		assert seen == [(session, route_ctx)]
+
+		state.n += 1
+		flush_effects()
+		assert seen == [(session, route_ctx), (session, route_ctx)]
+
+	def test_state_effect_sees_updated_route(self):
+		pathnames: list[str] = []
+
+		class Tracked(ps.State):
+			n: int = 0
+
+			@ps.effect
+			def track(self):
+				_ = self.n
+				pathnames.append(PulseContext.get().route.pathname)
+
+		app, session, route_ctx = make_session("/")
+		with ps.PulseContext(app=app, render=session, route=route_ctx):
+			state = Tracked()
+		flush_effects()
+		assert pathnames == ["/"]
+
+		route_ctx.update(make_route_info("/next"))
+		state.n += 1
+		flush_effects()
+		assert pathnames == ["/", "/next"]
+
+	def test_global_state_effect_has_render_but_no_route(self):
+		seen: list[tuple[object, object]] = []
+
+		class Tracked(ps.State):
+			n: int = 0
+
+			@ps.effect
+			def track(self):
+				_ = self.n
+				ctx = PulseContext.get()
+				seen.append((ctx.render, ctx.route))
+
+		session_state = ps.global_state(Tracked)
+		app, session, route_ctx = make_session()
+		with ps.PulseContext(app=app, render=session, route=route_ctx):
+			state = session_state()
+		flush_effects()
+		assert seen == [(session, None)]
+
+		state.n += 1
+		flush_effects()
+		assert seen == [(session, None), (session, None)]
+
+	def test_cleanup_reenters_context(self):
+		cleaned: list[object] = []
+
+		class Tracked(ps.State):
+			n: int = 0
+
+			@ps.effect
+			def track(self):
+				_ = self.n
+
+				def cleanup():
+					cleaned.append(PulseContext.get().render)
+
+				return cleanup
+
+		app, session, route_ctx = make_session()
+		with ps.PulseContext(app=app, render=session, route=route_ctx):
+			state = Tracked()
+		flush_effects()
+		assert cleaned == []
+
+		state.n += 1
+		flush_effects()
+		assert cleaned == [session]
+
+		state.dispose()
+		assert cleaned == [session, session]
+
+	def test_inline_effect_reenters_render_and_route(self):
+		seen: list[tuple[object, object]] = []
+
+		@ps.component
+		def Comp():
+			@ps.effect
+			def track():
+				ctx = PulseContext.get()
+				seen.append((ctx.render, ctx.route))
+
+			return ps.div()
+
+		app, session, route_ctx = make_session()
+		with ps.PulseContext(app=app, render=session, route=route_ctx):
+			with HookContext():
+				Comp.fn()
+		flush_effects()
+		assert seen == [(session, route_ctx)]
+
+	def test_standalone_effect_without_render_is_unbound(self):
+		ran = {"n": 0}
+
+		@ps.effect
+		def track():
+			ran["n"] += 1
+			with pytest.raises(RuntimeError, match="PULSE_CONTEXT is not set"):
+				PulseContext.get()
+
+		flush_effects()
+		assert ran["n"] == 1
+
+	@pytest.mark.asyncio
+	async def test_async_state_effect_reenters_context(self):
+		seen: list[object] = []
+
+		class Tracked(ps.State):
+			@ps.effect
+			async def track(self):
+				seen.append(PulseContext.get().render)
+
+		app, session, route_ctx = make_session()
+		with ps.PulseContext(app=app, render=session, route=route_ctx):
+			Tracked()
+		assert await wait_for(lambda: seen == [session], timeout=0.2)

--- a/packages/pulse/python/tests/test_effect_context.py
+++ b/packages/pulse/python/tests/test_effect_context.py
@@ -153,13 +153,15 @@ class TestEffectPulseContext:
 		assert seen == [(session, route_ctx)]
 
 	def test_standalone_effect_without_render_is_unbound(self):
+		from pulse.context import PULSE_CONTEXT
+
 		ran = {"n": 0}
 
 		@ps.effect
 		def track():
 			ran["n"] += 1
-			with pytest.raises(RuntimeError, match="PULSE_CONTEXT is not set"):
-				PulseContext.get()
+			ctx = PULSE_CONTEXT.get()
+			assert ctx is None or ctx.render is None
 
 		flush_effects()
 		assert ran["n"] == 1

--- a/packages/pulse/python/tests/test_effect_context.py
+++ b/packages/pulse/python/tests/test_effect_context.py
@@ -1,3 +1,4 @@
+# pyright: reportUnusedFunction=false
 from __future__ import annotations
 
 import pulse as ps
@@ -66,7 +67,9 @@ class TestEffectPulseContext:
 			@ps.effect
 			def track(self):
 				_ = self.n
-				pathnames.append(PulseContext.get().route.pathname)
+				route = PulseContext.get().route
+				assert route is not None
+				pathnames.append(route.pathname)
 
 		app, session, route_ctx = make_session("/")
 		with ps.PulseContext(app=app, render=session, route=route_ctx):

--- a/skills/pulse/references/context.md
+++ b/skills/pulse/references/context.md
@@ -213,7 +213,7 @@ async def fetch_external():
 **Available in:**
 - Component render functions
 - Event callbacks (`on_click`, `on_change`, etc.)
-- Effect functions (`@ps.effect`) — re-enters the creating render session; route-scoped effects also get that mount's `RouteContext`. `ps.global_state` effects get render but not route.
+- Effect functions (`@ps.effect`) — re-enters the creating render session; route-scoped effects resolve the live mount and get its `RouteContext` when present. `ps.global_state` effects get render but not route.
 - Query/mutation methods
 
 **NOT available in:**

--- a/skills/pulse/references/context.md
+++ b/skills/pulse/references/context.md
@@ -213,7 +213,7 @@ async def fetch_external():
 **Available in:**
 - Component render functions
 - Event callbacks (`on_click`, `on_change`, etc.)
-- Effect functions (`@ps.effect`) — re-enters the creating render session; route-scoped effects resolve the live mount and get its `RouteContext` when present. `ps.global_state` effects get render but not route.
+- Effect functions (`@ps.effect`) — re-enters the creating render session. Route-scoped effects resolve the creating mount generation: live and replayed-and-reattached generations get their current `RouteContext`, detached grace-window generations remain stale for navigation, and gone or replaced generations run route-free. `ps.global_state` effects get render but not route; nested states constructed in its factory inherit this session-scoped behavior.
 - Query/mutation methods
 
 **NOT available in:**

--- a/skills/pulse/references/context.md
+++ b/skills/pulse/references/context.md
@@ -213,7 +213,7 @@ async def fetch_external():
 **Available in:**
 - Component render functions
 - Event callbacks (`on_click`, `on_change`, etc.)
-- Effect functions (`@ps.effect`)
+- Effect functions (`@ps.effect`) — re-enters the creating render session; route-scoped effects also get that mount's `RouteContext`. `ps.global_state` effects get render but not route.
 - Query/mutation methods
 
 **NOT available in:**

--- a/skills/pulse/references/hooks.md
+++ b/skills/pulse/references/hooks.md
@@ -270,7 +270,7 @@ value = config_ref()  # Call to get current value
 
 ## Inline @ps.effect
 
-Effects inside component functions. Auto-registered during render. Each run (and cleanup) re-enters the creating render session and that mount's `RouteContext`.
+Effects inside component functions. Auto-registered during render. Each run (and cleanup) re-enters the creating render session and resolves the live mount's `RouteContext`.
 
 ```python
 @ps.component

--- a/skills/pulse/references/hooks.md
+++ b/skills/pulse/references/hooks.md
@@ -270,7 +270,7 @@ value = config_ref()  # Call to get current value
 
 ## Inline @ps.effect
 
-Effects inside component functions. Auto-registered during render. Each run (and cleanup) re-enters the creating render session and resolves the live mount's `RouteContext`.
+Effects inside component functions. Auto-registered during render. Each run (and cleanup) re-enters the creating render session and resolves the creating mount generation. Live and replayed-and-reattached generations provide the current `RouteContext`; detached grace-window generations are stale for navigation; gone or replaced generations run route-free.
 
 ```python
 @ps.component
@@ -285,6 +285,8 @@ def Logger():
 
     return ps.div(...)
 ```
+
+Async cleanups are awaited in async paths and scheduled when invoked from synchronous cleanup paths.
 
 **key parameter for loops:**
 ```python

--- a/skills/pulse/references/hooks.md
+++ b/skills/pulse/references/hooks.md
@@ -270,7 +270,7 @@ value = config_ref()  # Call to get current value
 
 ## Inline @ps.effect
 
-Effects inside component functions. Auto-registered during render.
+Effects inside component functions. Auto-registered during render. Each run (and cleanup) re-enters the creating render session and that mount's `RouteContext`.
 
 ```python
 @ps.component

--- a/skills/pulse/references/state.md
+++ b/skills/pulse/references/state.md
@@ -100,6 +100,8 @@ class TrackerState(ps.State):
             self.results = await api.search(self.query)
 ```
 
+Created under a render session, the effect re-enters that session on every run (and cleanup). Mount-local `ps.state` also keeps the creating route; `ps.global_state` does not.
+
 ### Cleanup Pattern
 
 Return a cleanup function from effects:

--- a/skills/pulse/references/state.md
+++ b/skills/pulse/references/state.md
@@ -100,7 +100,7 @@ class TrackerState(ps.State):
             self.results = await api.search(self.query)
 ```
 
-Created under a render session, the effect re-enters that session on every run (and cleanup). Mount-local `ps.state` also keeps the creating route; `ps.global_state` does not.
+Created under a render session, the effect re-enters that session on every run (and cleanup). Mount-local `ps.state` resolves the live creating route mount; `ps.global_state` does not use a route.
 
 ### Cleanup Pattern
 

--- a/skills/pulse/references/state.md
+++ b/skills/pulse/references/state.md
@@ -100,7 +100,7 @@ class TrackerState(ps.State):
             self.results = await api.search(self.query)
 ```
 
-Created under a render session, the effect re-enters that session on every run (and cleanup). Mount-local `ps.state` resolves the live creating route mount; `ps.global_state` does not use a route.
+Created under a render session, the effect re-enters that session on every run (and cleanup). Mount-local `ps.state` resolves the creating route generation: live or replayed-and-reattached mounts use the current route, detached grace-window mounts are stale for navigation, and gone or replaced mounts run route-free. `ps.global_state` does not use a route, and nested states created in its factory remain session-scoped and route-free.
 
 ### Cleanup Pattern
 
@@ -118,6 +118,8 @@ class SubscriptionState(ps.State):
     def handle_event(self, data):
         print(f"Received: {data}")
 ```
+
+Async cleanups are awaited by async effects and scheduled by synchronous cleanup paths.
 
 ### Effect Options
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`@ps.effect` now captures the creating `PulseContext` and remounts it on every run and cleanup.

**Render** is always captured when the effect is born under a session. **Route** only when the effect is route-scoped (component `@ps.effect`, mount-local `ps.state`). `ps.global_state` constructs the instance with `route=None` so session-scoped effects do not pin the creating mount.

`PulseContext.bind(fn)` is the wrapper. Raw `Effect(...)` is unchanged.

**Tests**
- State effect sees render + route after `flush_effects()` with no ambient context
- Same `RouteContext` object stays current across `update()`
- `global_state` effect has render, `route is None`
- Cleanup re-enters context
- Inline component `@ps.effect` same as mount-local
- Standalone `@ps.effect` without a render session stays unbound
- Async state effect re-enters render
- `make all` green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf1537bc-ee33-4bec-a1a3-f763e0d3ba43?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf1537bc-ee33-4bec-a1a3-f763e0d3ba43&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

